### PR TITLE
Support building with EWDK 2022

### DIFF
--- a/samples/rxfilter/rxfilter.c
+++ b/samples/rxfilter/rxfilter.c
@@ -83,64 +83,64 @@ ParseArgs(
     Rule.Action = XDP_PROGRAM_ACTION_PASS;
 
     while (i < ArgC) {
-        if (!stricmp(ArgV[i], "-IfIndex")) {
+        if (!_stricmp(ArgV[i], "-IfIndex")) {
             if (++i > ArgC) {
                 LOGERR("Missing IfIndex");
                 goto Usage;
             }
             IfIndex = atoi(ArgV[i]);
-        } else if (!stricmp(ArgV[i], "-QueueId")) {
+        } else if (!_stricmp(ArgV[i], "-QueueId")) {
             if (++i > ArgC) {
                 LOGERR("Missing QueueId");
                 goto Usage;
             }
             QueueId = atoi(ArgV[i]);
-        } else if (!stricmp(ArgV[i], "-XdpMode")) {
+        } else if (!_stricmp(ArgV[i], "-XdpMode")) {
             if (++i > ArgC) {
                 LOGERR("Missing XdpMode");
                 goto Usage;
             }
-            if (!stricmp(ArgV[i], "Generic")) {
+            if (!_stricmp(ArgV[i], "Generic")) {
                 ProgramFlags |= XDP_CREATE_PROGRAM_FLAG_GENERIC;
-            } else if (!stricmp(ArgV[i], "Native")) {
+            } else if (!_stricmp(ArgV[i], "Native")) {
                 ProgramFlags |= XDP_CREATE_PROGRAM_FLAG_NATIVE;
-            } else if (stricmp(ArgV[i], "System")) {
+            } else if (_stricmp(ArgV[i], "System")) {
                 LOGERR("Invalid XdpMode");
                 goto Usage;
             }
-        } else if (!stricmp(ArgV[i], "-MatchType")) {
+        } else if (!_stricmp(ArgV[i], "-MatchType")) {
             if (++i > ArgC) {
                 LOGERR("Missing MatchType");
                 goto Usage;
             }
-            if (!stricmp(ArgV[i], "All")) {
+            if (!_stricmp(ArgV[i], "All")) {
                 Rule.Match = XDP_MATCH_ALL;
-            } else if (!stricmp(ArgV[i], "UdpDstPort")) {
+            } else if (!_stricmp(ArgV[i], "UdpDstPort")) {
                 Rule.Match = XDP_MATCH_UDP_DST;
             } else {
                 LOGERR("Invalid MatchType");
                 goto Usage;
             }
-        } else if (!stricmp(ArgV[i], "-Action")) {
+        } else if (!_stricmp(ArgV[i], "-Action")) {
             if (++i > ArgC) {
                 LOGERR("Missing Action");
                 goto Usage;
             }
-            if (!stricmp(ArgV[i], "Pass")) {
+            if (!_stricmp(ArgV[i], "Pass")) {
                 Rule.Action = XDP_PROGRAM_ACTION_PASS;
-            } else if (!stricmp(ArgV[i], "Drop")) {
+            } else if (!_stricmp(ArgV[i], "Drop")) {
                 Rule.Action = XDP_PROGRAM_ACTION_DROP;
             } else {
                 LOGERR("Invalid Action");
                 goto Usage;
             }
-        } else if (!stricmp(ArgV[i], "-UdpDstPort")) {
+        } else if (!_stricmp(ArgV[i], "-UdpDstPort")) {
             if (++i > ArgC) {
                 LOGERR("Missing UdpDstPort");
                 goto Usage;
             }
             if (Rule.Match == XDP_MATCH_UDP_DST) {
-                Rule.Pattern.Port = _byteswap_ushort(atoi(ArgV[i]));
+                Rule.Pattern.Port = _byteswap_ushort((UINT16)atoi(ArgV[i]));
             } else {
                 LOGERR("Unexpected UdpDstPort");
             }

--- a/samples/rxfilter/rxfilter.vcxproj
+++ b/samples/rxfilter/rxfilter.vcxproj
@@ -19,11 +19,10 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{c0c730a8-2dab-4c28-8c4b-5effa6b494dd}</ProjectGuid>
     <RootNamespace>rxfilter</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
     <ConfigurationType>Application</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/src/rtl/inc/xdprtl.h
+++ b/src/rtl/inc/xdprtl.h
@@ -48,14 +48,14 @@
 #define ntohs _byteswap_ushort
 #endif
 
+#ifdef KERNEL_MODE
+
 NTSTATUS
 RtlUInt32RoundUpToPowerOfTwo(
     _In_ UINT32 Value,
     _Out_ UINT32 *Result
     );
-
-#ifdef KERNEL_MODE
-
+    
 _IRQL_requires_max_(APC_LEVEL)
 _Acquires_exclusive_lock_(Lock)
 VOID
@@ -83,6 +83,24 @@ VOID
 RtlReleasePushLockShared(
     _Inout_ EX_PUSH_LOCK *Lock
     );
+
+#else
+
+inline
+INT8
+RtlFindMostSignificantBit(
+    _In_ UINT64 Value
+    )
+{
+    DWORD BitOffset;
+
+    if (_BitScanReverse64(&BitOffset, Value)) {
+        return (INT8)BitOffset;
+    } else {
+        return -1;
+    }
+}
+
 #endif
 
 UINT32

--- a/test/build_headers/sdk/c/csdkheaders.vcxproj
+++ b/test/build_headers/sdk/c/csdkheaders.vcxproj
@@ -22,11 +22,10 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{f092f711-04ed-443e-9978-4d270f89a2cb}</ProjectGuid>
     <RootNamespace>csdkheaders</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/test/build_headers/sdk/cpp/cppsdkheaders.vcxproj
+++ b/test/build_headers/sdk/cpp/cppsdkheaders.vcxproj
@@ -22,11 +22,10 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{1EC347F7-A95F-49F3-B35F-77443A601F53}</ProjectGuid>
     <RootNamespace>cppsdkheaders</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/test/common/inc/xdpndisuser.h
+++ b/test/common/inc/xdpndisuser.h
@@ -11,6 +11,9 @@ extern "C" {
 
 #include <xdpfnoid.h>
 
+#pragma warning(push)
+#pragma warning(disable:4201) // nonstandard extension used: nameless struct/union
+
 #define OID_GEN_RECEIVE_BLOCK_SIZE              0x0001010B
 #define OID_GEN_CURRENT_PACKET_FILTER           0x0001010E
 #define OID_GEN_RECEIVE_SCALE_PARAMETERS        0x00010204  // query and set
@@ -746,6 +749,8 @@ typedef struct _NDIS_OFFLOAD
 #define NDIS_SIZEOF_NDIS_OFFLOAD_REVISION_6   RTL_SIZEOF_THROUGH_FIELD(NDIS_OFFLOAD, UdpSegmentation)
 
 #define NDIS_SIZEOF_NDIS_OFFLOAD_REVISION_7   RTL_SIZEOF_THROUGH_FIELD(NDIS_OFFLOAD, UdpSegmentation)
+
+#pragma warning(pop)
 
 #ifdef __cplusplus
 } // extern "C"

--- a/test/common/lib/util/util.cpp
+++ b/test/common/lib/util/util.cpp
@@ -118,7 +118,7 @@ XdpUninstall()
 {
     CHAR CmdBuff[256];
 
-    sprintf(CmdBuff, "%s  .\\xdp.ps1 -Uninstall %s", GetPowershellPrefix(), XdpPreinstalled ? "-DriverPreinstalled" : "");
+    sprintf_s(CmdBuff, "%s  .\\xdp.ps1 -Uninstall %s", GetPowershellPrefix(), XdpPreinstalled ? "-DriverPreinstalled" : "");
     NT_VERIFY(system(CmdBuff) == 0);
     NT_VERIFY(!IsServiceRunning(XDP_SERVICE_NAME));
     return TRUE;

--- a/test/common/lib/util/util.vcxproj
+++ b/test/common/lib/util/util.vcxproj
@@ -14,11 +14,10 @@
     <ProjectGuid>{bdd99a80-0936-47b0-918d-04cf3b472fb0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>util</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -24,7 +24,11 @@
 #include <iphlpapi.h>
 #include <ws2tcpip.h>
 #include <mstcpip.h>
+
+#pragma warning(push)
+#pragma warning(disable:26457) // (void) should not be used to ignore return values, use 'std::ignore =' instead (es.48)
 #include <wil/resource.h>
+#pragma warning(pop)
 
 #include <afxdp_helper.h>
 #include <xdpapi.h>

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -1521,7 +1521,7 @@ WaitForWfpQuarantine(
         if (SUCCEEDED(MpRxIndicateFrame(GenericMp, &RxFrame))) {
             Bytes = recv(UdpSocket.get(), RecvPayload, sizeof(RecvPayload), 0);
         } else {
-            Bytes = -1;
+            Bytes = (DWORD)-1;
         }
 
         if (Bytes == sizeof(UdpPayload)) {
@@ -2519,7 +2519,6 @@ GenericRxUdpFragmentQuicShortHeader(
     UINT16 LocalPort, RemotePort;
     ETHERNET_ADDRESS LocalHw, RemoteHw;
     INET_ADDR LocalIp, RemoteIp;
-    UINT32 UdpFrameOffset = 0;
     UINT32 TotalOffset = 0;
 
     auto UdpSocket = CreateUdpSocket(Af, &If, &LocalPort);
@@ -2640,7 +2639,6 @@ GenericRxUdpFragmentQuicLongHeader(
     UINT16 LocalPort, RemotePort;
     ETHERNET_ADDRESS LocalHw, RemoteHw;
     INET_ADDR LocalIp, RemoteIp;
-    UINT32 UdpFrameOffset = 0;
     UINT32 TotalOffset = 0;
 
     auto UdpSocket = CreateUdpSocket(Af, &If, &LocalPort);
@@ -3738,8 +3736,6 @@ GenericLoopback(
     UINT16 LocalPort, RemotePort;
     ETHERNET_ADDRESS LocalHw, RemoteHw;
     INET_ADDR LocalIp, RemoteIp;
-    UINT32 UdpFrameOffset = 0;
-    UINT32 TotalOffset = 0;
     SOCKADDR_INET LocalSockAddr = {0};
 
     auto If = FnMpIf;
@@ -3946,7 +3942,6 @@ FnLwfTx()
 VOID
 FnLwfOid()
 {
-    HRESULT Result;
     OID_KEY OidKeys[2] = {0};
     UINT32 MpInfoBufferLength;
     unique_malloc_ptr<VOID> MpInfoBuffer;
@@ -4066,7 +4061,7 @@ SetXdpRss(
     auto GenericMp = MpOpenGeneric(If.GetIfIndex());
     auto AdapterMp = MpOpenAdapter(If.GetIfIndex());
     unique_malloc_ptr<XDP_RSS_CONFIGURATION> RssConfig;
-    UINT32 HashSecretKeySize = 40;
+    UINT16 HashSecretKeySize = 40;
     UINT32 RssConfigSize = sizeof(*RssConfig) + HashSecretKeySize + IndirectionTableSize;
 
     //
@@ -4241,7 +4236,7 @@ VerifyRssDatapath(
     UCHAR Mask = 0x00;
     LwfRxFilter(DefaultLwf, &Pattern, &Mask, sizeof(Pattern));
 
-    IndicateOnAllActiveRssQueues(If, RssProcessors.size());
+    IndicateOnAllActiveRssQueues(If, (UINT32)RssProcessors.size());
 
     //
     // Verify that the resulting indications are as expected.
@@ -4252,7 +4247,7 @@ VerifyRssDatapath(
     // miniport's RSS processor set and that its RSS hash is 0.
     //
 
-    UINT32 NumRssProcessors = RssProcessors.size();
+    UINT32 NumRssProcessors = (UINT32)RssProcessors.size();
     for (UINT32 Index = 0; Index < NumRssProcessors; Index++) {
         auto Frame = LwfRxAllocateAndGetFrame(DefaultLwf, Index);
         PROCESSOR_NUMBER Processor = Frame->Output.ProcessorNumber;
@@ -4271,7 +4266,7 @@ OffloadRssError()
 {
     wil::unique_handle InterfaceHandle;
     unique_malloc_ptr<XDP_RSS_CONFIGURATION> RssConfig;
-    UINT32 IndirectionTableSize = 1 * sizeof(PROCESSOR_NUMBER);
+    UINT16 IndirectionTableSize = 1 * sizeof(PROCESSOR_NUMBER);
     UINT32 RssConfigSize = sizeof(*RssConfig) + IndirectionTableSize;
 
     //
@@ -4556,7 +4551,7 @@ OffloadRssInterfaceRestart()
             continue;
         }
 
-        UINT32 Size = 0;
+        Size = 0;
         Result = XdpRssGet(InterfaceHandle.get(), NULL, &Size);
         if (Result == HRESULT_FROM_WIN32(ERROR_MORE_DATA)) {
             break;
@@ -4707,7 +4702,7 @@ CreateIndirectionTable(
     _Out_ UINT32 *IndirectionTableSize
     )
 {
-    *IndirectionTableSize = ProcessorIndices.size() * sizeof(*IndirectionTable);
+    *IndirectionTableSize = (UINT32)ProcessorIndices.size() * sizeof(*IndirectionTable);
 
     IndirectionTable.reset((PROCESSOR_NUMBER *)malloc(*IndirectionTableSize));
     TEST_TRUE(IndirectionTable.get() != NULL);
@@ -4946,13 +4941,9 @@ OffloadSetHardwareCapabilities()
 VOID
 GenericXskQueryAffinity()
 {
-    wil::unique_handle InterfaceHandle;
     unique_malloc_ptr<XDP_RSS_CONFIGURATION> RssConfig;
     unique_malloc_ptr<XDP_RSS_CONFIGURATION> ModifiedRssConfig;
     unique_malloc_ptr<XDP_RSS_CONFIGURATION> OriginalRssConfig;
-    UINT32 RssConfigSize;
-    UINT32 ModifiedRssConfigSize;
-    UINT32 OriginalRssConfigSize;
     UCHAR BufferVa[] = "GenericXskQueryAffinity";
     auto GenericMp = MpOpenGeneric(FnMpIf.GetIfIndex());
 

--- a/test/functional/lib/xdptests.vcxproj
+++ b/test/functional/lib/xdptests.vcxproj
@@ -14,11 +14,10 @@
     <ProjectGuid>{b7c007da-b437-4ca5-896e-5cb5a5006d01}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xdptests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/test/functional/lwf/lib/ioctl.c
+++ b/test/functional/lwf/lib/ioctl.c
@@ -15,7 +15,7 @@ VOID *
 FnLwfInitializeEa(
     _In_ XDPFNLWF_FILE_TYPE FileType,
     _Out_ VOID *EaBuffer,
-    _In_ ULONG EaLength
+    _In_ UINT32 EaLength
     )
 {
     FILE_FULL_EA_INFORMATION *EaHeader = EaBuffer;
@@ -40,7 +40,7 @@ HRESULT
 FnLwfOpen(
     _In_ ULONG Disposition,
     _In_opt_ VOID *EaBuffer,
-    _In_ ULONG EaLength,
+    _In_ UINT32 EaLength,
     _Out_ HANDLE *Handle
     )
 {
@@ -76,12 +76,12 @@ FnLwfOpen(
 HRESULT
 FnLwfIoctl(
     _In_ HANDLE XdpHandle,
-    _In_ ULONG Operation,
+    _In_ UINT32 Operation,
     _In_opt_ VOID *InBuffer,
-    _In_ ULONG InBufferSize,
+    _In_ UINT32 InBufferSize,
     _Out_opt_ VOID *OutBuffer,
-    _In_ ULONG OutputBufferSize,
-    _Out_opt_ ULONG *BytesReturned,
+    _In_ UINT32 OutputBufferSize,
+    _Out_opt_ UINT32 *BytesReturned,
     _In_opt_ OVERLAPPED *Overlapped
     )
 {
@@ -128,7 +128,7 @@ FnLwfIoctl(
     }
 
     if (BytesReturned != NULL) {
-        *BytesReturned = (ULONG)IoStatusBlock->Information;
+        *BytesReturned = (UINT32)IoStatusBlock->Information;
     }
 
 Exit:

--- a/test/functional/lwf/lib/ioctl.c
+++ b/test/functional/lwf/lib/ioctl.c
@@ -38,7 +38,7 @@ FnLwfInitializeEa(
 
 HRESULT
 FnLwfOpen(
-    _In_ ULONG Disposition,
+    _In_ UINT32 Disposition,
     _In_opt_ VOID *EaBuffer,
     _In_ UINT32 EaLength,
     _Out_ HANDLE *Handle

--- a/test/functional/lwf/lib/ioctl.h
+++ b/test/functional/lwf/lib/ioctl.h
@@ -29,25 +29,25 @@ VOID *
 FnLwfInitializeEa(
     _In_ XDPFNLWF_FILE_TYPE FileType,
     _Out_ VOID *EaBuffer,
-    _In_ ULONG EaLength
+    _In_ UINT32 EaLength
     );
 
 HRESULT
 FnLwfOpen(
-    _In_ ULONG Disposition,
+    _In_ UINT32 Disposition,
     _In_opt_ VOID *EaBuffer,
-    _In_ ULONG EaLength,
+    _In_ UINT32 EaLength,
     _Out_ HANDLE *Handle
     );
 
 HRESULT
 FnLwfIoctl(
     _In_ HANDLE XdpHandle,
-    _In_ ULONG Operation,
+    _In_ UINT32 Operation,
     _In_opt_ VOID *InBuffer,
-    _In_ ULONG InBufferSize,
+    _In_ UINT32 InBufferSize,
     _Out_opt_ VOID *OutBuffer,
-    _In_ ULONG OutputBufferSize,
-    _Out_opt_ ULONG *BytesReturned,
+    _In_ UINT32 OutputBufferSize,
+    _Out_opt_ UINT32 *BytesReturned,
     _In_opt_ OVERLAPPED *Overlapped
     );

--- a/test/functional/lwf/lib/xdpfnlwfapi.c
+++ b/test/functional/lwf/lib/xdpfnlwfapi.c
@@ -103,7 +103,7 @@ FnLwfRxGetFrame(
     Result =
         FnLwfIoctl(
             Handle, IOCTL_RX_GET_FRAME, &In, sizeof(In), Frame, *FrameBufferLength,
-            (ULONG *)FrameBufferLength, NULL);
+            FrameBufferLength, NULL);
 
     if (SUCCEEDED(Result) && Frame != NULL) {
         //

--- a/test/functional/lwf/lib/xdpfnlwfapi.vcxproj
+++ b/test/functional/lwf/lib/xdpfnlwfapi.vcxproj
@@ -15,11 +15,10 @@
     <ProjectGuid>{34a40976-2d2e-4a27-b9ff-390fc573a4de}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xdpfnlwfapi</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/test/functional/mp/lib/ioctl.c
+++ b/test/functional/mp/lib/ioctl.c
@@ -15,7 +15,7 @@ VOID *
 FnMpInitializeEa(
     _In_ XDPFNMP_FILE_TYPE FileType,
     _Out_ VOID *EaBuffer,
-    _In_ ULONG EaLength
+    _In_ UINT32 EaLength
     )
 {
     FILE_FULL_EA_INFORMATION *EaHeader = EaBuffer;
@@ -38,9 +38,9 @@ FnMpInitializeEa(
 
 HRESULT
 FnMpOpen(
-    _In_ ULONG Disposition,
+    _In_ UINT32 Disposition,
     _In_opt_ VOID *EaBuffer,
-    _In_ ULONG EaLength,
+    _In_ UINT32 EaLength,
     _Out_ HANDLE *Handle
     )
 {
@@ -76,12 +76,12 @@ FnMpOpen(
 HRESULT
 FnMpIoctl(
     _In_ HANDLE XdpHandle,
-    _In_ ULONG Operation,
+    _In_ UINT32 Operation,
     _In_opt_ VOID *InBuffer,
-    _In_ ULONG InBufferSize,
+    _In_ UINT32 InBufferSize,
     _Out_opt_ VOID *OutBuffer,
-    _In_ ULONG OutputBufferSize,
-    _Out_opt_ ULONG *BytesReturned,
+    _In_ UINT32 OutputBufferSize,
+    _Out_opt_ UINT32 *BytesReturned,
     _In_opt_ OVERLAPPED *Overlapped
     )
 {
@@ -128,7 +128,7 @@ FnMpIoctl(
     }
 
     if (BytesReturned != NULL) {
-        *BytesReturned = (ULONG)IoStatusBlock->Information;
+        *BytesReturned = (UINT32)IoStatusBlock->Information;
     }
 
 Exit:

--- a/test/functional/mp/lib/ioctl.h
+++ b/test/functional/mp/lib/ioctl.h
@@ -29,25 +29,25 @@ VOID *
 FnMpInitializeEa(
     _In_ XDPFNMP_FILE_TYPE FileType,
     _Out_ VOID *EaBuffer,
-    _In_ ULONG EaLength
+    _In_ UINT32 EaLength
     );
 
 HRESULT
 FnMpOpen(
-    _In_ ULONG Disposition,
+    _In_ UINT32 Disposition,
     _In_opt_ VOID *EaBuffer,
-    _In_ ULONG EaLength,
+    _In_ UINT32 EaLength,
     _Out_ HANDLE *Handle
     );
 
 HRESULT
 FnMpIoctl(
     _In_ HANDLE XdpHandle,
-    _In_ ULONG Operation,
+    _In_ UINT32 Operation,
     _In_opt_ VOID *InBuffer,
-    _In_ ULONG InBufferSize,
+    _In_ UINT32 InBufferSize,
     _Out_opt_ VOID *OutBuffer,
-    _In_ ULONG OutputBufferSize,
-    _Out_opt_ ULONG *BytesReturned,
+    _In_ UINT32 OutputBufferSize,
+    _Out_opt_ UINT32 *BytesReturned,
     _In_opt_ OVERLAPPED *Overlapped
     );

--- a/test/functional/mp/lib/xdpfnmpapi.c
+++ b/test/functional/mp/lib/xdpfnmpapi.c
@@ -135,7 +135,7 @@ FnMpTxGetFrame(
     Result =
         FnMpIoctl(
             Handle, IOCTL_TX_GET_FRAME, &In, sizeof(In), Frame, *FrameBufferLength,
-            (ULONG *)FrameBufferLength, NULL);
+            FrameBufferLength, NULL);
 
     if (SUCCEEDED(Result) && Frame != NULL) {
         //

--- a/test/functional/mp/lib/xdpfnmpapi.vcxproj
+++ b/test/functional/mp/lib/xdpfnmpapi.vcxproj
@@ -15,11 +15,10 @@
     <ProjectGuid>{15de7d30-6a0b-47c7-8ddc-1cfc658e8a1e}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xdpfnmpapi</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/test/functional/taef/tests.cpp
+++ b/test/functional/taef/tests.cpp
@@ -30,10 +30,14 @@ LogTestFailure(
     INT Line,
     _Printf_format_string_ const LPWSTR Format,
     ...
-)
+    )
 {
     static const INT Size = 256;
     WCHAR Buffer[Size];
+
+    UNREFERENCED_PARAMETER(File);
+    UNREFERENCED_PARAMETER(Function);
+    UNREFERENCED_PARAMETER(Line);
 
     va_list Args;
     va_start(Args, Format);
@@ -50,10 +54,14 @@ LogTestWarning(
     INT Line,
     _Printf_format_string_ const LPWSTR Format,
     ...
-)
+    )
 {
     static const INT Size = 256;
     WCHAR Buffer[Size];
+
+    UNREFERENCED_PARAMETER(File);
+    UNREFERENCED_PARAMETER(Function);
+    UNREFERENCED_PARAMETER(Line);
 
     va_list Args;
     va_start(Args, Format);

--- a/test/functional/taef/xdpfunctionaltests.vcxproj
+++ b/test/functional/taef/xdpfunctionaltests.vcxproj
@@ -34,13 +34,12 @@
     <ProjectGuid>{02D631DF-E2E7-4A6E-9773-94A45B19C367}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xdpfunctionaltests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>

--- a/test/functional/taef/xdpfunctionaltests.vcxproj
+++ b/test/functional/taef/xdpfunctionaltests.vcxproj
@@ -43,6 +43,14 @@
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(DisableRegistryUse)' == 'true'">
+    <!--
+      Workaround for EWDK build failures:
+      Microsoft.Cpp.VCTools.props sets these to invalid values if they're not
+      already set. -->
+    <VCInstallDir_160 Condition="'$(VCInstallDir_160)' == ''">$(VSInstallDir)VC\</VCInstallDir_160>
+    <VCToolsInstallDir_160 Condition="'$(VCToolsInstallDir_160)' == '' and '$(VCToolsVersion)' != ''">$(VCInstallDir_160)Tools\MSVC\$(VCToolsVersion)\</VCToolsInstallDir_160>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(SolutionDir)xdp.cpp.props" />
   <Import Project="$(SolutionDir)xdp.cpp.user.props" />

--- a/test/pktcmd/pktcmd.vcxproj
+++ b/test/pktcmd/pktcmd.vcxproj
@@ -19,11 +19,10 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{6FA0FEF2-5947-4D11-8DDA-A0968852EDAB}</ProjectGuid>
     <RootNamespace>pktcmd</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
     <ConfigurationType>Application</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/test/pkthlp/um/pkthlp_um.vcxproj
+++ b/test/pkthlp/um/pkthlp_um.vcxproj
@@ -14,11 +14,10 @@
     <ProjectGuid>{e84ff937-7445-4b8e-ba40-dffacc09c060}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>pkthlp_um</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/test/rssconfig/rssconfig.vcxproj
+++ b/test/rssconfig/rssconfig.vcxproj
@@ -14,11 +14,10 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{798300cd-0d26-4fcd-843b-30a9585b102c}</ProjectGuid>
     <RootNamespace>rssconfig</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
     <ConfigurationType>Application</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/test/spinxsk/spinxsk.c
+++ b/test/spinxsk/spinxsk.c
@@ -12,6 +12,7 @@
 #include <afxdp_experimental.h>
 #include <xdpapi.h>
 #include <xdpapi_internal.h>
+#include <xdprtl.h>
 
 #include "trace.h"
 #include "util.h"

--- a/test/spinxsk/spinxsk.vcxproj
+++ b/test/spinxsk/spinxsk.vcxproj
@@ -22,11 +22,10 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{a831b9f7-3948-48cc-b4f7-db725ef13408}</ProjectGuid>
     <RootNamespace>spinxsk</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
     <ConfigurationType>Application</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/test/spinxsk/spinxsk.vcxproj
+++ b/test/spinxsk/spinxsk.vcxproj
@@ -49,6 +49,7 @@
     <ClCompile>
       <AdditionalIncludeDirectories>
         $(SolutionDir)published\private;
+        $(SolutionDir)src\rtl\inc;
         $(SolutionDir)test\common\inc;
         $(IntDir);
         %(AdditionalIncludeDirectories)

--- a/test/xskbench/xskbench.c
+++ b/test/xskbench/xskbench.c
@@ -128,7 +128,7 @@ CHAR *HELP =
     printf_error(__VA_ARGS__); exit(1)
 
 #define ASSERT_FRE(expr) \
-    if (!(expr)) { ABORT("("#expr") failed line %d\n", __LINE__);}
+    if (!(expr)) { ABORT("(%s) failed line %d\n", #expr, __LINE__);}
 
 #if DBG
 #define VERIFY(expr) assert(expr)
@@ -207,7 +207,7 @@ typedef struct {
     LONG nodeAffinity;
     LONG group;
     LONG idealCpu;
-    LONG yieldCount;
+    UINT32 yieldCount;
     DWORD_PTR cpuAffinity;
     BOOLEAN wait;
 
@@ -640,7 +640,9 @@ LatCmp(
     CONST VOID *B
     )
 {
-    return *(CONST INT64 *)A - *(CONST INT64 *)B;
+    CONST UINT64 *a = A;
+    CONST UINT64 *b = B; 
+    return (*a > *b) - (*a < *b);
 }
 
 INT64
@@ -1492,7 +1494,7 @@ ParseQueueArgs(
             if (++i > argc) {
                 Usage();
             }
-            Queue->txPatternLength = strlen(argv[i]);
+            Queue->txPatternLength = (UINT32)strlen(argv[i]);
             ASSERT_FRE(Queue->txPatternLength > 0 && Queue->txPatternLength % 2 == 0);
             Queue->txPatternLength /= 2;
             Queue->txPattern = malloc(Queue->txPatternLength);
@@ -1686,7 +1688,7 @@ ParseArgs(
 
     INT tStart = -1;
     INT tIndex = 0;
-    for (INT i = 0; i < argc; i++) {
+    for (i = 0; i < argc; i++) {
         if (!strcmp(argv[i], "-t")) {
             if (tStart != -1) {
                 ParseThreadArgs(&threads[tIndex++], i - tStart, &argv[tStart]);

--- a/test/xskbench/xskbench.vcxproj
+++ b/test/xskbench/xskbench.vcxproj
@@ -22,11 +22,10 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{d6e512a0-8dbf-4baf-9393-bfa746c9325c}</ProjectGuid>
     <RootNamespace>xskbench</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>
     <ConfigurationType>Application</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />


### PR DESCRIPTION
Add support for building via the EWDK (a standalone ISO) instead of a locally installed Visual Studio + WDK. Convert all the user mode projects to use the `WindowsApplicationForDrivers10.0` toolset instead of `v142`, which raises the warning level of the projects and requires a few other minor changes.

Resolves #68 