### PR TITLE
fix EWDK devkit build

### DIFF
--- a/src/nmr/nmr.vcxproj
+++ b/src/nmr/nmr.vcxproj
@@ -55,6 +55,8 @@
         but portable codegen instead.
         -->
       <WholeProgramOptimization>false</WholeProgramOptimization>
+      <!-- EWDK builds do not binplace the PDB for this library, so force it here. -->
+      <ProgramDataBaseFileName>$(OutDir)xdpnmr.pdb</ProgramDataBaseFileName>
     </ClCompile>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
In #71 the build succeeded, but it turns out the devkit still did not build cleanly. This PR fixes that by ensuring xdpnmr.pdb gets binplaced to the artifacts directory as expected.

Update for #68 