### PR TITLE
Add a runtime kit to be generated during the build

### DIFF
--- a/.azure/templates/devkit.yml
+++ b/.azure/templates/devkit.yml
@@ -28,6 +28,12 @@ jobs:
       filePath: tools/create-devkit.ps1
       arguments: -Flavor ${{ parameters.config }} -Platform ${{ parameters.arch }}
 
+  - task: PowerShell@2
+    displayName: Create Runtime Kit
+    inputs:
+      filePath: tools/create-runtime-kit.ps1
+      arguments: -Flavor ${{ parameters.config }} -Platform ${{ parameters.arch }}
+
   - task: PublishBuildArtifacts@1
     displayName: Upload Artifacts
     inputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,9 @@ jobs:
     - name: Create Dev Kit
       shell: pwsh
       run: tools/create-devkit.ps1 -Flavor ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
+    - name: Create Runtime Kit
+      shell: pwsh
+      run: tools/create-runtime-kit.ps1 -Flavor ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
     - name: Upload Kit
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
       with:

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -21,6 +21,9 @@ param (
     [switch]$DevKit = $false,
 
     [Parameter(Mandatory = $false)]
+    [switch]$RuntimeKit = $false,
+
+    [Parameter(Mandatory = $false)]
     [switch]$UpdateDeps = $false
 )
 
@@ -61,4 +64,8 @@ if (!$NoSign) {
 
 if ($DevKit) {
     tools/create-devkit.ps1 -Flavor $Flavor
+}
+
+if ($RuntimeKit) {
+    tools/create-runtime-kit.ps1 -Flavor $Flavor
 }

--- a/tools/create-runtime-kit.ps1
+++ b/tools/create-runtime-kit.ps1
@@ -1,0 +1,53 @@
+#
+# Assembles a runtime kit for both AF_XDP client usage.
+# Code must be built before running this script.
+#
+
+param (
+    [ValidateSet("x64")]
+    [Parameter(Mandatory=$false)]
+    [string]$Platform = "x64",
+
+    [ValidateSet("Debug", "Release")]
+    [Parameter(Mandatory=$false)]
+    [string]$Flavor = "Debug"
+)
+
+$RootDir = Split-Path $PSScriptRoot -Parent
+. $RootDir\tools\common.ps1
+
+$Name = "xdp-runtime-$Platform"
+if ($Flavor -eq "Debug") {
+    $Name += "-debug"
+}
+$DstPath = "artifacts\kit\$Name"
+
+Remove-Item $DstPath -Recurse -ErrorAction Ignore
+New-Item -Path $DstPath -ItemType Directory > $null
+
+copy docs\usage.md $DstPath
+
+New-Item -Path $DstPath\bin -ItemType Directory > $null
+copy "artifacts\bin\$($Platform)_$($Flavor)\CoreNetSignRoot.cer" $DstPath\bin
+copy "artifacts\bin\$($Platform)_$($Flavor)\xdp\xdp.inf" $DstPath\bin
+copy "artifacts\bin\$($Platform)_$($Flavor)\xdp\xdp.sys" $DstPath\bin
+copy "artifacts\bin\$($Platform)_$($Flavor)\xdp\xdp.cat" $DstPath\bin
+copy "artifacts\bin\$($Platform)_$($Flavor)\xdp\xdpapi.dll" $DstPath\bin
+
+New-Item -Path $DstPath\symbols -ItemType Directory > $null
+copy "artifacts\bin\$($Platform)_$($Flavor)\xdp.pdb"   $DstPath\symbols
+copy "artifacts\bin\$($Platform)_$($Flavor)\xdpapi.pdb" $DstPath\symbols
+
+
+[xml]$XdpVersion = Get-Content $RootDir\xdp.props
+$Major = $XdpVersion.Project.PropertyGroup.XdpMajorVersion
+$Minor = $XdpVersion.Project.PropertyGroup.XdpMinorVersion
+$Patch = $XdpVersion.Project.PropertyGroup.XdpPatchVersion
+
+$VersionString = "$Major.$Minor.$Patch"
+
+if (!((Get-BuildBranch).StartsWith("release/"))) {
+    $VersionString += "-prerelease+" + (git.exe describe --long --always --dirty --exclude=* --abbrev=8)
+}
+
+Compress-Archive -DestinationPath "$DstPath\$Name-$VersionString.zip" -Path $DstPath\*


### PR DESCRIPTION
To make it easier for runtime consumers to grab just what they need, make a runtime kit generated by the build.