### PR TITLE
Skip setting NDIS polling configuration

### DIFF
--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -312,8 +312,9 @@ function Install-XdpMp {
     Set-NetAdapterAdvancedProperty -Name $XdpMpServiceName -RegistryKeyword PollProvider -DisplayValue $XdpmpPollProvider
 
     if ($XdpmpPollProvider -eq "NDIS") {
-        Write-Verbose "Set-NetAdapterDataPathConfiguration -Name $XdpMpServiceName -Profile Passive"
-        Set-NetAdapterDataPathConfiguration -Name $XdpMpServiceName -Profile Passive
+        #Write-Verbose "Set-NetAdapterDataPathConfiguration -Name $XdpMpServiceName -Profile Passive"
+        #Set-NetAdapterDataPathConfiguration -Name $XdpMpServiceName -Profile Passive
+        Write-Verbose "Skipping NDIS polling configuration"
     }
 
     Wait-For-Adapters -IfDesc $XdpMpServiceName


### PR DESCRIPTION
Resolve #94 

The NDIS polling configuration cmdlet was introduced in WS2022, but we currently don't use NDIS polling on WS2022 due to known issues in its implementation. We are continuing to use NDIS polling uplevel, but design changes to polling have (at least temporarily) broken the NDIS polling configuration cmdlet. Skip setting the configuration to unblock tests.