### PR TITLE
Maintain a pool of RX->TX NBLs instead of using NDIS

### DIFF
--- a/src/xdplwf/generic.c
+++ b/src/xdplwf/generic.c
@@ -177,6 +177,8 @@ XdpGenericRegistryUpdate(
     } else {
         XdpGenericUpdateDelayDetachTimeout(DELAY_DETACH_DEFAULT_TIMEOUT_SEC);
     }
+
+    XdpGenericReceiveRegistryUpdate();
 }
 
 VOID

--- a/src/xdplwf/recv.c
+++ b/src/xdplwf/recv.c
@@ -503,6 +503,7 @@ XdpGenericRxFreeNblCloneCache(
         Nbl->FirstNetBuffer->CurrentMdl = NULL;
         Nbl->FirstNetBuffer->DataLength = 0;
         Nbl->FirstNetBuffer->DataOffset = 0;
+        Nbl->FirstNetBuffer->CurrentMdlOffset = 0;
 
         NdisFreeNetBufferList(Nbl);
     }

--- a/src/xdplwf/recv.h
+++ b/src/xdplwf/recv.h
@@ -16,6 +16,10 @@ typedef struct _XDP_LWF_GENERIC_RX_QUEUE {
     XDP_EXTENSION FragmentExtension;
     XDP_EXTENSION FrameInterfaceContextExtension;
     NDIS_HANDLE TxCloneNblPool;
+    UINT32 TxCloneCacheLimit;
+    UINT32 TxCloneCacheCount;
+    SLIST_HEADER TxCloneNblSList;
+    NET_BUFFER_LIST *TxCloneNblList;
     EX_RUNDOWN_REF NblRundown;
 
     //
@@ -120,4 +124,9 @@ VOID
 XdpGenericRxRestart(
     _In_ XDP_LWF_GENERIC *Generic,
     _In_ UINT32 NewMtu
+    );
+
+VOID
+XdpGenericReceiveRegistryUpdate(
+    VOID
     );


### PR DESCRIPTION
The NDIS routines that allocate and free NBLs are not very efficient for our use case: most importantly they do not support batching, and they are also just complex.

Instead, use a per-RX-queue list (which can pop a single NBL without any synchronization) and a per-RX-queue s-list (which can push/pop a batch of NBLs in a single interlocked operation) to minimize forwarding overhead.

Increases XDPMP throughput to 350Gbps from 230Gbps on a 4-CPU test machine with 1514-byte frames.