### PR TITLE
Specify Windows Versions

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -20,7 +20,7 @@ have built a barebones [program](/published/external/xdp/program.h) module.
 
 > What versions of Windows does XDP support?
 
-XDP is currently tested on Windows Server 2016, 2019, and 2022.
+XDP is currently tested on Windows Server 2019 and 2022.
 
 > When is this shipping with Windows?
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,9 @@
 # How to use XDP for Windows
 
+## Prerequisites
+
+- Windows Server 2019 or 2022
+
 ## Installation
 
 XDP for Windows consists of a usermode library (xdpapi.dll) and a driver (xdp.sys).


### PR DESCRIPTION
Updates usage page to specify which Windows versions should be used. Removes references to 2016 in FAQ since it isn't supported for eBPF and it might be seen as a regression if we publicly state 2016 support and then remove it.

Fixes #15.