### PR TITLE
Add minimal XDP user mode API versioning

### DIFF
--- a/published/external/afxdp.h
+++ b/published/external/afxdp.h
@@ -111,11 +111,13 @@ C_ASSERT(sizeof(XSK_RING_FLAGS) == sizeof(UINT32));
 // Creates an AF_XDP socket object and returns a handle to it.
 // To close the socket object, call CloseHandle.
 //
+typedef
 HRESULT
-XDPAPI
-XskCreate(
+XSK_CREATE_FN(
     _Out_ HANDLE* socket
     );
+
+XDPAPI XSK_CREATE_FN XskCreate;
 
 typedef enum _XSK_BIND_FLAGS {
     XSK_BIND_FLAG_NONE = 0x0,
@@ -153,14 +155,16 @@ C_ASSERT(sizeof(XSK_BIND_FLAGS) == sizeof(UINT32));
 // can only be bound to a single network interface queue.
 //
 
+typedef
 HRESULT
-XDPAPI
-XskBind(
+XSK_BIND_FN(
     _In_ HANDLE socket,
     _In_ UINT32 ifIndex,
     _In_ UINT32 queueId,
     _In_ XSK_BIND_FLAGS flags
     );
+
+XDPAPI XSK_BIND_FN XskBind;
 
 typedef enum _XSK_ACTIVATE_FLAGS {
     XSK_ACTIVATE_FLAG_NONE = 0x0,
@@ -182,12 +186,14 @@ C_ASSERT(sizeof(XSK_ACTIVATE_FLAGS) == sizeof(UINT32));
 // 2) The socket object must have registered or shared a UMEM.
 //
 
+typedef
 HRESULT
-XDPAPI
-XskActivate(
+XSK_ACTIVATE_FN(
     _In_ HANDLE socket,
     _In_ XSK_ACTIVATE_FLAGS flags
     );
+
+XDPAPI XSK_ACTIVATE_FN XskActivate;
 
 //
 // XskNotifySocket
@@ -254,14 +260,16 @@ typedef enum _XSK_NOTIFY_RESULT_FLAGS {
 DEFINE_ENUM_FLAG_OPERATORS(XSK_NOTIFY_RESULT_FLAGS)
 C_ASSERT(sizeof(XSK_NOTIFY_RESULT_FLAGS) == sizeof(UINT32));
 
+typedef
 HRESULT
-XDPAPI
-XskNotifySocket(
+XSK_NOTIFY_SOCKET_FN(
     _In_ HANDLE socket,
     _In_ XSK_NOTIFY_FLAGS flags,
     _In_ UINT32 waitTimeoutMilliseconds,
     _Out_ XSK_NOTIFY_RESULT_FLAGS *result
     );
+
+XDPAPI XSK_NOTIFY_SOCKET_FN XskNotifySocket;
 
 typedef struct _OVERLAPPED OVERLAPPED;
 
@@ -282,65 +290,73 @@ typedef struct _OVERLAPPED OVERLAPPED;
 // Unlike XskNotifySocket, this routine does not perform the wait inline.
 // Instead, if a wait was requested and could not be immediately satisfied, the
 // routine returns HRESULT_FROM_WIN32(ERROR_IO_PENDING) and the overlapped IO
-// will be completed asynchronously. Once the IO has completed, the 
+// will be completed asynchronously. Once the IO has completed, the
 // XskGetNotifyAsyncResult routine may be used to retrieve the result flags.
 //
 
+typedef
 HRESULT
-XDPAPI
-XskNotifyAsync(
+XSK_NOTIFY_ASYNC_FN(
     _In_ HANDLE socket,
     _In_ XSK_NOTIFY_FLAGS flags,
     _Inout_ OVERLAPPED *overlapped
     );
 
+XDPAPI XSK_NOTIFY_ASYNC_FN XskNotifyAsync;
+
 //
 // Retrieves the result flags from a previously completed XskNotifyAsync.
 //
 
+typedef
 HRESULT
-XDPAPI
-XskGetNotifyAsyncResult(
+XSK_GET_NOTIFY_ASYNC_RESULT_FN(
     _In_ OVERLAPPED *overlapped,
     _Out_ XSK_NOTIFY_RESULT_FLAGS *result
     );
+
+XDPAPI XSK_GET_NOTIFY_ASYNC_RESULT_FN XskGetNotifyAsyncResult;
 
 //
 // XskSetSockopt
 //
 // Sets a socket option.
 //
+typedef
 HRESULT
-XDPAPI
-XskSetSockopt(
+XSK_SET_SOCKOPT_FN(
     _In_ HANDLE socket,
     _In_ UINT32 optionName,
     _In_reads_bytes_opt_(optionLength) const VOID *optionValue,
     _In_ UINT32 optionLength
     );
 
+XDPAPI XSK_SET_SOCKOPT_FN XskSetSockopt;
+
 //
 // XskGetSockopt
 //
 // Gets a socket option.
 //
+typedef
 HRESULT
-XDPAPI
-XskGetSockopt(
+XSK_GET_SOCKOPT_FN(
     _In_ HANDLE socket,
     _In_ UINT32 optionName,
     _Out_writes_bytes_(*optionLength) VOID *optionValue,
     _Inout_ UINT32 *optionLength
     );
 
+XDPAPI XSK_GET_SOCKOPT_FN XskGetSockopt;
+
 //
 // XskIoctl
 //
 // Performs a socket IOCTL.
 //
+typedef
 HRESULT
-XDPAPI
-XskIoctl(
+XSK_IOCTL_FN(
     _In_ HANDLE socket,
     _In_ UINT32 optionName,
     _In_reads_bytes_opt_(inputLength) const VOID *inputValue,
@@ -348,6 +364,8 @@ XskIoctl(
     _Out_writes_bytes_(*outputLength) VOID *outputValue,
     _Inout_ UINT32 *outputLength
     );
+
+XDPAPI XSK_IOCTL_FN XskIoctl;
 
 //
 // Socket options

--- a/published/external/xdpapi.h
+++ b/published/external/xdpapi.h
@@ -43,9 +43,9 @@ extern "C" {
 //
 #define XDP_CREATE_PROGRAM_FLAG_SHARE   0x4
 
+typedef
 HRESULT
-XDPAPI
-XdpCreateProgram(
+XDP_CREATE_PROGRAM_FN(
     _In_ UINT32 InterfaceIndex,
     _In_ CONST XDP_HOOK_ID *HookId,
     _In_ UINT32 QueueId,
@@ -55,6 +55,7 @@ XdpCreateProgram(
     _Out_ HANDLE *Program
     );
 
+XDPAPI XDP_CREATE_PROGRAM_FN XdpCreateProgram;
 
 //
 // Interface API.
@@ -63,12 +64,14 @@ XdpCreateProgram(
 //
 // Open a handle to get/set offloads/configurations/properties on an interface.
 //
+typedef
 HRESULT
-XDPAPI
-XdpInterfaceOpen(
+XDP_INTERFACE_OPEN_FN(
     _In_ UINT32 InterfaceIndex,
     _Out_ HANDLE *InterfaceHandle
     );
+
+XDPAPI XDP_INTERFACE_OPEN_FN XdpInterfaceOpen;
 
 //
 // RSS offload.
@@ -150,13 +153,15 @@ XdpInitializeRssCapabilities(
 // too small, HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER) will be returned.
 // Call with a NULL RssCapabilities to get the length.
 //
+typedef
 HRESULT
-XDPAPI
-XdpRssGetCapabilities(
+XDP_RSS_GET_CAPABILITIES_FN(
     _In_ HANDLE InterfaceHandle,
     _Out_opt_ XDP_RSS_CAPABILITIES *RssCapabilities,
     _Inout_ UINT32 *RssCapabilitiesSize
     );
+
+XDPAPI XDP_RSS_GET_CAPABILITIES_FN XdpRssGetCapabilities;
 
 //
 // Upon set, indicates XDP_RSS_CONFIGURATION.HashType should not be ignored.
@@ -245,26 +250,159 @@ XdpInitializeRssConfiguration(
 // the handle is closed. Upon handle closure, RSS settings will revert back to
 // their original state.
 //
+typedef
 HRESULT
-XDPAPI
-XdpRssSet(
+XDP_RSS_SET_FN(
     _In_ HANDLE InterfaceHandle,
     _In_ CONST XDP_RSS_CONFIGURATION *RssConfiguration,
     _In_ UINT32 RssConfigurationSize
     );
+
+XDPAPI XDP_RSS_SET_FN XdpRssSet;
 
 //
 // Query RSS settings on an interface. If the input RssConfigurationSize is too
 // small, HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER) will be returned. Call
 // with a NULL RssConfiguration to get the length.
 //
+typedef
 HRESULT
-XDPAPI
-XdpRssGet(
+XDP_RSS_GET_FN(
     _In_ HANDLE InterfaceHandle,
     _Out_opt_ XDP_RSS_CONFIGURATION *RssConfiguration,
     _Inout_ UINT32 *RssConfigurationSize
     );
+
+XDPAPI XDP_RSS_GET_FN XdpRssGet;
+
+#include "afxdp.h"
+
+typedef struct _XDP_API_TABLE XDP_API_TABLE;
+
+//
+// The only API version currently supported. Any change to the API is considered
+// a breaking change and support for previous versions will be removed.
+//
+#define XDP_VERSION_PRERELEASE 100001
+
+//
+// Opens the API and returns an API function table with the rest of the API's
+// functions. Each open must invoke a corresponding XdpCloseApi when the API
+// will no longer be used.
+//
+typedef
+HRESULT
+XDP_OPEN_API_FN(
+    _In_ UINT32 XdpApiVersion,
+    _Out_ CONST XDP_API_TABLE **XdpApiTable
+    );
+
+XDPAPI XDP_OPEN_API_FN XdpOpenApi;
+
+//
+// Releases the reference to the API returned by XdpOpenApi.
+//
+typedef
+VOID
+XDP_CLOSE_API_FN(
+    _In_ CONST XDP_API_TABLE *XdpApiTable
+    );
+
+XDPAPI XDP_CLOSE_API_FN XdpCloseApi;
+
+typedef struct _XDP_API_TABLE {
+    XDP_OPEN_API_FN *XdpOpenApi;
+    XDP_CLOSE_API_FN *XdpCloseApi;
+    XDP_CREATE_PROGRAM_FN *XdpCreateProgram;
+    XDP_INTERFACE_OPEN_FN *XdpInterfaceOpen;
+    XDP_RSS_GET_CAPABILITIES_FN *XdpRssGetCapabilities;
+    XDP_RSS_SET_FN *XdpRssSet;
+    XDP_RSS_GET_FN *XdpRssGet;
+    XSK_CREATE_FN *XskCreate;
+    XSK_BIND_FN *XskBind;
+    XSK_ACTIVATE_FN *XskActivate;
+    XSK_NOTIFY_SOCKET_FN *XskNotifySocket;
+    XSK_NOTIFY_ASYNC_FN *XskNotifyAsync;
+    XSK_GET_NOTIFY_ASYNC_RESULT_FN *XskGetNotifyAsyncResult;
+    XSK_SET_SOCKOPT_FN *XskSetSockopt;
+    XSK_GET_SOCKOPT_FN *XskGetSockopt;
+    XSK_IOCTL_FN *XskIoctl;
+} XDP_API_TABLE;
+
+typedef struct _XDP_LOAD_CONTEXT *XDP_LOAD_API_CONTEXT;
+
+#if !defined(_KERNEL_MODE)
+
+//
+// Dynamically loads XDP, then opens the API and returns an API function table
+// with the rest of the API's functions. Each open must invoke a corresponding
+// XdpCloseApi when the API will no longer be used.
+//
+// This routine cannot be called from DllMain.
+//
+inline
+HRESULT
+XdpLoadApi(
+    _In_ UINT32 XdpApiVersion,
+    _Out_ XDP_LOAD_API_CONTEXT *XdpLoadApiContext,
+    _Out_ CONST XDP_API_TABLE **XdpApiTable
+    )
+{
+    HRESULT Result;
+    HMODULE XdpHandle;
+    XDP_OPEN_API_FN *OpenApi;
+
+    *XdpLoadApiContext = NULL;
+    *XdpApiTable = NULL;
+
+    XdpHandle = LoadLibraryA("xdpapi.dll");
+    if (XdpHandle == NULL) {
+        Result = E_NOINTERFACE;
+        goto Exit;
+    }
+
+    OpenApi = (XDP_OPEN_API_FN *)GetProcAddress(XdpHandle, "XdpOpenApi");
+    if (OpenApi == NULL) {
+        Result = E_NOINTERFACE;
+        goto Exit;
+    }
+
+    Result = OpenApi(XdpApiVersion, XdpApiTable);
+
+Exit:
+
+    if (SUCCEEDED(Result)) {
+        *XdpLoadApiContext = (XDP_LOAD_API_CONTEXT)XdpHandle;
+    } else {
+        if (XdpHandle != NULL) {
+            FreeLibrary(XdpHandle);
+        }
+    }
+
+    return Result;
+}
+
+//
+// Releases the reference to the API returned by XdpOpenApi, then dynamically
+// unloads XDP.
+//
+// This routine cannot be called from DllMain.
+//
+inline
+VOID
+XdpUnloadApi(
+    _In_ XDP_LOAD_API_CONTEXT XdpLoadApiContext,
+    _In_ CONST XDP_API_TABLE *XdpApiTable
+    )
+{
+    HMODULE XdpHandle = (HMODULE)XdpLoadApiContext;
+
+    XdpApiTable->XdpCloseApi(XdpApiTable);
+
+    FreeLibrary(XdpHandle);
+}
+
+#endif // !defined(_KERNEL_MODE)
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/rtl/inc/xdpassert.h
+++ b/src/rtl/inc/xdpassert.h
@@ -25,5 +25,11 @@
 #endif
 #endif
 
+#ifdef KERNEL_MODE
 #define FRE_ASSERT(e) \
     (NT_VERIFY(e) ? TRUE : (RtlFailFast(FAST_FAIL_INVALID_ARG), FALSE))
+#elif DBG
+#define FRE_ASSERT(e) (ASSERT(e) ? TRUE : (__fastfail(FAST_FAIL_INVALID_ARG), FALSE))
+#else
+#define FRE_ASSERT(e) ((e) ? TRUE : (__fastfail(FAST_FAIL_INVALID_ARG), FALSE))
+#endif

--- a/src/xdpapi/xdpapi.c
+++ b/src/xdpapi/xdpapi.c
@@ -5,6 +5,52 @@
 
 #include "precomp.h"
 
+static CONST XDP_API_TABLE XdpApiTablePrerelease = {
+    .XdpOpenApi = XdpOpenApi,
+    .XdpCloseApi = XdpCloseApi,
+    .XdpCreateProgram = XdpCreateProgram,
+    .XdpInterfaceOpen = XdpInterfaceOpen,
+    .XdpRssGetCapabilities = XdpRssGetCapabilities,
+    .XdpRssSet = XdpRssSet,
+    .XdpRssGet = XdpRssGet,
+    .XskCreate = XskCreate,
+    .XskBind = XskBind,
+    .XskActivate = XskActivate,
+    .XskNotifySocket = XskNotifySocket,
+    .XskNotifyAsync = XskNotifyAsync,
+    .XskGetNotifyAsyncResult = XskGetNotifyAsyncResult,
+    .XskSetSockopt = XskSetSockopt,
+    .XskGetSockopt = XskGetSockopt,
+    .XskIoctl = XskIoctl,
+};
+
+HRESULT
+XDPAPI
+XdpOpenApi(
+    _In_ UINT32 XdpApiVersion,
+    _Out_ CONST XDP_API_TABLE **XdpApiTable
+    )
+{
+    *XdpApiTable = NULL;
+
+    if (XdpApiVersion != XDP_VERSION_PRERELEASE) {
+        return E_NOINTERFACE;
+    }
+
+    *XdpApiTable = &XdpApiTablePrerelease;
+
+    return S_OK;
+}
+
+VOID
+XDPAPI
+XdpCloseApi(
+    _In_ CONST XDP_API_TABLE *XdpApiTable
+    )
+{
+    FRE_ASSERT(XdpApiTable == &XdpApiTablePrerelease);
+}
+
 HRESULT
 XDPAPI
 XdpCreateProgram(

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -1599,6 +1599,55 @@ MpXdpDeregister(
 
 static
 VOID
+VerifyPrereleaseApiTable(
+    _In_ const XDP_API_TABLE *XdpApiTable
+    )
+{
+    TEST_EQUAL(XdpOpenApi, XdpApiTable->XdpOpenApi);
+    TEST_EQUAL(XdpCloseApi, XdpApiTable->XdpCloseApi);
+    TEST_EQUAL(XdpCreateProgram, XdpApiTable->XdpCreateProgram);
+    TEST_EQUAL(XdpInterfaceOpen, XdpApiTable->XdpInterfaceOpen);
+    TEST_EQUAL(XdpRssGetCapabilities, XdpApiTable->XdpRssGetCapabilities);
+    TEST_EQUAL(XdpRssSet, XdpApiTable->XdpRssSet);
+    TEST_EQUAL(XdpRssGet, XdpApiTable->XdpRssGet);
+    TEST_EQUAL(XskCreate, XdpApiTable->XskCreate);
+    TEST_EQUAL(XskBind, XdpApiTable->XskBind);
+    TEST_EQUAL(XskActivate, XdpApiTable->XskActivate);
+    TEST_EQUAL(XskNotifySocket, XdpApiTable->XskNotifySocket);
+    TEST_EQUAL(XskNotifyAsync, XdpApiTable->XskNotifyAsync);
+    TEST_EQUAL(XskGetNotifyAsyncResult, XdpApiTable->XskGetNotifyAsyncResult);
+    TEST_EQUAL(XskSetSockopt, XdpApiTable->XskSetSockopt);
+    TEST_EQUAL(XskGetSockopt, XdpApiTable->XskGetSockopt);
+    TEST_EQUAL(XskIoctl, XdpApiTable->XskIoctl);
+}
+
+VOID
+OpenApiTest()
+{
+    const XDP_API_TABLE *XdpApiTable;
+
+    TEST_HRESULT(XdpOpenApi(XDP_VERSION_PRERELEASE, &XdpApiTable));
+    VerifyPrereleaseApiTable(XdpApiTable);
+    XdpCloseApi(XdpApiTable);
+
+    TEST_FALSE(SUCCEEDED(XdpOpenApi(XDP_VERSION_PRERELEASE + 1, &XdpApiTable)));
+}
+
+VOID
+LoadApiTest()
+{
+    XDP_LOAD_API_CONTEXT XdpLoadApiContext;
+    const XDP_API_TABLE *XdpApiTable;
+
+    TEST_HRESULT(XdpLoadApi(XDP_VERSION_PRERELEASE, &XdpLoadApiContext, &XdpApiTable));
+    VerifyPrereleaseApiTable(XdpApiTable);
+    XdpUnloadApi(XdpLoadApiContext, XdpApiTable);
+
+    TEST_FALSE(SUCCEEDED(XdpOpenApi(XDP_VERSION_PRERELEASE + 1, &XdpApiTable)));
+}
+
+static
+VOID
 BindingTest(
     _In_ const TestInterface& If,
     _In_ BOOLEAN RestartAdapter

--- a/test/functional/lib/tests.h
+++ b/test/functional/lib/tests.h
@@ -12,6 +12,12 @@ bool
 TestCleanup();
 
 VOID
+OpenApiTest();
+
+VOID
+LoadApiTest();
+
+VOID
 GenericBinding();
 
 VOID
@@ -108,7 +114,7 @@ GenericXskWaitAsync(
     _In_ BOOLEAN Rx,
     _In_ BOOLEAN Tx
     );
-    
+
 VOID
 GenericLwfDelayDetach(
     _In_ BOOLEAN Rx,

--- a/test/functional/taef/tests.cpp
+++ b/test/functional/taef/tests.cpp
@@ -84,6 +84,14 @@ TEST_MODULE_CLEANUP(ModuleCleanup)
 TEST_CLASS(xdpfunctionaltests)
 {
 public:
+    TEST_METHOD(OpenApi) {
+        ::OpenApiTest();
+    }
+
+    TEST_METHOD(LoadApi) {
+        ::LoadApiTest();
+    }
+
     TEST_METHOD(GenericBinding) {
         ::GenericBinding();
     }


### PR DESCRIPTION
Add an optional dispatch table and optional run time linking. Apps can continue to use plain load-time linking for the time being.

A followup PR will convert the remaining test and sample code within the project to use the new versioned APIs.