### PR TITLE
Consume new API table and remove support for load-time linkage

### DIFF
--- a/published/external/afxdp.h
+++ b/published/external/afxdp.h
@@ -117,8 +117,6 @@ XSK_CREATE_FN(
     _Out_ HANDLE* socket
     );
 
-XDPAPI XSK_CREATE_FN XskCreate;
-
 typedef enum _XSK_BIND_FLAGS {
     XSK_BIND_FLAG_NONE = 0x0,
 
@@ -164,8 +162,6 @@ XSK_BIND_FN(
     _In_ XSK_BIND_FLAGS flags
     );
 
-XDPAPI XSK_BIND_FN XskBind;
-
 typedef enum _XSK_ACTIVATE_FLAGS {
     XSK_ACTIVATE_FLAG_NONE = 0x0,
 } XSK_ACTIVATE_FLAGS;
@@ -192,8 +188,6 @@ XSK_ACTIVATE_FN(
     _In_ HANDLE socket,
     _In_ XSK_ACTIVATE_FLAGS flags
     );
-
-XDPAPI XSK_ACTIVATE_FN XskActivate;
 
 //
 // XskNotifySocket
@@ -269,8 +263,6 @@ XSK_NOTIFY_SOCKET_FN(
     _Out_ XSK_NOTIFY_RESULT_FLAGS *result
     );
 
-XDPAPI XSK_NOTIFY_SOCKET_FN XskNotifySocket;
-
 typedef struct _OVERLAPPED OVERLAPPED;
 
 //
@@ -302,8 +294,6 @@ XSK_NOTIFY_ASYNC_FN(
     _Inout_ OVERLAPPED *overlapped
     );
 
-XDPAPI XSK_NOTIFY_ASYNC_FN XskNotifyAsync;
-
 //
 // Retrieves the result flags from a previously completed XskNotifyAsync.
 //
@@ -314,8 +304,6 @@ XSK_GET_NOTIFY_ASYNC_RESULT_FN(
     _In_ OVERLAPPED *overlapped,
     _Out_ XSK_NOTIFY_RESULT_FLAGS *result
     );
-
-XDPAPI XSK_GET_NOTIFY_ASYNC_RESULT_FN XskGetNotifyAsyncResult;
 
 //
 // XskSetSockopt
@@ -331,8 +319,6 @@ XSK_SET_SOCKOPT_FN(
     _In_ UINT32 optionLength
     );
 
-XDPAPI XSK_SET_SOCKOPT_FN XskSetSockopt;
-
 //
 // XskGetSockopt
 //
@@ -346,8 +332,6 @@ XSK_GET_SOCKOPT_FN(
     _Out_writes_bytes_(*optionLength) VOID *optionValue,
     _Inout_ UINT32 *optionLength
     );
-
-XDPAPI XSK_GET_SOCKOPT_FN XskGetSockopt;
 
 //
 // XskIoctl
@@ -364,8 +348,6 @@ XSK_IOCTL_FN(
     _Out_writes_bytes_(*outputLength) VOID *outputValue,
     _Inout_ UINT32 *outputLength
     );
-
-XDPAPI XSK_IOCTL_FN XskIoctl;
 
 //
 // Socket options

--- a/published/external/xdpapi.h
+++ b/published/external/xdpapi.h
@@ -55,8 +55,6 @@ XDP_CREATE_PROGRAM_FN(
     _Out_ HANDLE *Program
     );
 
-XDPAPI XDP_CREATE_PROGRAM_FN XdpCreateProgram;
-
 //
 // Interface API.
 //
@@ -70,8 +68,6 @@ XDP_INTERFACE_OPEN_FN(
     _In_ UINT32 InterfaceIndex,
     _Out_ HANDLE *InterfaceHandle
     );
-
-XDPAPI XDP_INTERFACE_OPEN_FN XdpInterfaceOpen;
 
 //
 // RSS offload.
@@ -160,8 +156,6 @@ XDP_RSS_GET_CAPABILITIES_FN(
     _Out_opt_ XDP_RSS_CAPABILITIES *RssCapabilities,
     _Inout_ UINT32 *RssCapabilitiesSize
     );
-
-XDPAPI XDP_RSS_GET_CAPABILITIES_FN XdpRssGetCapabilities;
 
 //
 // Upon set, indicates XDP_RSS_CONFIGURATION.HashType should not be ignored.
@@ -258,8 +252,6 @@ XDP_RSS_SET_FN(
     _In_ UINT32 RssConfigurationSize
     );
 
-XDPAPI XDP_RSS_SET_FN XdpRssSet;
-
 //
 // Query RSS settings on an interface. If the input RssConfigurationSize is too
 // small, HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER) will be returned. Call
@@ -272,8 +264,6 @@ XDP_RSS_GET_FN(
     _Out_opt_ XDP_RSS_CONFIGURATION *RssConfiguration,
     _Inout_ UINT32 *RssConfigurationSize
     );
-
-XDPAPI XDP_RSS_GET_FN XdpRssGet;
 
 #include "afxdp.h"
 

--- a/samples/rxfilter/rxfilter.c
+++ b/samples/rxfilter/rxfilter.c
@@ -177,6 +177,7 @@ main(
     CHAR **argv
     )
 {
+    const XDP_API_TABLE *XdpApi;
     HRESULT Result;
     HANDLE Program;
     CONST XDP_HOOK_ID XdpInspectRxL2 = {
@@ -190,10 +191,18 @@ main(
     //
     ParseArgs(argc, argv);
 
+    Result = XdpOpenApi(XDP_VERSION_PRERELEASE, &XdpApi);
+    if (FAILED(Result)) {
+        LOGERR("XdpOpenApi failed: %x", Result);
+        return 1;
+    }
+
     //
     // Create an XDP program using the parsed rule at the L2 inspect hook point.
     //
-    Result = XdpCreateProgram(IfIndex, &XdpInspectRxL2, QueueId, ProgramFlags, &Rule, 1, &Program);
+    Result =
+        XdpApi->XdpCreateProgram(
+            IfIndex, &XdpInspectRxL2, QueueId, ProgramFlags, &Rule, 1, &Program);
     if (FAILED(Result)) {
         LOGERR("XdpCreateProgram failed: %x", Result);
         return 1;
@@ -203,6 +212,6 @@ main(
     // Let XDP filter frames until this process is terminated.
     //
     Sleep(INFINITE);
-    
+
     return 0;
 }

--- a/src/xdpapi/afxdp.c
+++ b/src/xdpapi/afxdp.c
@@ -7,7 +7,6 @@
 #include <assert.h>
 
 HRESULT
-XDPAPI
 XskCreate(
     _Out_ HANDLE* socket
     )
@@ -33,7 +32,6 @@ XskCreate(
 }
 
 HRESULT
-XDPAPI
 XskBind(
     _In_ HANDLE socket,
     _In_ UINT32 ifIndex,
@@ -67,7 +65,6 @@ XskBind(
 }
 
 HRESULT
-XDPAPI
 XskActivate(
     _In_ HANDLE socket,
     _In_ XSK_ACTIVATE_FLAGS flags
@@ -97,7 +94,6 @@ XskActivate(
 }
 
 HRESULT
-XDPAPI
 XskSetSockopt(
     _In_ HANDLE socket,
     _In_ UINT32 optionName,
@@ -131,7 +127,6 @@ XskSetSockopt(
 }
 
 HRESULT
-XDPAPI
 XskGetSockopt(
     _In_ HANDLE socket,
     _In_ UINT32 optionName,
@@ -163,7 +158,6 @@ XskGetSockopt(
 }
 
 HRESULT
-XDPAPI
 XskIoctl(
     _In_ HANDLE socket,
     _In_ UINT32 optionName,
@@ -184,7 +178,6 @@ XskIoctl(
 }
 
 HRESULT
-XDPAPI
 XskNotifySocket(
     _In_ HANDLE socket,
     _In_ XSK_NOTIFY_FLAGS flags,
@@ -220,7 +213,6 @@ XskNotifySocket(
 }
 
 HRESULT
-XDPAPI
 XskNotifyAsync(
     _In_ HANDLE socket,
     _In_ XSK_NOTIFY_FLAGS flags,
@@ -253,7 +245,6 @@ XskNotifyAsync(
 }
 
 HRESULT
-XDPAPI
 XskGetNotifyAsyncResult(
     _In_ OVERLAPPED *overlapped,
     _Out_ XSK_NOTIFY_RESULT_FLAGS *result

--- a/src/xdpapi/xdpapi.c
+++ b/src/xdpapi/xdpapi.c
@@ -5,6 +5,23 @@
 
 #include "precomp.h"
 
+XDP_OPEN_API_FN XdpOpenApi;
+XDP_CLOSE_API_FN XdpCloseApi;
+XDP_CREATE_PROGRAM_FN XdpCreateProgram;
+XDP_INTERFACE_OPEN_FN XdpInterfaceOpen;
+XDP_RSS_GET_CAPABILITIES_FN XdpRssGetCapabilities;
+XDP_RSS_SET_FN XdpRssSet;
+XDP_RSS_GET_FN XdpRssGet;
+XSK_CREATE_FN XskCreate;
+XSK_BIND_FN XskBind;
+XSK_ACTIVATE_FN XskActivate;
+XSK_NOTIFY_SOCKET_FN XskNotifySocket;
+XSK_NOTIFY_ASYNC_FN XskNotifyAsync;
+XSK_GET_NOTIFY_ASYNC_RESULT_FN XskGetNotifyAsyncResult;
+XSK_SET_SOCKOPT_FN XskSetSockopt;
+XSK_GET_SOCKOPT_FN XskGetSockopt;
+XSK_IOCTL_FN XskIoctl;
+
 static CONST XDP_API_TABLE XdpApiTablePrerelease = {
     .XdpOpenApi = XdpOpenApi,
     .XdpCloseApi = XdpCloseApi,
@@ -52,7 +69,6 @@ XdpCloseApi(
 }
 
 HRESULT
-XDPAPI
 XdpCreateProgram(
     _In_ UINT32 InterfaceIndex,
     _In_ CONST XDP_HOOK_ID *HookId,
@@ -83,7 +99,6 @@ XdpCreateProgram(
 }
 
 HRESULT
-XDPAPI
 XdpInterfaceOpen(
     _In_ UINT32 InterfaceIndex,
     _Out_ HANDLE *InterfaceHandle
@@ -105,7 +120,6 @@ XdpInterfaceOpen(
 }
 
 HRESULT
-XDPAPI
 XdpRssGetCapabilities(
     _In_ HANDLE InterfaceHandle,
     _Out_opt_ XDP_RSS_CAPABILITIES *RssCapabilities,
@@ -125,7 +139,6 @@ XdpRssGetCapabilities(
 }
 
 HRESULT
-XDPAPI
 XdpRssSet(
     _In_ HANDLE InterfaceHandle,
     _In_ CONST XDP_RSS_CONFIGURATION *RssConfiguration,
@@ -145,7 +158,6 @@ XdpRssSet(
 }
 
 HRESULT
-XDPAPI
 XdpRssGet(
     _In_ HANDLE InterfaceHandle,
     _Out_opt_ XDP_RSS_CONFIGURATION *RssConfiguration,

--- a/test/spinxsk/spinxsk.c
+++ b/test/spinxsk/spinxsk.c
@@ -185,6 +185,7 @@ typedef struct {
 struct QUEUE_CONTEXT {
     UINT32 queueId;
 
+    CONST XDP_API_TABLE *xdpApi;
     HANDLE sock;
     HANDLE sharedUmemSock;
     HANDLE rss;
@@ -385,7 +386,7 @@ AttachXdpProgram(
         flags |= XDP_CREATE_PROGRAM_FLAG_SHARE;
     }
 
-    res = XskGetSockopt(Sock, XSK_SOCKOPT_RX_HOOK_ID, &hookId, &hookIdSize);
+    res = Queue->xdpApi->XskGetSockopt(Sock, XSK_SOCKOPT_RX_HOOK_ID, &hookId, &hookIdSize);
     if (FAILED(res)) {
         goto Exit;
     }
@@ -415,7 +416,9 @@ AttachXdpProgram(
         }
     }
 
-    res = XdpCreateProgram(ifindex, &hookId, Queue->queueId, flags, &rule, 1, &handle);
+    res =
+        Queue->xdpApi->XdpCreateProgram(
+            ifindex, &hookId, Queue->queueId, flags, &rule, 1, &handle);
     if (SUCCEEDED(res)) {
         EnterCriticalSection(&RxProgramSet->Lock);
         if (RxProgramSet->HandleCount < RTL_NUMBER_OF(RxProgramSet->Handles)) {
@@ -541,6 +544,10 @@ CleanupQueue(
         ASSERT_FRE(res);
     }
 
+    if (Queue->xdpApi != NULL) {
+        XdpCloseApi(Queue->xdpApi);
+    }
+
     DeleteCriticalSection(&Queue->sharedUmemRxProgramSet.Lock);
     DeleteCriticalSection(&Queue->rxProgramSet.Lock);
 
@@ -617,11 +624,11 @@ FuzzRssSet(
     //
 
     if (fuzzer->fuzzerInterface != NULL) {
-        (void)XdpRssSet(fuzzer->fuzzerInterface, RssConfiguration, RssConfigSize);
+        (void)queue->xdpApi->XdpRssSet(fuzzer->fuzzerInterface, RssConfiguration, RssConfigSize);
     } else {
         AcquireSRWLockShared(&queue->rssLock);
         if (queue->rss != NULL) {
-            (void)XdpRssSet(queue->rss, RssConfiguration, RssConfigSize);
+            (void)queue->xdpApi->XdpRssSet(queue->rss, RssConfiguration, RssConfigSize);
         }
         ReleaseSRWLockShared(&queue->rssLock);
     }
@@ -647,11 +654,11 @@ FuzzRssGet(
     UINT32 size = 0;
 
     if (Fuzzer->fuzzerInterface != NULL) {
-        res = XdpRssGet(Fuzzer->fuzzerInterface, NULL, &size);
+        res = Queue->xdpApi->XdpRssGet(Fuzzer->fuzzerInterface, NULL, &size);
     } else {
         AcquireSRWLockShared(&Queue->rssLock);
         if (Queue->rss != NULL) {
-            res = XdpRssGet(Queue->rss, NULL, &size);
+            res = Queue->xdpApi->XdpRssGet(Queue->rss, NULL, &size);
         } else {
             res = E_INVALIDARG;
         }
@@ -671,12 +678,12 @@ FuzzRssGet(
 
     if (Fuzzer->fuzzerInterface != NULL) {
 #pragma prefast(suppress : 6386, "SAL does not understand the mod operator")
-        XdpRssGet(Fuzzer->fuzzerInterface, rssConfiguration, &size);
+        Queue->xdpApi->XdpRssGet(Fuzzer->fuzzerInterface, rssConfiguration, &size);
     } else {
         AcquireSRWLockShared(&Queue->rssLock);
         if (Queue->rss != NULL) {
 #pragma prefast(suppress : 6386, "SAL does not understand the mod operator")
-            XdpRssGet(Queue->rss, rssConfiguration, &size);
+            Queue->xdpApi->XdpRssGet(Queue->rss, rssConfiguration, &size);
         }
         ReleaseSRWLockShared(&Queue->rssLock);
     }
@@ -699,11 +706,11 @@ FuzzRssGetCapabilities(
     UINT32 size = 0;
 
     if (Fuzzer->fuzzerInterface != NULL) {
-        res = XdpRssGetCapabilities(Fuzzer->fuzzerInterface, NULL, &size);
+        res = Queue->xdpApi->XdpRssGetCapabilities(Fuzzer->fuzzerInterface, NULL, &size);
     } else {
         AcquireSRWLockShared(&Queue->rssLock);
         if (Queue->rss != NULL) {
-            res = XdpRssGetCapabilities(Queue->rss, NULL, &size);
+            res = Queue->xdpApi->XdpRssGetCapabilities(Queue->rss, NULL, &size);
         } else {
             res = E_INVALIDARG;
         }
@@ -723,12 +730,12 @@ FuzzRssGetCapabilities(
 
     if (Fuzzer->fuzzerInterface != NULL) {
 #pragma prefast(suppress : 6386, "SAL does not understand the mod operator")
-        XdpRssGetCapabilities(Fuzzer->fuzzerInterface, rssCapabilities, &size);
+        Queue->xdpApi->XdpRssGetCapabilities(Fuzzer->fuzzerInterface, rssCapabilities, &size);
     } else {
         AcquireSRWLockShared(&Queue->rssLock);
         if (Queue->rss != NULL) {
 #pragma prefast(suppress : 6386, "SAL does not understand the mod operator")
-            XdpRssGetCapabilities(Queue->rss, rssCapabilities, &size);
+            Queue->xdpApi->XdpRssGetCapabilities(Queue->rss, rssCapabilities, &size);
         }
         ReleaseSRWLockShared(&Queue->rssLock);
     }
@@ -775,7 +782,7 @@ FuzzRss(
             fuzzer->fuzzerInterface = NULL;
         }
 
-        XdpInterfaceOpen(ifindex, &fuzzer->fuzzerInterface);
+        queue->xdpApi->XdpInterfaceOpen(ifindex, &fuzzer->fuzzerInterface);
     }
 
     if (RandUlong() % 25 == 0) {
@@ -821,6 +828,11 @@ InitializeQueue(
     InitializeCriticalSection(&queue->rxProgramSet.Lock);
     InitializeCriticalSection(&queue->sharedUmemRxProgramSet.Lock);
     InitializeSRWLock(&queue->rssLock);
+
+    res = XdpOpenApi(XDP_VERSION_PRERELEASE, &queue->xdpApi);
+    if (FAILED(res)) {
+        goto Exit;
+    }
 
     queue->fuzzers = calloc(queue->fuzzerCount, sizeof(*queue->fuzzers));
     if (queue->fuzzers == NULL) {
@@ -874,13 +886,13 @@ InitializeQueue(
         queue->scenarioConfig.sharedUmemSockTx = TRUE;
     }
 
-    res = XskCreate(&queue->sock);
+    res = queue->xdpApi->XskCreate(&queue->sock);
     if (FAILED(res)) {
         goto Exit;
     }
 
     if (queue->scenarioConfig.sharedUmemSockRx || queue->scenarioConfig.sharedUmemSockTx) {
-        res = XskCreate(&queue->sharedUmemSock);
+        res = queue->xdpApi->XskCreate(&queue->sharedUmemSock);
         if (FAILED(res)) {
             goto Exit;
         }
@@ -977,7 +989,7 @@ FuzzSocketUmemSetup(
         }
 
         res =
-            XskSetSockopt(
+            Queue->xdpApi->XskSetSockopt(
                 Sock, XSK_SOCKOPT_UMEM_REG, &umemReg, sizeof(umemReg));
         if (SUCCEEDED(res)) {
             Queue->umemReg = umemReg;
@@ -1011,7 +1023,7 @@ FuzzSocketSharedUmemSetup(
         }
 
         res =
-            XskSetSockopt(
+            Queue->xdpApi->XskSetSockopt(
                 Sock, XSK_SOCKOPT_SHARE_UMEM, &SharedUmemSock, sizeof(SharedUmemSock));
         if (SUCCEEDED(res)) {
             TraceVerbose(
@@ -1058,7 +1070,7 @@ FuzzSocketRxTxSetup(
         if (RandUlong() % 2) {
             FuzzRingSize(Queue, &ringSize);
             res =
-                XskSetSockopt(
+                Queue->xdpApi->XskSetSockopt(
                     Sock, XSK_SOCKOPT_RX_RING_SIZE, &ringSize, sizeof(ringSize));
             if (SUCCEEDED(res)) {
                 WriteBooleanRelease(WasRxSet, TRUE);
@@ -1070,7 +1082,7 @@ FuzzSocketRxTxSetup(
         if (RandUlong() % 2) {
             FuzzRingSize(Queue, &ringSize);
             res =
-                XskSetSockopt(
+                Queue->xdpApi->XskSetSockopt(
                     Sock, XSK_SOCKOPT_TX_RING_SIZE, &ringSize, sizeof(ringSize));
             if (SUCCEEDED(res)) {
                 WriteBooleanRelease(WasTxSet, TRUE);
@@ -1081,14 +1093,14 @@ FuzzSocketRxTxSetup(
     if (RandUlong() % 2) {
         FuzzRingSize(Queue, &ringSize);
         res =
-            XskSetSockopt(
+            Queue->xdpApi->XskSetSockopt(
                 Sock, XSK_SOCKOPT_RX_FILL_RING_SIZE, &ringSize, sizeof(ringSize));
     }
 
     if (RandUlong() % 2) {
         FuzzRingSize(Queue, &ringSize);
         res =
-            XskSetSockopt(
+            Queue->xdpApi->XskSetSockopt(
                 Sock, XSK_SOCKOPT_TX_COMPLETION_RING_SIZE, &ringSize, sizeof(ringSize));
     }
 }
@@ -1113,13 +1125,13 @@ FuzzSocketMisc(
     if (RandUlong() % 2) {
         XSK_RING_INFO_SET ringInfo;
         optSize = sizeof(ringInfo);
-        XskGetSockopt(Sock, XSK_SOCKOPT_RING_INFO, &ringInfo, &optSize);
+        Queue->xdpApi->XskGetSockopt(Sock, XSK_SOCKOPT_RING_INFO, &ringInfo, &optSize);
     }
 
     if (RandUlong() % 2) {
         XSK_STATISTICS stats;
         optSize = sizeof(stats);
-        XskGetSockopt(Sock, XSK_SOCKOPT_STATISTICS, &stats, &optSize);
+        Queue->xdpApi->XskGetSockopt(Sock, XSK_SOCKOPT_STATISTICS, &stats, &optSize);
     }
 
     if (RandUlong() % 2) {
@@ -1129,7 +1141,7 @@ FuzzSocketMisc(
             XDP_HOOK_INSPECT,
         };
         FuzzHookId(&hookId);
-        XskSetSockopt(Sock, XSK_SOCKOPT_RX_HOOK_ID, &hookId, sizeof(hookId));
+        Queue->xdpApi->XskSetSockopt(Sock, XSK_SOCKOPT_RX_HOOK_ID, &hookId, sizeof(hookId));
     }
 
     if (RandUlong() % 2) {
@@ -1139,7 +1151,7 @@ FuzzSocketMisc(
             XDP_HOOK_INJECT,
         };
         FuzzHookId(&hookId);
-        XskSetSockopt(Sock, XSK_SOCKOPT_TX_HOOK_ID, &hookId, sizeof(hookId));
+        Queue->xdpApi->XskSetSockopt(Sock, XSK_SOCKOPT_TX_HOOK_ID, &hookId, sizeof(hookId));
     }
 
     if (RandUlong() % 2) {
@@ -1165,9 +1177,9 @@ FuzzSocketMisc(
         }
 
         if (RandUlong() % 2) {
-            XskNotifySocket(Sock, notifyFlags, timeoutMs, &notifyResult);
+            Queue->xdpApi->XskNotifySocket(Sock, notifyFlags, timeoutMs, &notifyResult);
         } else {
-            XskNotifyAsync(Sock, notifyFlags, &overlapped);
+            Queue->xdpApi->XskNotifyAsync(Sock, notifyFlags, &overlapped);
         }
     }
 
@@ -1196,7 +1208,7 @@ FuzzSocketMisc(
         }
 
         #pragma prefast(suppress:6387) // Intentionally passing NULL parameter.
-        XskGetSockopt(Sock, option, procNumParam, &optSize);
+        Queue->xdpApi->XskGetSockopt(Sock, option, procNumParam, &optSize);
     }
 
     if (!cleanDatapath && !(RandUlong() % 3)) {
@@ -1244,7 +1256,7 @@ FuzzSocketBind(
             bindFlags |= 0x1 << (RandUlong() % 32);
         }
 
-        res = XskBind(Sock, ifindex, Queue->queueId, bindFlags);
+        res = Queue->xdpApi->XskBind(Sock, ifindex, Queue->queueId, bindFlags);
         if (SUCCEEDED(res)) {
             WriteBooleanRelease(WasSockBound, TRUE);
         }
@@ -1253,6 +1265,7 @@ FuzzSocketBind(
 
 VOID
 FuzzSocketActivate(
+    _In_ QUEUE_CONTEXT *Queue,
     _In_ HANDLE Sock,
     _Inout_ BOOLEAN *WasSockActivated
     )
@@ -1265,7 +1278,7 @@ FuzzSocketActivate(
             activateFlags = RandUlong() & RandUlong();
         }
 
-        res = XskActivate(Sock, activateFlags);
+        res = Queue->xdpApi->XskActivate(Sock, activateFlags);
         if (SUCCEEDED(res)) {
             WriteBooleanRelease(WasSockActivated, TRUE);
         }
@@ -1304,7 +1317,9 @@ InitializeDatapath(
     Datapath->flags.wait = FALSE;
     Datapath->txiosize = queue->umemReg.chunkSize - queue->umemReg.headroom;
 
-    res = XskGetSockopt(Datapath->sock, XSK_SOCKOPT_RING_INFO, &ringInfo, &ringInfoSize);
+    res =
+        queue->xdpApi->XskGetSockopt(
+            Datapath->sock, XSK_SOCKOPT_RING_INFO, &ringInfo, &ringInfoSize);
     if (FAILED(res)) {
         goto Exit;
     }
@@ -1390,7 +1405,8 @@ NotifyDriver(
     }
 
     if (DirectionFlags != 0) {
-        XskNotifySocket(Datapath->sock, DirectionFlags, WAIT_DRIVER_TIMEOUT_MS, &notifyResult);
+        Datapath->shared->queue->xdpApi->XskNotifySocket(
+            Datapath->sock, DirectionFlags, WAIT_DRIVER_TIMEOUT_MS, &notifyResult);
     }
 }
 
@@ -1544,7 +1560,9 @@ PrintDatapathStats(
     CHAR txPacketCount[64] = { 0 };
     HRESULT res;
 
-    res = XskGetSockopt(Datapath->sock, XSK_SOCKOPT_STATISTICS, &stats, &optSize);
+    res =
+        Datapath->shared->queue->xdpApi->XskGetSockopt(
+            Datapath->sock, XSK_SOCKOPT_STATISTICS, &stats, &optSize);
     if (FAILED(res)) {
         return;
     }
@@ -1656,9 +1674,10 @@ XskFuzzerWorkerFn(
                 scenarioConfig->sharedUmemSockTx, &scenarioConfig->isSharedUmemSockBound);
         }
 
-        FuzzSocketActivate(queue->sock, &scenarioConfig->isSockActivated);
+        FuzzSocketActivate(queue, queue->sock, &scenarioConfig->isSockActivated);
         if (queue->sharedUmemSock != NULL) {
-            FuzzSocketActivate(queue->sharedUmemSock, &scenarioConfig->isSharedUmemSockActivated);
+            FuzzSocketActivate(
+                queue, queue->sharedUmemSock, &scenarioConfig->isSharedUmemSockActivated);
         }
 
         if (ScenarioConfigComplete(scenarioConfig)) {


### PR DESCRIPTION
Consume the new `XDP_API_TABLE` throughout the XDP project and remove support for load-time linkage of XDP routines.

Partially implements #52 