### PR TITLE
Use new 1ES agent pools in CI

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -61,7 +61,7 @@ stages:
       iterations: 1
   - template: ./templates/tests.yml
     parameters:
-      pool: XDP-CI-1ES-Functional
+      pool: XDP-CI-1ES-Functional-2
       image: MMS2016
       arch: x64
       config: Debug
@@ -70,7 +70,7 @@ stages:
       iterations: ${{ variables.functionalIterations }}
   - template: ./templates/tests.yml
     parameters:
-      pool: XDP-CI-1ES-Functional
+      pool: XDP-CI-1ES-Functional-2
       image: MMS2019
       arch: x64
       config: Debug
@@ -79,7 +79,7 @@ stages:
       iterations: ${{ variables.functionalIterations }}
   - template: ./templates/tests.yml
     parameters:
-      pool: XDP-CI-1ES-Functional
+      pool: XDP-CI-1ES-Functional-2
       image: MMS2022
       arch: x64
       config: Debug
@@ -102,7 +102,7 @@ stages:
       iterations: 1
   - template: ./templates/tests.yml
     parameters:
-      pool: XDP-CI-1ES-Functional
+      pool: XDP-CI-1ES-Functional-2
       image: MMS2016
       arch: x64
       config: Release
@@ -111,7 +111,7 @@ stages:
       iterations: ${{ variables.functionalIterations }}
   - template: ./templates/tests.yml
     parameters:
-      pool: XDP-CI-1ES-Functional
+      pool: XDP-CI-1ES-Functional-2
       image: MMS2019
       arch: x64
       config: Release
@@ -120,7 +120,7 @@ stages:
       iterations: ${{ variables.functionalIterations }}
   - template: ./templates/tests.yml
     parameters:
-      pool: XDP-CI-1ES-Functional
+      pool: XDP-CI-1ES-Functional-2
       image: MMS2022
       arch: x64
       config: Release
@@ -145,7 +145,7 @@ stages:
       successThresholdPercent: 50
   - template: ./templates/spinxsk.yml
     parameters:
-      pool: XDP-CI-1ES-Spinxsk
+      pool: XDP-CI-1ES-Spinxsk-2
       image: MMS2016TLS
       arch: x64
       config: Debug
@@ -156,7 +156,7 @@ stages:
       jobTimeoutMinutes: ${{ variables.spinxskJobTimeout }}
   - template: ./templates/spinxsk.yml
     parameters:
-      pool: XDP-CI-1ES-Spinxsk
+      pool: XDP-CI-1ES-Spinxsk-2
       image: MMS2019TLS
       arch: x64
       config: Debug
@@ -167,7 +167,7 @@ stages:
       jobTimeoutMinutes: ${{ variables.spinxskJobTimeout }}
   - template: ./templates/spinxsk.yml
     parameters:
-      pool: XDP-CI-1ES-Spinxsk
+      pool: XDP-CI-1ES-Spinxsk-2
       image: MMS2022TLS
       arch: x64
       config: Debug
@@ -194,7 +194,7 @@ stages:
       successThresholdPercent: 50
   - template: ./templates/spinxsk.yml
     parameters:
-      pool: XDP-CI-1ES-Spinxsk
+      pool: XDP-CI-1ES-Spinxsk-2
       image: MMS2016TLS
       arch: x64
       config: Release
@@ -205,7 +205,7 @@ stages:
       jobTimeoutMinutes: ${{ variables.spinxskJobTimeout }}
   - template: ./templates/spinxsk.yml
     parameters:
-      pool: XDP-CI-1ES-Spinxsk
+      pool: XDP-CI-1ES-Spinxsk-2
       image: MMS2019TLS
       arch: x64
       config: Release
@@ -216,7 +216,7 @@ stages:
       jobTimeoutMinutes: ${{ variables.spinxskJobTimeout }}
   - template: ./templates/spinxsk.yml
     parameters:
-      pool: XDP-CI-1ES-Spinxsk
+      pool: XDP-CI-1ES-Spinxsk-2
       image: MMS2022TLS
       arch: x64
       config: Release

--- a/.azure/azure-pipelines.longhaul.yml
+++ b/.azure/azure-pipelines.longhaul.yml
@@ -31,7 +31,7 @@ stages:
   jobs:
   - template: ./templates/spinxsk.yml
     parameters:
-      pool: XDP-CI-1ES-Spinxsk
+      pool: XDP-CI-1ES-Spinxsk-2
       image: MMS2016TLS
       arch: x64
       config: Debug
@@ -42,7 +42,7 @@ stages:
       jobTimeoutMinutes: ${{ variables.spinxskJobTimeout }}
   - template: ./templates/spinxsk.yml
     parameters:
-      pool: XDP-CI-1ES-Spinxsk
+      pool: XDP-CI-1ES-Spinxsk-2
       image: MMS2019TLS
       arch: x64
       config: Debug
@@ -53,7 +53,7 @@ stages:
       jobTimeoutMinutes: ${{ variables.spinxskJobTimeout }}
   - template: ./templates/spinxsk.yml
     parameters:
-      pool: XDP-CI-1ES-Spinxsk
+      pool: XDP-CI-1ES-Spinxsk-2
       image: MMS2022TLS
       arch: x64
       config: Debug


### PR DESCRIPTION
We've had to create a new set of 1ES agent pools, so use these new pools.