### PR TITLE
Mitigate NDIS bugcheck when RSS is set by a LWF before TCPIP

### DIFF
--- a/src/xdplwf/offload.c
+++ b/src/xdplwf/offload.c
@@ -738,6 +738,20 @@ XdpLwfOffloadRssSet(
     }
 
     //
+    // There is an NDIS bug where LWFs setting the RSS configuration can cause
+    // a bugcheck if no upper level has previously set the RSS configuration.
+    // To avoid this scenario, prevent setting RSS configuration until the
+    // upper layer has set the configuration.
+    //
+    if (Filter->Offload.UpperEdge.Rss == NULL) {
+        TraceError(
+            TRACE_LWF,
+            "OffloadContext=%p RSS cannot be set without upper layer being set", OffloadContext);
+        Status = STATUS_DEVICE_NOT_READY;
+        goto Exit;
+    }
+
+    //
     // Ensure compatibility with existing settings. Currently, only allow
     // overwrite of a configuration plumbed by the same offload context.
     //

--- a/src/xdplwf/offload.c
+++ b/src/xdplwf/offload.c
@@ -896,7 +896,9 @@ XdpLwfOffloadRssSet(
     //
     // Inherit unspecified parameters from the current RSS settings.
     //
-    InheritXdpRssParams(&RssSetting->Params, &CurrentRssSetting->Params);
+    InheritXdpRssParams(
+        &RssSetting->Params,
+        (CurrentRssSetting != NULL) ? &CurrentRssSetting->Params : NULL);
 
     //
     // Form and issue the OID.


### PR DESCRIPTION
If an LWF injects an OID_GEN_RECEIVE_SCALE_PARAMETERS before any protocol (i.e. open) submits the same OID, then NDIS bugchecks while attempting to cache the RSS parameters on the miniport in a lazily-allocated cache buffer. The cache buffer is allocated by an NDIS routine that isn't called for LWFs.

Prevent this from happening by rejecting XDP set RSS requests until the protocol (e.g. TCPIP) has sent down an RSS OID.