### PR TITLE
Converge on build tools with ebpf-for-windows

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -46,6 +46,29 @@ stages:
       arch: x64
       config: Release
 
+# Some driver developers are building for WS2022 LTSC targets using VS2019 +
+# the Windows Server 2022 WDK, so validate our project still builds in that
+# environment.
+- stage: build_ltsc_debug
+  displayName: Build (Debug)
+  dependsOn: []
+  jobs:
+  - template: ./templates/build.yml
+    parameters:
+      arch: x64
+      config: Debug
+      vmImage: windows-2019
+
+- stage: build_ltsc_release
+  displayName: Build (Release)
+  dependsOn: []
+  jobs:
+  - template: ./templates/build.yml
+    parameters:
+      arch: x64
+      config: Release
+      vmImage: windows-2019
+
 - stage: test_debug
   displayName: Functional Tests (Debug)
   dependsOn:

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -58,6 +58,7 @@ stages:
       arch: x64
       config: Debug
       vmImage: windows-2019
+      publish: false
 
 - stage: build_ltsc_release
   displayName: Build (Release)
@@ -68,6 +69,7 @@ stages:
       arch: x64
       config: Release
       vmImage: windows-2019
+      publish: false
 
 - stage: test_debug
   displayName: Functional Tests (Debug)

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -50,7 +50,7 @@ stages:
 # the Windows Server 2022 WDK, so validate our project still builds in that
 # environment.
 - stage: build_ltsc_debug
-  displayName: Build (Debug)
+  displayName: Build (VS2019 Debug)
   dependsOn: []
   jobs:
   - template: ./templates/build.yml
@@ -61,7 +61,7 @@ stages:
       publish: false
 
 - stage: build_ltsc_release
-  displayName: Build (Release)
+  displayName: Build (VS2019 Release)
   dependsOn: []
   jobs:
   - template: ./templates/build.yml

--- a/.azure/templates/build.yml
+++ b/.azure/templates/build.yml
@@ -3,12 +3,13 @@
 parameters:
   arch: ''
   config: 'Debug,Release'
+  vmImage: 'windows-2022'
 
 jobs:
 - job: build_${{ parameters.arch }}
   displayName: ${{ parameters.arch }}
   pool:
-    vmImage: windows-2019
+    vmImage: ${{ parameters.vmImage }}
   variables:
   - name: runCodesignValidationInjection # We don't sign things currently
     value: false

--- a/.azure/templates/build.yml
+++ b/.azure/templates/build.yml
@@ -4,6 +4,7 @@ parameters:
   arch: ''
   config: 'Debug,Release'
   vmImage: 'windows-2022'
+  publish: true
 
 jobs:
 - job: build_${{ parameters.arch }}
@@ -68,6 +69,7 @@ jobs:
 
   - task: CopyFiles@2
     displayName: Filter Artifacts
+    condition: and(succeeded(), eq('${{ parameters.publish }}', 'true'))
     inputs:
       sourceFolder: artifacts/bin
       contents: '**/!(*.ilk|*.exp|*.lastcodeanalysissucceeded)'
@@ -75,12 +77,14 @@ jobs:
 
   - task: PublishBuildArtifacts@1
     displayName: Upload Artifacts
+    condition: and(succeeded(), eq('${{ parameters.publish }}', 'true'))
     inputs:
       artifactName: artifacts
       pathToPublish: $(Build.ArtifactStagingDirectory)
       parallel: true
 
   - task: PublishSymbols@2
+    condition: and(succeeded(), eq('${{ parameters.publish }}', 'true'))
     inputs:
         sourceFolder: $(Build.ArtifactStagingDirectory)/bin
         searchPattern: '**/*.pdb'

--- a/.azure/templates/devkit.yml
+++ b/.azure/templates/devkit.yml
@@ -3,12 +3,13 @@
 parameters:
   arch: 'x64'
   config: 'Debug'
+  vmImage: 'windows-2022'
 
 jobs:
 - job: devkit_${{ parameters.arch }}_${{ parameters.config }}
   displayName: devkit
   pool:
-    vmImage: windows-2019
+    vmImage: ${{ parameters.vmImage }}
   variables:
   - name: runCodesignValidationInjection
     value: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ permissions: read-all
 jobs:
   build:
     name: Build
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:
@@ -192,7 +192,7 @@ jobs:
       matrix:
         configuration: [Release]
         platform: [x64]
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - name: Checkout repository
       uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c

--- a/docs/development.md
+++ b/docs/development.md
@@ -18,10 +18,11 @@ git submodule update --init --recursive
 
 ### Prerequisites
 
-- [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/)
+- [Visual Studio](https://visualstudio.microsoft.com/downloads/)
+  - Visual Studio 2022 is recommended; Visual Studio 2019 or newer is required.
   - Latest Spectre-mitigated libs (via "Individual components" section of Visual Studio Installer)
 - [Windows Driver Kit](https://docs.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk)
-  (LTSC 2022 WDK or newer)
+  - WDK for Windows 11, version 22H2 (version 10.0.22621.x) is recommended; WDK for Windows Server 2022 LTSC or newer is required.
 
 ### Building
 


### PR DESCRIPTION
Until now, our automation has been building XDP using the Windows Server 2019 agents available in Azure Pipelines and GitHub. 

Since the ebpf-for-windows project is using newer tools, and some of them are mutually exclusive with older versions, upgrade our automation to the same versions as the eBPF project.

Since some IHVs are still using older toolchains (e.g. the 2022 WDK on top of VS2019) create a downlevel build to validate that workflow.