### PR TITLE
Simplify/refactor the current program model

### DIFF
--- a/published/external/xdpapi.h
+++ b/published/external/xdpapi.h
@@ -37,12 +37,6 @@ extern "C" {
 //
 #define XDP_CREATE_PROGRAM_FLAG_NATIVE  0x2
 
-//
-// Allow sharing the XDP queue with other XDP programs. All programs on the
-// interface must use this flag for sharing to be enabled.
-//
-#define XDP_CREATE_PROGRAM_FLAG_SHARE   0x4
-
 typedef
 HRESULT
 XDP_CREATE_PROGRAM_FN(

--- a/published/external/xdpapi.h
+++ b/published/external/xdpapi.h
@@ -267,7 +267,7 @@ typedef struct _XDP_API_TABLE XDP_API_TABLE;
 // The only API version currently supported. Any change to the API is considered
 // a breaking change and support for previous versions will be removed.
 //
-#define XDP_VERSION_PRERELEASE 100002
+#define XDP_VERSION_PRERELEASE 100003
 
 //
 // Opens the API and returns an API function table with the rest of the API's

--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -1880,6 +1880,16 @@ XdpProgramAttach(
         goto Exit;
     }
 
+    //
+    // Register for interface/queue removal notifications.
+    //
+    XdpRxQueueRegisterNotifications(
+        ProgramBinding->RxQueue, &ProgramBinding->RxQueueNotificationEntry, XdpProgramRxQueueNotify);
+
+    ASSERT(
+        !IsListEmpty(&ProgramBinding->RxQueueNotificationEntry.Link) &&
+        !IsListEmpty(&ProgramBinding->RxQueueEntry));
+
     Status =
         XdpRxQueueSetProgram(
             ProgramBinding->RxQueue, CompiledProgram, XdpProgramValidateIfQueue,
@@ -1892,12 +1902,6 @@ XdpProgramAttach(
         TRACE_CORE, "Attached program RxQueue=%p ProgramObject=%p",
         ProgramBinding->RxQueue, ProgramObject);
     XdpProgramTraceObject(ProgramObject);
-
-    //
-    // Register for interface/queue removal notifications.
-    //
-    XdpRxQueueRegisterNotifications(
-        ProgramBinding->RxQueue, &ProgramBinding->RxQueueNotificationEntry, XdpProgramRxQueueNotify);
 
 Exit:
 

--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -1945,6 +1945,7 @@ XdpProgramAttach(
             ProgramBinding->RxQueue, CompiledProgram, XdpProgramValidateIfQueue,
             ProgramObject);
     if (!NT_SUCCESS(Status)) {
+        ExFreePoolWithTag(CompiledProgram, XDP_POOLTAG_PROGRAM);
         goto Exit;
     }
 
@@ -1963,9 +1964,6 @@ XdpProgramAttach(
 Exit:
 
     if (!NT_SUCCESS(Status)) {
-        if (CompiledProgram) {
-            ExFreePoolWithTag(CompiledProgram, XDP_POOLTAG_PROGRAM);
-        }
         XdpProgramDelete(ProgramObject);
     }
 

--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -1401,13 +1401,15 @@ XdpProgramDetachRxQueue(
 
     ASSERT(RxQueue != NULL);
 
-    if (IsListEmpty(&ProgramBinding->RxQueueEntry)) {
+    if (!IsListEmpty(&ProgramBinding->RxQueueEntry)) {
         //
         // Remove the binding from the RX queue and recompile bound program.
         //
         RemoveEntryList(&ProgramBinding->RxQueueEntry);
-        XdpProgramCompileNewProgram(RxQueue, &CompiledProgram);
+        InitializeListHead(&ProgramBinding->RxQueueEntry);
 
+        XdpProgramCompileNewProgram(RxQueue, &CompiledProgram);
+        
         XdpRxQueueDeregisterNotifications(RxQueue, &ProgramBinding->RxQueueNotificationEntry);
         XdpRxQueueSetProgram(RxQueue, CompiledProgram, NULL, NULL);
     }
@@ -1874,6 +1876,7 @@ XdpProgramAttach(
     Status = XdpProgramCompileNewProgram(ProgramBinding->RxQueue, &CompiledProgram);
     if (!NT_SUCCESS(Status)) {
         RemoveEntryList(&ProgramBinding->RxQueueEntry);
+        InitializeListHead(&ProgramBinding->RxQueueEntry);
         goto Exit;
     }
 

--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -1950,8 +1950,7 @@ XdpIrpCreateProgram(
     XDP_PROGRAM_OBJECT *ProgramObject = NULL;
     NTSTATUS Status;
     CONST UINT32 ValidFlags =
-        XDP_CREATE_PROGRAM_FLAG_GENERIC | XDP_CREATE_PROGRAM_FLAG_NATIVE |
-        XDP_CREATE_PROGRAM_FLAG_SHARE;
+        XDP_CREATE_PROGRAM_FLAG_GENERIC | XDP_CREATE_PROGRAM_FLAG_NATIVE;
 
     if (Disposition != FILE_CREATE || InputBufferLength < sizeof(*Params)) {
         Status = STATUS_INVALID_PARAMETER;

--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -1403,7 +1403,7 @@ XdpProgramDetachRxQueue(
 
     if (!IsListEmpty(&ProgramBinding->RxQueueEntry)) {
         //
-        // Remove the binding from the RX queue and recompile bound program.
+        // Remove the binding from the RX queue and recompile bound programs.
         //
         RemoveEntryList(&ProgramBinding->RxQueueEntry);
         InitializeListHead(&ProgramBinding->RxQueueEntry);

--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -1340,7 +1340,11 @@ XdpProgramUpdateCompiledProgram(
         Entry = Entry->Flink;
     }
 
-    ASSERT(Program->RuleCount > RuleIndex);
+    //
+    // If the program compiled for this newly added binding failed to be added
+    // to the RX queue, we will end up having Program->RuleCount == RuleIndex.
+    //
+    ASSERT(Program->RuleCount >= RuleIndex);
     Program->RuleCount = RuleIndex;
     TraceExitSuccess(TRACE_CORE);
 }

--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -1109,22 +1109,20 @@ XdpProgramGetXskBypassTarget(
 //
 // Control path routines.
 //
+typedef struct _XDP_PROGRAM_OBJECT XDP_PROGRAM_OBJECT;
+
+typedef struct _XDP_PROGRAM_BINDING {
+    XDP_RX_QUEUE *RxQueue;
+    LIST_ENTRY RxQueueEntry;
+    XDP_RX_QUEUE_NOTIFICATION_ENTRY RxQueueNotificationEntry;
+    XDP_PROGRAM_OBJECT *OwningProject;
+} XDP_PROGRAM_BINDING;
 
 typedef struct _XDP_PROGRAM_OBJECT {
     XDP_FILE_OBJECT_HEADER Header;
     XDP_BINDING_HANDLE IfHandle;
-    XDP_RX_QUEUE *RxQueue;
-    XDP_RX_QUEUE_NOTIFICATION_ENTRY RxQueueNotificationEntry;
-    LIST_ENTRY SharingLink;
+    XDP_PROGRAM_BINDING *Binding;
     ULONG_PTR CreatedByPid;
-
-    union {
-        struct {
-            UINT32 SharingEnabled : 1;
-            UINT32 IsMetaProgram : 1;
-        };
-        UINT32 Value;
-    } Flags;
 
     XDP_PROGRAM Program;
 } XDP_PROGRAM_OBJECT;
@@ -1151,8 +1149,8 @@ XdpProgramTraceObject(
     )
 {
     TraceInfo(
-        TRACE_CORE, "Program=%p CreatedByPid=%Iu Flags=0x%x",
-        ProgramObject, ProgramObject->CreatedByPid, ProgramObject->Flags.Value);
+        TRACE_CORE, "Program=%p CreatedByPid=%Iu",
+        ProgramObject, ProgramObject->CreatedByPid);
 
     for (UINT32 i = 0; i < ProgramObject->Program.RuleCount; i++) {
         CONST XDP_RULE *Rule = &ProgramObject->Program.Rules[i];
@@ -1316,42 +1314,77 @@ XdpProgramTraceObject(
 
 static
 _IRQL_requires_max_(DISPATCH_LEVEL)
-VOID
-XdpProgramPopulateMetaProgram(
-    _Inout_ XDP_PROGRAM_OBJECT *MetaProgramObject
+NTSTATUS
+XdpProgramCompileNewProgram(
+    _In_ XDP_RX_QUEUE *RxQueue,
+    _Out_ XDP_PROGRAM **Program
     )
 {
-    XDP_PROGRAM *MetaProgram = &MetaProgramObject->Program;
-    LIST_ENTRY *Entry = &MetaProgramObject->SharingLink;
+    NTSTATUS Status;
+    LIST_ENTRY *BindingListHead = XdpRxQueueGetProgramBindingList(RxQueue);
+    LIST_ENTRY *Entry = BindingListHead->Flink;
+    UINT32 RuleCount = 0;
+    XDP_PROGRAM *NewProgram;
+    SIZE_T AllocationSize;
 
-    TraceEnter(TRACE_CORE, "MetaProgram=%p", MetaProgramObject);
+    TraceEnter(TRACE_CORE, "Compiling new program on RxQueue=%p", RxQueue);
 
-    //
-    // Traverse the shared programs and concatenate their rulesets into the
-    // shared metaprogram. Note that we may be reusing a previously-populated
-    // metaprogram if a shared program is being detached.
-    //
-    MetaProgram->RuleCount = 0;
-
-    while ((Entry = Entry->Flink) != &MetaProgramObject->SharingLink) {
-        CONST XDP_PROGRAM_OBJECT *SharedProgramObject =
-            CONTAINING_RECORD(Entry, XDP_PROGRAM_OBJECT, SharingLink);
-        CONST XDP_PROGRAM *SharedProgram = &SharedProgramObject->Program;
-
-        for (UINT32 i = 0; i < SharedProgram->RuleCount; i++) {
-            MetaProgram->Rules[MetaProgram->RuleCount++] = SharedProgram->Rules[i];
+    while (Entry != BindingListHead) {
+        XDP_PROGRAM_BINDING* ProgramBinding = CONTAINING_RECORD(Entry, XDP_PROGRAM_BINDING, RxQueueEntry);
+        Status =
+            RtlUInt32Add(
+                RuleCount, ProgramBinding->OwningProject->Program.RuleCount, &RuleCount);
+        if (!NT_SUCCESS(Status)) {
+            goto Exit;
         }
-
-        ASSERT(MetaProgram->RuleCount != 0);
-        ASSERT(SharedProgramObject->Flags.SharingEnabled);
-
-        TraceInfo(
-            TRACE_CORE, "Merged SharedProgram=%p into MetaProgram=%p",
-            SharedProgramObject, MetaProgramObject);
-        XdpProgramTraceObject(SharedProgramObject);
+        Entry = Entry->Flink;
     }
 
+    if (RuleCount == 0) {
+        //
+        // No program bindings on the RX queue.
+        //
+        *Program = NULL;
+        Status = STATUS_SUCCESS;
+        goto Exit;
+    }
+
+    Status = RtlSizeTMult(sizeof(XDP_RULE), RuleCount, &AllocationSize);
+    if (!NT_SUCCESS(Status)) {
+        goto Exit;
+    }
+
+    Status = RtlSizeTAdd(sizeof(*NewProgram), AllocationSize, &AllocationSize);
+    if (!NT_SUCCESS(Status)) {
+        goto Exit;
+    }
+
+    NewProgram = ExAllocatePoolZero(NonPagedPoolNx, AllocationSize, XDP_POOLTAG_PROGRAM);
+    if (NewProgram == NULL) {
+        Status = STATUS_NO_MEMORY;
+        goto Exit;
+    }
+
+    Entry = BindingListHead->Flink;
+    while (Entry != BindingListHead) {
+        XDP_PROGRAM_BINDING* ProgramBinding =
+            CONTAINING_RECORD(Entry, XDP_PROGRAM_BINDING, RxQueueEntry);
+        CONST XDP_PROGRAM_OBJECT *BoundProgramObject = ProgramBinding->OwningProject;
+
+        for (UINT32 i = 0; i < BoundProgramObject->Program.RuleCount; i++) {
+            NewProgram->Rules[NewProgram->RuleCount++] = BoundProgramObject->Program.Rules[i];
+        }
+
+        Entry = Entry->Flink;
+    }
+
+    ASSERT(NewProgram->RuleCount == RuleCount);
+
+    *Program = NewProgram;
+
+Exit:
     TraceExitSuccess(TRACE_CORE);
+    return Status;
 }
 
 static
@@ -1360,51 +1393,28 @@ XdpProgramDetachRxQueue(
     _In_ XDP_PROGRAM_OBJECT *ProgramObject
     )
 {
-    XDP_RX_QUEUE *RxQueue = ProgramObject->RxQueue;
+    XDP_PROGRAM_BINDING *ProgramBinding = ProgramObject->Binding;
+    XDP_RX_QUEUE *RxQueue = ProgramBinding->RxQueue;
+    XDP_PROGRAM *CompiledProgram = NULL;
 
-    TraceEnter(TRACE_CORE, "Program=%p", ProgramObject);
+    TraceEnter(TRACE_CORE, "Detach ProgramObject=%p from RxQueue", ProgramObject);
 
     ASSERT(RxQueue != NULL);
-    ASSERT(!ProgramObject->Flags.IsMetaProgram);
 
-    if (XdpRxQueueGetProgram(RxQueue) == &ProgramObject->Program) {
-        ASSERT(!ProgramObject->Flags.SharingEnabled);
-        XdpRxQueueDeregisterNotifications(RxQueue, &ProgramObject->RxQueueNotificationEntry);
-        XdpRxQueueSetProgram(RxQueue, NULL, NULL, NULL);
-    } else if (ProgramObject->Flags.SharingEnabled && !IsListEmpty(&ProgramObject->SharingLink)) {
-        XDP_PROGRAM *MetaProgram = XdpRxQueueGetProgram(RxQueue);
-        XDP_PROGRAM_OBJECT *MetaProgramObject =
-            CONTAINING_RECORD(MetaProgram, XDP_PROGRAM_OBJECT, Program);
-
+    if (IsListEmpty(&ProgramBinding->RxQueueEntry)) {
         //
-        // This program isn't directly attached to the RX queue, but a meta
-        // program is. Remove this program from the metaprogram, and either
-        // update the program ruleset (in-place) or remove the meta-program if
-        // this was the final shared program.
+        // Remove the binding from the RX queue and recompile bound program.
         //
-        ASSERT(MetaProgram != NULL);
-        ASSERT(MetaProgramObject->Flags.IsMetaProgram);
+        RemoveEntryList(&ProgramBinding->RxQueueEntry);
+        XdpProgramCompileNewProgram(RxQueue, &CompiledProgram);
 
-        XdpRxQueueDeregisterNotifications(RxQueue, &ProgramObject->RxQueueNotificationEntry);
-        RemoveEntryList(&ProgramObject->SharingLink);
-        InitializeListHead(&ProgramObject->SharingLink);
-
-        if (IsListEmpty(&MetaProgramObject->SharingLink)) {
-            XdpRxQueueSetProgram(RxQueue, NULL, NULL, NULL);
-            ExFreePoolWithTag(MetaProgramObject, XDP_POOLTAG_PROGRAM);
-            TraceInfo(
-                TRACE_CORE, "Detached metaprogram RxQueue=%p Program=%p",
-                RxQueue, MetaProgramObject);
-        } else {
-            XdpRxQueueSync(RxQueue, XdpProgramPopulateMetaProgram, MetaProgramObject);
-            TraceInfo(
-                TRACE_CORE, "Updated metaprogram RxQueue=%p Program=%p",
-                RxQueue, MetaProgramObject);
-        }
+        XdpRxQueueDeregisterNotifications(RxQueue, &ProgramBinding->RxQueueNotificationEntry);
+        XdpRxQueueSetProgram(RxQueue, CompiledProgram, NULL, NULL);
     }
 
     TraceExitSuccess(TRACE_CORE);
 }
+
 static
 VOID
 XdpProgramReleasePortSet(
@@ -1476,17 +1486,16 @@ XdpProgramDelete(
     _In_ XDP_PROGRAM_OBJECT *ProgramObject
     )
 {
-    TraceEnter(TRACE_CORE, "Program=%p", ProgramObject);
-
-    ASSERT(!ProgramObject->Flags.IsMetaProgram);
+    XDP_PROGRAM_BINDING *ProgramBinding = ProgramObject->Binding;
+    TraceEnter(TRACE_CORE, "ProgramObject=%p", ProgramObject);
 
     //
     // Detach the XDP program from the RX queue.
     //
-    if (ProgramObject->RxQueue != NULL) {
+    if (ProgramBinding->RxQueue != NULL) {
         XdpProgramDetachRxQueue(ProgramObject);
-        XdpRxQueueDereference(ProgramObject->RxQueue);
-        ProgramObject->RxQueue = NULL;
+        XdpRxQueueDereference(ProgramBinding->RxQueue);
+        ProgramBinding->RxQueue = NULL;
     }
 
     //
@@ -1523,7 +1532,8 @@ XdpProgramDelete(
         }
     }
 
-    TraceVerbose(TRACE_CORE, "Deleted Program=%p", ProgramObject);
+    TraceVerbose(TRACE_CORE, "Deleted ProgramObject=%p", ProgramObject);
+    ExFreePoolWithTag(ProgramBinding, XDP_POOLTAG_PROGRAM);
     ExFreePoolWithTag(ProgramObject, XDP_POOLTAG_PROGRAM);
     TraceExitSuccess(TRACE_CORE);
 }
@@ -1535,13 +1545,13 @@ XdpProgramRxQueueNotify(
     XDP_RX_QUEUE_NOTIFICATION_TYPE NotificationType
     )
 {
-    XDP_PROGRAM_OBJECT *ProgramObject =
-        CONTAINING_RECORD(NotificationEntry, XDP_PROGRAM_OBJECT, RxQueueNotificationEntry);
+    XDP_PROGRAM_BINDING *ProgramBinding =
+        CONTAINING_RECORD(NotificationEntry, XDP_PROGRAM_BINDING, RxQueueNotificationEntry);
 
     switch (NotificationType) {
 
     case XDP_RX_QUEUE_NOTIFICATION_DELETE:
-        XdpProgramDetachRxQueue(ProgramObject);
+        XdpProgramDetachRxQueue(ProgramBinding->OwningProject);
         break;
 
     }
@@ -1553,10 +1563,7 @@ XdpProgramCanXskBypass(
     _In_ XDP_PROGRAM *Program
     )
 {
-    XDP_PROGRAM_OBJECT *ProgramObject = CONTAINING_RECORD(Program, XDP_PROGRAM_OBJECT, Program);
-
     return
-        ProgramObject->Flags.SharingEnabled == FALSE &&
         Program->RuleCount == 1 &&
         Program->Rules[0].Match == XDP_MATCH_ALL &&
         Program->Rules[0].Action == XDP_PROGRAM_ACTION_REDIRECT &&
@@ -1591,7 +1598,6 @@ XdpProgramAllocate(
     }
 
     ProgramObject->CreatedByPid = (ULONG_PTR)PsGetCurrentProcessId();
-    InitializeListHead(&ProgramObject->SharingLink);
 
 Exit:
 
@@ -1782,6 +1788,32 @@ Exit:
 }
 
 static
+NTSTATUS
+XdpProgramBindingAllocate(
+    _Out_ XDP_PROGRAM_BINDING **NewProgramBinding,
+    _In_ XDP_PROGRAM_OBJECT *ProgramObject
+    )
+{
+    XDP_PROGRAM_BINDING *ProgramBinding = NULL;
+    NTSTATUS Status;
+
+    ProgramBinding = ExAllocatePoolZero(NonPagedPoolNx, sizeof(*ProgramBinding), XDP_POOLTAG_PROGRAM);
+    if (ProgramBinding == NULL) {
+        Status = STATUS_NO_MEMORY;
+        goto Exit;
+    }
+
+    InitializeListHead(&ProgramBinding->RxQueueEntry);
+    ProgramBinding->OwningProject = ProgramObject;
+    ProgramObject->Binding = ProgramBinding;
+    Status = STATUS_SUCCESS;
+
+Exit:
+    *NewProgramBinding = ProgramBinding;
+    return Status;
+}
+
+static
 VOID
 XdpProgramAttach(
     _In_ XDP_BINDING_WORKITEM *WorkItem
@@ -1790,8 +1822,8 @@ XdpProgramAttach(
     XDP_PROGRAM_WORKITEM *Item = (XDP_PROGRAM_WORKITEM *)WorkItem;
     XDP_PROGRAM_OBJECT *ProgramObject = Item->ProgramObject;
     XDP_PROGRAM *Program = &ProgramObject->Program;
-    XDP_PROGRAM *ExistingProgram;
-    XDP_PROGRAM_OBJECT *ExistingProgramObject = NULL;
+    XDP_PROGRAM_BINDING* ProgramBinding = NULL;
+    XDP_PROGRAM *CompiledProgram = NULL;
     NTSTATUS Status;
 
     TraceEnter(TRACE_CORE, "Program=%p", ProgramObject);
@@ -1804,16 +1836,18 @@ XdpProgramAttach(
         goto Exit;
     }
 
-    Status =
-        XdpRxQueueFindOrCreate(
-            Item->Bind.BindingHandle, &Item->HookId, Item->QueueId, &ProgramObject->RxQueue);
+    Status = XdpProgramBindingAllocate(&ProgramBinding, ProgramObject);
     if (!NT_SUCCESS(Status)) {
         goto Exit;
     }
 
-    //
-    // Perform further rule validation that requires the interface work queue.
-    //
+    Status =
+        XdpRxQueueFindOrCreate(
+            Item->Bind.BindingHandle, &Item->HookId, Item->QueueId, &ProgramBinding->RxQueue);
+    if (!NT_SUCCESS(Status)) {
+        goto Exit;
+    }
+
     for (ULONG Index = 0; Index < Program->RuleCount; Index++) {
         XDP_RULE *Rule = &Program->Rules[Index];
 
@@ -1822,7 +1856,7 @@ XdpProgramAttach(
             switch (Rule->Redirect.TargetType) {
 
             case XDP_REDIRECT_TARGET_TYPE_XSK:
-                Status = XskValidateDatapathHandle(Rule->Redirect.Target, ProgramObject->RxQueue);
+                Status = XskValidateDatapathHandle(Rule->Redirect.Target, ProgramBinding->RxQueue);
                 if (!NT_SUCCESS(Status)) {
                     goto Exit;
                 }
@@ -1835,134 +1869,32 @@ XdpProgramAttach(
         }
     }
 
-    //
-    // Query the existing top-level program on the queue, if any.
-    //
-    ExistingProgram = XdpRxQueueGetProgram(ProgramObject->RxQueue);
-    if (ExistingProgram != NULL) {
-        ExistingProgramObject = CONTAINING_RECORD(ExistingProgram, XDP_PROGRAM_OBJECT, Program);
+    InsertTailList(
+        XdpRxQueueGetProgramBindingList(ProgramBinding->RxQueue), &ProgramBinding->RxQueueEntry);
+    Status = XdpProgramCompileNewProgram(ProgramBinding->RxQueue, &CompiledProgram);
+    if (!NT_SUCCESS(Status)) {
+        RemoveEntryList(&ProgramBinding->RxQueueEntry);
+        goto Exit;
     }
 
-    if (ProgramObject->Flags.SharingEnabled) {
-        UINT32 MetaRuleCount = Program->RuleCount;
-        XDP_PROGRAM_OBJECT *NewMetaProgramObject = NULL;
-
-        if (ExistingProgramObject != NULL && !ExistingProgramObject->Flags.SharingEnabled) {
-            Status = STATUS_SHARING_VIOLATION;
-            goto Exit;
-        }
-
-        //
-        // Calculate the new total rule count and allocate a new metaprogram.
-        //
-        if (ExistingProgram != NULL) {
-            Status = RtlUInt32Add(MetaRuleCount, ExistingProgram->RuleCount, &MetaRuleCount);
-            if (!NT_SUCCESS(Status)) {
-                goto Exit;
-            }
-        }
-
-        Status = XdpProgramAllocate(MetaRuleCount, &NewMetaProgramObject);
-        if (!NT_SUCCESS(Status)) {
-            goto Exit;
-        }
-
-        NewMetaProgramObject->Flags.SharingEnabled = TRUE;
-        NewMetaProgramObject->Flags.IsMetaProgram = TRUE;
-
-        //
-        // Migrate the list of shared programs from the old metaprogram (if
-        // present) onto the new metaprogram and add our new program to the
-        // list.
-        //
-        if (ExistingProgramObject != NULL) {
-            ASSERT(ExistingProgramObject->Flags.IsMetaProgram);
-            ASSERT(IsListEmpty(&NewMetaProgramObject->SharingLink));
-            ASSERT(!IsListEmpty(&ExistingProgramObject->SharingLink));
-            AppendTailList(&NewMetaProgramObject->SharingLink, &ExistingProgramObject->SharingLink);
-            RemoveEntryList(&ExistingProgramObject->SharingLink);
-            InitializeListHead(&ExistingProgramObject->SharingLink);
-        }
-
-        ASSERT(IsListEmpty(&ProgramObject->SharingLink));
-        InsertTailList(&NewMetaProgramObject->SharingLink, &ProgramObject->SharingLink);
-
-        //
-        // Merge all shared programs into the shared metaprogram ruleset.
-        //
-        XdpProgramPopulateMetaProgram(NewMetaProgramObject);
-
-        //
-        // Synchronize with data path and replace old metaprogram with new
-        // metaprogram.
-        //
-        Status =
-            XdpRxQueueSetProgram(
-                ProgramObject->RxQueue, &NewMetaProgramObject->Program, XdpProgramValidateIfQueue,
-                NewMetaProgramObject);
-        if (NT_SUCCESS(Status)) {
-            TraceInfo(
-                TRACE_CORE, "Attached metaprogram RxQueue=%p Program=%p OldProgram=%p",
-                ProgramObject->RxQueue, ProgramObject, ExistingProgramObject);
-            XdpProgramTraceObject(ProgramObject);
-
-            if (ExistingProgramObject != NULL) {
-                ExFreePoolWithTag(ExistingProgramObject, XDP_POOLTAG_PROGRAM);
-                ExistingProgramObject = NULL;
-            }
-        } else {
-            //
-            // Revert changes to the program, revert changes to the current
-            // metaprogram (if it exists), scrap the new metaprogram, and bail.
-            //
-
-            RemoveEntryList(&ProgramObject->SharingLink);
-            InitializeListHead(&ProgramObject->SharingLink);
-
-            if (ExistingProgramObject != NULL) {
-                ASSERT(ExistingProgramObject->Flags.IsMetaProgram);
-                ASSERT(IsListEmpty(&ExistingProgramObject->SharingLink));
-                ASSERT(!IsListEmpty(&NewMetaProgramObject->SharingLink));
-                AppendTailList(
-                    &ExistingProgramObject->SharingLink, &NewMetaProgramObject->SharingLink);
-                RemoveEntryList(&NewMetaProgramObject->SharingLink);
-                InitializeListHead(&NewMetaProgramObject->SharingLink);
-            }
-
-            ASSERT(IsListEmpty(&NewMetaProgramObject->SharingLink));
-            ExFreePoolWithTag(NewMetaProgramObject, XDP_POOLTAG_PROGRAM);
-            goto Exit;
-        }
-    } else {
-        //
-        // The new program has not enabled sharing; directly attach this program
-        // to the queue if it is empty.
-        //
-
-        if (ExistingProgramObject != NULL) {
-            Status = STATUS_DUPLICATE_OBJECTID;
-            goto Exit;
-        }
-
-        Status =
-            XdpRxQueueSetProgram(
-                ProgramObject->RxQueue, Program, XdpProgramValidateIfQueue,
-                ProgramObject);
-        if (!NT_SUCCESS(Status)) {
-            goto Exit;
-        }
+    Status =
+        XdpRxQueueSetProgram(
+            ProgramBinding->RxQueue, CompiledProgram, XdpProgramValidateIfQueue,
+            ProgramObject);
+    if (!NT_SUCCESS(Status)) {
+        goto Exit;
     }
 
     TraceInfo(
-        TRACE_CORE, "Attached program RxQueue=%p Program=%p",
-        ProgramObject->RxQueue, ProgramObject);
+        TRACE_CORE, "Attached program RxQueue=%p ProgramObject=%p",
+        ProgramBinding->RxQueue, ProgramObject);
     XdpProgramTraceObject(ProgramObject);
 
     //
     // Register for interface/queue removal notifications.
     //
     XdpRxQueueRegisterNotifications(
-        ProgramObject->RxQueue, &ProgramObject->RxQueueNotificationEntry, XdpProgramRxQueueNotify);
+        ProgramBinding->RxQueue, &ProgramBinding->RxQueueNotificationEntry, XdpProgramRxQueueNotify);
 
 Exit:
 
@@ -2059,10 +1991,6 @@ RetryBinding:
         XdpCaptureProgram(Params->Rules, Params->RuleCount, Irp->RequestorMode, &ProgramObject);
     if (!NT_SUCCESS(Status)) {
         goto Exit;
-    }
-
-    if (Params->Flags & XDP_CREATE_PROGRAM_FLAG_SHARE) {
-        ProgramObject->Flags.SharingEnabled = TRUE;
     }
 
     KeInitializeEvent(&WorkItem.CompletionEvent, NotificationEvent, FALSE);

--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -1530,7 +1530,7 @@ XdpProgramDelete(
     //
     // Detach the XDP program from the RX queue.
     //
-    if (ProgramBinding->RxQueue != NULL) {
+    if (ProgramBinding != NULL && ProgramBinding->RxQueue != NULL) {
         XdpProgramDetachRxQueue(ProgramObject);
         XdpRxQueueDereference(ProgramBinding->RxQueue);
         ProgramBinding->RxQueue = NULL;
@@ -1571,7 +1571,9 @@ XdpProgramDelete(
     }
 
     TraceVerbose(TRACE_CORE, "Deleted ProgramObject=%p", ProgramObject);
-    ExFreePoolWithTag(ProgramBinding, XDP_POOLTAG_PROGRAM);
+    if (ProgramBinding != NULL) {
+        ExFreePoolWithTag(ProgramBinding, XDP_POOLTAG_PROGRAM);
+    }
     ExFreePoolWithTag(ProgramObject, XDP_POOLTAG_PROGRAM);
     TraceExitSuccess(TRACE_CORE);
 }

--- a/src/xdp/rx.c
+++ b/src/xdp/rx.c
@@ -1128,6 +1128,13 @@ XdpRxQueueSetProgram(
 
 Exit:
 
+    if (!NT_SUCCESS(Status) && Program != NULL) {
+        //
+        // Now that the compiled program won't be used, clean it up.
+        //
+        ExFreePoolWithTag(Program, XDP_POOLTAG_PROGRAM);
+    }
+
     TraceExitStatus(TRACE_CORE);
     return Status;
 }

--- a/src/xdp/rx.c
+++ b/src/xdp/rx.c
@@ -1086,7 +1086,7 @@ XdpRxQueueSetProgram(
         SwapParams.RxQueue = RxQueue;
         SwapParams.NewProgram = Program;
         XdpRxQueueSync(RxQueue, XdpRxQueueSwapProgram, &SwapParams);
-        if (OldCompiledProgram) {
+        if (OldCompiledProgram != NULL) {
             //
             // Free the old compiled program because it's no longer being used.
             //
@@ -1109,7 +1109,10 @@ XdpRxQueueSetProgram(
         // interface.
         //
         XdpRxQueueDetachInterface(RxQueue);
-        RxQueue->Program = NULL;
+        if (RxQueue->Program != NULL) {
+            ExFreePoolWithTag(RxQueue->Program, XDP_POOLTAG_PROGRAM);
+            RxQueue->Program = NULL;
+        }
     }
 
     Status = STATUS_SUCCESS;

--- a/src/xdp/rx.h
+++ b/src/xdp/rx.h
@@ -83,8 +83,8 @@ XdpRxQueueSetProgram(
     _In_opt_ VOID *ValidationContext
     );
 
-XDP_PROGRAM *
-XdpRxQueueGetProgram(
+LIST_ENTRY *
+XdpRxQueueGetProgramBindingList(
     _In_ XDP_RX_QUEUE *RxQueue
     );
 

--- a/src/xdp/rx.h
+++ b/src/xdp/rx.h
@@ -88,6 +88,11 @@ XdpRxQueueGetProgramBindingList(
     _In_ XDP_RX_QUEUE *RxQueue
     );
 
+XDP_PROGRAM *
+XdpRxQueueGetProgram(
+    _In_ XDP_RX_QUEUE *RxQueue
+    );
+
 NDIS_HANDLE
 XdpRxQueueGetInterfacePollHandle(
     _In_ XDP_RX_QUEUE *RxQueue

--- a/src/xdp/xdpp.h
+++ b/src/xdp/xdpp.h
@@ -15,14 +15,16 @@
 // Internal definitions.
 //
 
-#define XDP_POOLTAG_CPU_CONTEXT 'CpdX' // XdpC
-#define XDP_POOLTAG_EXTENSION   'EpdX' // XdpE
-#define XDP_POOLTAG_IF          'IpdX' // XdpI
-#define XDP_POOLTAG_IFSET       'ipdX' // Xdpi
-#define XDP_POOLTAG_INTERFACE   'fIdX' // XdIf
-#define XDP_POOLTAG_MAP         'MpdX' // XdpM
-#define XDP_POOLTAG_NMR         'NpdX' // XdpN
-#define XDP_POOLTAG_PROGRAM     'PpdX' // XdpP
-#define XDP_POOLTAG_RING        'rpdX' // Xdpr
-#define XDP_POOLTAG_RXQUEUE     'RpdX' // XdpR
-#define XDP_POOLTAG_TXQUEUE     'TpdX' // XdpT
+#define XDP_POOLTAG_CPU_CONTEXT         'CpdX' // XdpC
+#define XDP_POOLTAG_EXTENSION           'EpdX' // XdpE
+#define XDP_POOLTAG_IF                  'IpdX' // XdpI
+#define XDP_POOLTAG_IFSET               'ipdX' // Xdpi
+#define XDP_POOLTAG_INTERFACE           'fIdX' // XdIf
+#define XDP_POOLTAG_MAP                 'MpdX' // XdpM
+#define XDP_POOLTAG_NMR                 'NpdX' // XdpN
+#define XDP_POOLTAG_PROGRAM             'PpdX' // XdpP
+#define XDP_POOLTAG_PROGRAM_OBJECT      'OpdX' // XdpO
+#define XDP_POOLTAG_PROGRAM_BINDING     'bPdX' // XdPb
+#define XDP_POOLTAG_RING                'rpdX' // Xdpr
+#define XDP_POOLTAG_RXQUEUE             'RpdX' // XdpR
+#define XDP_POOLTAG_TXQUEUE             'TpdX' // XdpT

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -2946,57 +2946,6 @@ GenericRxMultiProgram()
 }
 
 VOID
-GenericRxMultiProgramConflicts()
-{
-    auto If = FnMpIf;
-    XDP_RULE Rule = {};
-
-    Rule.Match = XDP_MATCH_ALL;
-    Rule.Action = XDP_PROGRAM_ACTION_PASS;
-
-    //
-    // Verify a non-sharing program prevents sharing.
-    //
-    wil::unique_handle failProgram;
-    wil::unique_handle validProgram =
-        CreateXdpProg(If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
-
-    //
-    // A non-sharing program should fail with ERROR_OBJECT_ALREADY_EXISTS.
-    //
-    TEST_EQUAL(
-        HRESULT_FROM_WIN32(ERROR_OBJECT_ALREADY_EXISTS),
-        TryCreateXdpProg(
-            failProgram, If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1));
-
-    //
-    // A sharing program should fail with ERROR_SHARING_VIOLATION.
-    //
-    TEST_EQUAL(
-        HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION),
-        TryCreateXdpProg(
-            failProgram, If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
-            XDP_CREATE_PROGRAM_FLAG_SHARE));
-
-    //
-    // Verify a sharing program prevents sharing with non-sharing programs.
-    //
-    validProgram.reset();
-    validProgram =
-        CreateXdpProg(
-            If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
-            XDP_CREATE_PROGRAM_FLAG_SHARE);
-
-    //
-    // A non-sharing program should fail with ERROR_OBJECT_ALREADY_EXISTS.
-    //
-    TEST_EQUAL(
-        HRESULT_FROM_WIN32(ERROR_OBJECT_ALREADY_EXISTS),
-        TryCreateXdpProg(
-            failProgram, If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1));
-}
-
-VOID
 GenericRxUdpFragmentQuicShortHeader(
     _In_ ADDRESS_FAMILY Af
     )

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -1808,7 +1808,7 @@ CreateTcpSocket(
     ProgramHandleTx =
         CreateXdpProg(
             If->GetIfIndex(), &XdpInspectTxL2, If->GetQueueId(), XDP_GENERIC,
-            &RuleTx, 1, XDP_CREATE_PROGRAM_FLAG_SHARE);
+            &RuleTx, 1);
 
     If->GetHwAddress(&LocalHw);
     If->GetRemoteHwAddress(&RemoteHw);
@@ -2895,7 +2895,7 @@ GenericRxMultiProgram()
         Sockets[Index].ProgramHandle =
             CreateXdpProg(
                 If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC,
-                &Rule, 1, XDP_CREATE_PROGRAM_FLAG_SHARE);
+                &Rule, 1);
     }
 
     auto GenericMp = MpOpenGeneric(If.GetIfIndex());

--- a/test/functional/lib/tests.h
+++ b/test/functional/lib/tests.h
@@ -54,9 +54,6 @@ VOID
 GenericRxMultiProgram();
 
 VOID
-GenericRxMultiProgramConflicts();
-
-VOID
 GenericRxUdpFragmentQuicShortHeader(
     _In_ ADDRESS_FAMILY Af
     );

--- a/test/functional/taef/tests.cpp
+++ b/test/functional/taef/tests.cpp
@@ -124,10 +124,6 @@ public:
         ::GenericRxMultiProgram();
     }
 
-    TEST_METHOD(GenericRxMultiProgramConflicts) {
-        ::GenericRxMultiProgramConflicts();
-    }
-
     TEST_METHOD(GenericTxToRxInject) {
         ::GenericTxToRxInject();
     }

--- a/test/spinxsk/spinxsk.c
+++ b/test/spinxsk/spinxsk.c
@@ -398,10 +398,6 @@ AttachXdpProgram(
         flags |= XDP_CREATE_PROGRAM_FLAG_NATIVE;
     }
 
-    if (RandUlong() % 4) {
-        flags |= XDP_CREATE_PROGRAM_FLAG_SHARE;
-    }
-
     res = Queue->xdpApi->XskGetSockopt(Sock, XSK_SOCKOPT_RX_HOOK_ID, &hookId, &hookIdSize);
     if (FAILED(res)) {
         goto Exit;


### PR DESCRIPTION
1. The new model always allows program sharing. Thus, meta program and sharing related flags and structs have been deleted.
2. Now, when a program is plumbed, a program "binding" is inserted to the RX queue. More programs just mean more bindings on a RX queue.
3. All rules are still placed on a contiguous memory to remain the performance of the data path. When add/removing a program, a new "compiled" program is generated on control path from all bindings on the RX queue.

This refactoring IMO would make binding to all queues easier to implement. We would just need to extend program object to have an array of program bindings.
