### PR TITLE
code cleanup: don't set output parameters when fast IO fails

### DIFF
--- a/src/xdp/dispatch.c
+++ b/src/xdp/dispatch.c
@@ -291,7 +291,6 @@ XdpFastDeviceIoControl(
     PAGED_CODE();
 
     if (FileObjHeader == NULL) {
-        IoStatus->Status = STATUS_INVALID_PARAMETER;
         return FALSE;
     }
 
@@ -302,7 +301,6 @@ XdpFastDeviceIoControl(
                 FileObjHeader, InputBuffer, InputBufferLength, OutputBuffer,
                 OutputBufferLength, IoControlCode, IoStatus);
     default:
-        IoStatus->Status = STATUS_INVALID_PARAMETER;
         return FALSE;
     }
 


### PR DESCRIPTION
Remove unnecessary (and misleading) setting of output status parameter when fast IO returns false.