### PR TITLE
Revert "Add XSK_NOTIFY_FLAG_CANCEL_WAIT Support (#64)"

### DIFF
--- a/published/external/afxdp.h
+++ b/published/external/afxdp.h
@@ -232,11 +232,6 @@ typedef enum _XSK_NOTIFY_FLAGS {
     // Wait until a TX completion ring entry is available.
     //
     XSK_NOTIFY_FLAG_WAIT_TX = 0x8,
-
-    //
-    // Cancel a wait from a different thread.
-    //
-    XSK_NOTIFY_FLAG_CANCEL_WAIT = 0x10,
 } XSK_NOTIFY_FLAGS;
 
 DEFINE_ENUM_FLAG_OPERATORS(XSK_NOTIFY_FLAGS)

--- a/test/common/inc/xdptest.h
+++ b/test/common/inc/xdptest.h
@@ -57,15 +57,6 @@
     } \
 }
 
-#define TEST_HRESULT_EQUAL(expected, condition) { \
-    constexpr auto expectedHR_ = expected; \
-    auto conditionHR_ = condition; \
-    if (conditionHR_ != expectedHR_) \
-    { \
-        TEST_FAILURE(#condition " (0x%x) not equal to " #expected " (0x%x)", conditionHR_, expectedHR_); \
-    } \
-}
-
 #define TEST_NTSTATUS(condition) { \
     HRESULT hr_ = HRESULT_FROM_NT(condition); \
     if (FAILED(hr_)) { \

--- a/test/functional/lib/tests.h
+++ b/test/functional/lib/tests.h
@@ -104,12 +104,6 @@ GenericXskWait(
     );
 
 VOID
-GenericXskCancelWait(
-    _In_ BOOLEAN Rx,
-    _In_ BOOLEAN Tx
-    );
-
-VOID
 GenericXskWaitAsync(
     _In_ BOOLEAN Rx,
     _In_ BOOLEAN Tx

--- a/test/functional/taef/tests.cpp
+++ b/test/functional/taef/tests.cpp
@@ -32,7 +32,7 @@ LogTestFailure(
     ...
     )
 {
-    static const INT Size = 256;
+    static const INT Size = 128;
     WCHAR Buffer[Size];
 
     UNREFERENCED_PARAMETER(File);
@@ -56,7 +56,7 @@ LogTestWarning(
     ...
     )
 {
-    static const INT Size = 256;
+    static const INT Size = 128;
     WCHAR Buffer[Size];
 
     UNREFERENCED_PARAMETER(File);
@@ -222,18 +222,6 @@ public:
 
     TEST_METHOD(GenericXskWaitRxTx) {
         GenericXskWait(TRUE, TRUE);
-    }
-
-    TEST_METHOD(GenericXskCancelWaitRx) {
-        GenericXskCancelWait(TRUE, FALSE);
-    }
-
-    TEST_METHOD(GenericXskCancelWaitTx) {
-        GenericXskCancelWait(FALSE, TRUE);
-    }
-
-    TEST_METHOD(GenericXskCancelWaitRxTx) {
-        GenericXskCancelWait(TRUE, TRUE);
     }
 
     TEST_METHOD(GenericXskWaitAsyncRx) {


### PR DESCRIPTION
This reverts commit 916a20000c0056e527b82f04c829e9994bde7145 (PR #64) which introduced cancellation of synchronous waits.

With the addition of asynchronous XSK waits, the synchronous wait cancellation is redundant. It also turned out to be insufficient for QUIC's use case.