### PR TITLE
Fix use-after-free bugcheck in offload creation path

### DIFF
--- a/published/private/xdpif.h
+++ b/published/private/xdpif.h
@@ -74,6 +74,16 @@ XDP_REMOVE_INTERFACE_COMPLETE(
     _In_ VOID *InterfaceContext
     );
 
+
+//
+// Completes an XDP interface set deletion.
+//
+typedef
+VOID
+XDP_DELETE_INTERFACE_SET_COMPLETE(
+    _In_ VOID *InterfaceContext
+    );
+
 //
 // Offload configuration.
 //
@@ -304,6 +314,7 @@ XdpIfCreateInterfaceSet(
     _In_ NET_IFINDEX IfIndex,
     _In_ CONST XDP_OFFLOAD_DISPATCH *OffloadDispatch,
     _In_ VOID *InterfaceSetContext,
+    _In_ XDP_DELETE_INTERFACE_SET_COMPLETE *DeleteInterfaceSetComplete,
     _Out_ XDPIF_INTERFACE_SET_HANDLE *InterfaceSetHandle
     );
 


### PR DESCRIPTION
Fix the only known bugcheck in XDP, which can be hit when an interface file object is being created while the underlying LWF interface is being removed. There is currently no protection of the interface underlying an XDP_INTERFACE_SET, so add that protection, which ensures LWF interfaces remain valid until all interface file objects are closed.

This reference protection is implicitly part of the current offload design; its implementation was simply missed. Other design options are possible, which may ease the implementation of interface offload providers and allow them to unload while file objects linger, but for now, just make the point fix within the existing design.

Resolves issue #97.