### PR TITLE
Revert "Bump microsoft/action-publish-symbols from c82a258c03d72d371fe9138fc887c2c6e1778e38 to 3"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           !artifacts/bin/**/*.exp
           !artifacts/bin/**/*.lastcodeanalysissucceeded
     - name: Publish Symbols
-      uses: microsoft/action-publish-symbols@44254ea6d79c64929877999567402c99de97a62d
+      uses: microsoft/action-publish-symbols@c82a258c03d72d371fe9138fc887c2c6e1778e38
       if: github.event_name != 'pull_request'
       with:
         accountName: mscodehub


### PR DESCRIPTION
Reverts microsoft/xdp-for-windows#83 due to build break in main. The issue is the same as https://github.com/microsoft/action-publish-symbols/issues/27.