### PR TITLE
Return DEVICE_NOT_READY instead of DELETE_PENDING when NDIS is paused

### DIFF
--- a/test/functional/lwf/sys/tx.c
+++ b/test/functional/lwf/sys/tx.c
@@ -161,7 +161,7 @@ TxIrpFlush(
 
     if (!ExAcquireRundownProtectionEx(&Filter->NblRundown, (UINT32)Nbls.NblCount)) {
         TxCleanupNblChain(NdisGetNblChainFromNblCountedQueue(&Nbls));
-        Status = STATUS_DELETE_PENDING;
+        Status = STATUS_DEVICE_NOT_READY;
         goto Exit;
     }
 

--- a/test/functional/mp/sys/generic/rx.c
+++ b/test/functional/mp/sys/generic/rx.c
@@ -193,7 +193,7 @@ GenericIrpRxFlush(
 
     if (!ExAcquireRundownProtectionEx(&Adapter->Generic->NblRundown, (UINT32)Nbls.NblCount)) {
         GenericRxCleanupNblChain(NdisGetNblChainFromNblCountedQueue(&Nbls));
-        Status = STATUS_DELETE_PENDING;
+        Status = STATUS_DEVICE_NOT_READY;
         goto Exit;
     }
 


### PR DESCRIPTION
STATUS_DEVICE_NOT_READY is both more accurate and results in a more intuitive Win32 error (ERROR_NOT_READY) when the functional test miniport/lwf datapath is paused. The existing error leads to ERROR_ACCESS_DENIED which is not very helpful.