### PR TITLE
work around flaky RSS test

### DIFF
--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -4259,11 +4259,11 @@ OffloadRssError()
     do {
         UINT32 CurrentRssConfigSize = 0;
         CurrentRssResult = XdpRssGet(InterfaceHandle.get(), NULL, &CurrentRssConfigSize);
-        if (SUCCEEDED(CurrentRssResult)) {
+        if (CurrentRssResult == HRESULT_FROM_WIN32(ERROR_MORE_DATA)) {
             break;
         }
     } while (Sleep(POLL_INTERVAL_MS), !Watchdog.IsExpired());
-    TEST_HRESULT(CurrentRssResult);
+    TEST_EQUAL(HRESULT_FROM_WIN32(ERROR_MORE_DATA), CurrentRssResult);
 
     RssConfig.reset((XDP_RSS_CONFIGURATION *)malloc(RssConfigSize));
 


### PR DESCRIPTION
Work around #3 by waiting for TCPIP to plumb RSS before attempting to partially override the settings.

The long term fix is to either support default settings for partial sets (since the defaults of zero are rejected by NDIS/miniport) or remove support for partial settings entirely.