### PR TITLE
Use NDIS_POLL_HANDLE consistently

### DIFF
--- a/published/external/xdp/ndis6poll.h
+++ b/published/external/xdp/ndis6poll.h
@@ -55,7 +55,7 @@ inline
 _IRQL_requires_max_(DISPATCH_LEVEL)
 VOID
 XdpCompleteNdisPoll(
-    _In_ NDIS_HANDLE PollHandle,
+    _In_ NDIS_POLL_HANDLE PollHandle,
     _In_ NDIS_POLL_DATA *Poll,
     _In_ XDP_POLL_TRANSMIT_DATA *Transmit,
     _In_ XDP_POLL_RECEIVE_DATA *Receive,


### PR DESCRIPTION
A partner noticed we're using the wrong NDIS handle type, so fix that.