### PR TITLE
Automate publishing of CI build to GitHub release

### DIFF
--- a/.azure/azure-pipelines.release.yml
+++ b/.azure/azure-pipelines.release.yml
@@ -1,3 +1,6 @@
+#
+# Copy release artifacts from the CI pipeline to a GitHub release.
+#
 
 name: 0.$(Date:yyyy).$(Date:MM).$(DayOfMonth).$(Rev:rr).0
 
@@ -27,21 +30,3 @@ steps:
       releaseNotesSource: inline
       releaseNotesInline: "Latest `main` build"
       assets: $(Pipeline.Workspace)/ci_pipeline/artifacts/**
-      #repositoryName: '$(Build.Repository.Name)' 
-      #action: 'create' # Options: create, edit, delete
-      #target: '$(Build.SourceVersion)' # Required when action == Create || Action == Edit
-      #tagSource: 'auto' # Required when action == Create# Options: auto, manual
-      #tagPattern: # Optional
-      #tag: # Required when action == Edit || Action == Delete || TagSource == Manual
-      #title: # Optional
-      #releaseNotesSource: 'file' # Optional. Options: file, inline
-      #releaseNotesInline: Use this option to manually enter release notes. Use with releaseNotesSource = inline
-      #releaseNotesFilePath: # Optional. Use the contents of a file as release notes. 
-      #releaseNotes: # Optional
-      #assets: '$(Build.ArtifactStagingDirectory)/*' # Optional
-      #assetUploadMode: 'delete' # Optional. Options: delete, replace
-      #isDraft: false # Optional
-      #isPreRelease: false # Optional
-      #addChangeLog: true # Optional
-      #compareWith: 'lastFullRelease' # Required when addChangeLog == True. Options: lastFullRelease, lastRelease, lastReleaseByTag
-      #releaseTag: # Required when compareWith == LastReleaseByTag


### PR DESCRIPTION
Publish XDP devkit and runtime to GitHub. Trigger is disabled by default, but can be run in one click by internal users.