### PR TITLE
Add minimal support for binding a program to all RX queues

### DIFF
--- a/published/external/xdpapi.h
+++ b/published/external/xdpapi.h
@@ -37,6 +37,11 @@ extern "C" {
 //
 #define XDP_CREATE_PROGRAM_FLAG_NATIVE  0x2
 
+//
+// Attach to all XDP queues on the interface.
+//
+#define XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES  0x4
+
 typedef
 HRESULT
 XDP_CREATE_PROGRAM_FN(

--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -1544,9 +1544,6 @@ XdpProgramDelete(
 
         //
         // Detach the XDP program from the RX queue.
-        //
-
-        //
         // The binding might have already been detached during interface tear-down.
         //
         if (!IsListEmpty(&ProgramBinding->RxQueueEntry)) {
@@ -1554,6 +1551,8 @@ XdpProgramDelete(
         }
 
         XdpRxQueueDereference(ProgramBinding->RxQueue);
+    
+        RemoveEntryList(&ProgramBinding->Link);
         ExFreePoolWithTag(ProgramBinding, XDP_POOLTAG_PROGRAM_BINDING);
     }
 

--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -1112,6 +1112,7 @@ XdpProgramGetXskBypassTarget(
 typedef struct _XDP_PROGRAM_OBJECT XDP_PROGRAM_OBJECT;
 
 typedef struct _XDP_PROGRAM_BINDING {
+    LIST_ENTRY Link;
     XDP_RX_QUEUE *RxQueue;
     LIST_ENTRY RxQueueEntry;
     XDP_RX_QUEUE_NOTIFICATION_ENTRY RxQueueNotificationEntry;
@@ -1121,7 +1122,7 @@ typedef struct _XDP_PROGRAM_BINDING {
 typedef struct _XDP_PROGRAM_OBJECT {
     XDP_FILE_OBJECT_HEADER Header;
     XDP_BINDING_HANDLE IfHandle;
-    XDP_PROGRAM_BINDING *Binding;
+    LIST_ENTRY ProgramBindings;
     ULONG_PTR CreatedByPid;
 
     XDP_PROGRAM Program;
@@ -1132,6 +1133,7 @@ typedef struct _XDP_PROGRAM_WORKITEM {
     XDP_HOOK_ID HookId;
     UINT32 QueueId;
     XDP_PROGRAM_OBJECT *ProgramObject;
+    BOOLEAN BindToAllQueues;
 
     KEVENT CompletionEvent;
     NTSTATUS CompletionStatus;
@@ -1427,36 +1429,37 @@ Exit:
 static
 VOID
 XdpProgramDetachRxQueue(
-    _In_ XDP_PROGRAM_OBJECT *ProgramObject
+    _In_ XDP_PROGRAM_BINDING *ProgramBinding
     )
 {
-    XDP_PROGRAM_BINDING *ProgramBinding = ProgramObject->Binding;
     XDP_RX_QUEUE *RxQueue = ProgramBinding->RxQueue;
 
-    TraceEnter(TRACE_CORE, "Detach ProgramObject=%p from RxQueue", ProgramObject);
+    TraceEnter(
+        TRACE_CORE,
+        "Detach ProgramBinding=%p on ProgramObject=%p from RxQueue=%p",
+        ProgramBinding, ProgramBinding->OwningProgram, ProgramBinding->RxQueue);
 
     ASSERT(RxQueue != NULL);
+    ASSERT(!IsListEmpty(&ProgramBinding->RxQueueEntry));
 
-    if (!IsListEmpty(&ProgramBinding->RxQueueEntry)) {
-        //
-        // Remove the binding from the RX queue and recompile bound programs.
-        //
-        RemoveEntryList(&ProgramBinding->RxQueueEntry);
-        InitializeListHead(&ProgramBinding->RxQueueEntry);
-        
-        XdpRxQueueDeregisterNotifications(RxQueue, &ProgramBinding->RxQueueNotificationEntry);
-        if (IsListEmpty(XdpRxQueueGetProgramBindingList(ProgramBinding->RxQueue))) {
-            XDP_PROGRAM *OldCompiledProgram = XdpRxQueueGetProgram(RxQueue);
-            XdpRxQueueSetProgram(RxQueue, NULL, NULL, NULL);
-            if (OldCompiledProgram != NULL) {
-                ExFreePoolWithTag(OldCompiledProgram, XDP_POOLTAG_PROGRAM);
-            }
-        } else {
-            //
-            // Update the program in-place because we are down sizing the program bindings.
-            //
-            XdpRxQueueSync(RxQueue, XdpProgramUpdateCompiledProgram, RxQueue);
+    //
+    // Remove the binding from the RX queue and recompile bound programs.
+    //
+    RemoveEntryList(&ProgramBinding->RxQueueEntry);
+    InitializeListHead(&ProgramBinding->RxQueueEntry);
+
+    XdpRxQueueDeregisterNotifications(RxQueue, &ProgramBinding->RxQueueNotificationEntry);
+    if (IsListEmpty(XdpRxQueueGetProgramBindingList(ProgramBinding->RxQueue))) {
+        XDP_PROGRAM *OldCompiledProgram = XdpRxQueueGetProgram(RxQueue);
+        XdpRxQueueSetProgram(RxQueue, NULL, NULL, NULL);
+        if (OldCompiledProgram != NULL) {
+            ExFreePoolWithTag(OldCompiledProgram, XDP_POOLTAG_PROGRAM);
         }
+    } else {
+        //
+        // Update the program in-place because we are down sizing the program bindings.
+        //
+        XdpRxQueueSync(RxQueue, XdpProgramUpdateCompiledProgram, RxQueue);
     }
 
     TraceExitSuccess(TRACE_CORE);
@@ -1533,16 +1536,25 @@ XdpProgramDelete(
     _In_ XDP_PROGRAM_OBJECT *ProgramObject
     )
 {
-    XDP_PROGRAM_BINDING *ProgramBinding = ProgramObject->Binding;
     TraceEnter(TRACE_CORE, "ProgramObject=%p", ProgramObject);
 
-    //
-    // Detach the XDP program from the RX queue.
-    //
-    if (ProgramBinding != NULL && ProgramBinding->RxQueue != NULL) {
-        XdpProgramDetachRxQueue(ProgramObject);
+    while (!IsListEmpty(&ProgramObject->ProgramBindings)) {
+        XDP_PROGRAM_BINDING *ProgramBinding =
+            (XDP_PROGRAM_BINDING *)ProgramObject->ProgramBindings.Flink;
+
+        //
+        // Detach the XDP program from the RX queue.
+        //
+
+        //
+        // The binding might have already been detached during interface tear-down.
+        //
+        if (!IsListEmpty(&ProgramBinding->RxQueueEntry)) {
+            XdpProgramDetachRxQueue(ProgramBinding);
+        }
+
         XdpRxQueueDereference(ProgramBinding->RxQueue);
-        ProgramBinding->RxQueue = NULL;
+        ExFreePoolWithTag(ProgramBinding, XDP_POOLTAG_PROGRAM_BINDING);
     }
 
     //
@@ -1580,9 +1592,6 @@ XdpProgramDelete(
     }
 
     TraceVerbose(TRACE_CORE, "Deleted ProgramObject=%p", ProgramObject);
-    if (ProgramBinding != NULL) {
-        ExFreePoolWithTag(ProgramBinding, XDP_POOLTAG_PROGRAM_BINDING);
-    }
     ExFreePoolWithTag(ProgramObject, XDP_POOLTAG_PROGRAM_OBJECT);
     TraceExitSuccess(TRACE_CORE);
 }
@@ -1600,7 +1609,7 @@ XdpProgramRxQueueNotify(
     switch (NotificationType) {
 
     case XDP_RX_QUEUE_NOTIFICATION_DELETE:
-        XdpProgramDetachRxQueue(ProgramBinding->OwningProgram);
+        XdpProgramDetachRxQueue(ProgramBinding);
         break;
 
     }
@@ -1621,7 +1630,7 @@ XdpProgramCanXskBypass(
 
 static
 NTSTATUS
-XdpProgramAllocate(
+XdpProgramObjectAllocate(
     _In_ UINT32 RuleCount,
     _Out_ XDP_PROGRAM_OBJECT **NewProgramObject
     )
@@ -1647,6 +1656,7 @@ XdpProgramAllocate(
     }
 
     ProgramObject->CreatedByPid = (ULONG_PTR)PsGetCurrentProcessId();
+    InitializeListHead(&ProgramObject->ProgramBindings);
 
 Exit:
 
@@ -1670,7 +1680,7 @@ XdpCaptureProgram(
 
     TraceEnter(TRACE_CORE, "-");
 
-    Status = XdpProgramAllocate(RuleCount, &ProgramObject);
+    Status = XdpProgramObjectAllocate(RuleCount, &ProgramObject);
     if (!NT_SUCCESS(Status)) {
         goto Exit;
     }
@@ -1855,8 +1865,12 @@ XdpProgramBindingAllocate(
     }
 
     InitializeListHead(&ProgramBinding->RxQueueEntry);
+    InitializeListHead(&ProgramBinding->Link);
+    XdpRxQueueInitializeNotificationEntry(&ProgramBinding->RxQueueNotificationEntry);
+
     ProgramBinding->OwningProgram = ProgramObject;
-    ProgramObject->Binding = ProgramBinding;
+    InsertTailList(&ProgramObject->ProgramBindings, &ProgramBinding->Link);
+
     Status = STATUS_SUCCESS;
 
 Exit:
@@ -1865,27 +1879,18 @@ Exit:
 }
 
 static
-VOID
-XdpProgramAttach(
-    _In_ XDP_BINDING_WORKITEM *WorkItem
+NTSTATUS
+XdpProgramBindingAttach(
+    _In_ XDP_BINDING_HANDLE XdpBinding,
+    _In_ CONST XDP_HOOK_ID *HookId,
+    _Inout_ XDP_PROGRAM_OBJECT *ProgramObject,
+    _In_ UINT32 QueueId
     )
 {
-    XDP_PROGRAM_WORKITEM *Item = (XDP_PROGRAM_WORKITEM *)WorkItem;
-    XDP_PROGRAM_OBJECT *ProgramObject = Item->ProgramObject;
     XDP_PROGRAM *Program = &ProgramObject->Program;
     XDP_PROGRAM_BINDING* ProgramBinding = NULL;
     XDP_PROGRAM *CompiledProgram = NULL;
     NTSTATUS Status;
-
-    TraceEnter(TRACE_CORE, "Program=%p", ProgramObject);
-
-    if (Item->HookId.SubLayer != XDP_HOOK_INSPECT) {
-        //
-        // Only RX queue programs are currently supported.
-        //
-        Status = STATUS_NOT_SUPPORTED;
-        goto Exit;
-    }
 
     Status = XdpProgramBindingAllocate(&ProgramBinding, ProgramObject);
     if (!NT_SUCCESS(Status)) {
@@ -1894,7 +1899,7 @@ XdpProgramAttach(
 
     Status =
         XdpRxQueueFindOrCreate(
-            Item->Bind.BindingHandle, &Item->HookId, Item->QueueId, &ProgramBinding->RxQueue);
+            XdpBinding, HookId, QueueId, &ProgramBinding->RxQueue);
     if (!NT_SUCCESS(Status)) {
         goto Exit;
     }
@@ -1924,8 +1929,6 @@ XdpProgramAttach(
         XdpRxQueueGetProgramBindingList(ProgramBinding->RxQueue), &ProgramBinding->RxQueueEntry);
     Status = XdpProgramCompileNewProgram(ProgramBinding->RxQueue, &CompiledProgram);
     if (!NT_SUCCESS(Status)) {
-        RemoveEntryList(&ProgramBinding->RxQueueEntry);
-        InitializeListHead(&ProgramBinding->RxQueueEntry);
         goto Exit;
     }
 
@@ -1936,8 +1939,8 @@ XdpProgramAttach(
         ProgramBinding->RxQueue, &ProgramBinding->RxQueueNotificationEntry, XdpProgramRxQueueNotify);
 
     ASSERT(
-        !IsListEmpty(&ProgramBinding->RxQueueNotificationEntry.Link) &&
-        !IsListEmpty(&ProgramBinding->RxQueueEntry));
+        !IsListEmpty(&ProgramBinding->RxQueueEntry) &&
+        !IsListEmpty(&ProgramBinding->Link));
 
     XDP_PROGRAM *OldCompiledProgram = XdpRxQueueGetProgram(ProgramBinding->RxQueue);
     Status =
@@ -1945,21 +1948,113 @@ XdpProgramAttach(
             ProgramBinding->RxQueue, CompiledProgram, XdpProgramValidateIfQueue,
             ProgramObject);
     if (!NT_SUCCESS(Status)) {
-        ExFreePoolWithTag(CompiledProgram, XDP_POOLTAG_PROGRAM);
         goto Exit;
     }
+
+    CompiledProgram = NULL;
 
     if (OldCompiledProgram != NULL) {
         //
         // We just swapped in a new compiled program. Delete the old one.
         //
         ExFreePoolWithTag(OldCompiledProgram, XDP_POOLTAG_PROGRAM);
+        OldCompiledProgram = NULL;
     }
 
     TraceInfo(
-        TRACE_CORE, "Attached program RxQueue=%p ProgramObject=%p",
-        ProgramBinding->RxQueue, ProgramObject);
-    XdpProgramTraceObject(ProgramObject);
+        TRACE_CORE, "Attached ProgramBinding %p RxQueue=%p ProgramObject=%p",
+        ProgramBinding, ProgramBinding->RxQueue, ProgramObject);
+
+Exit:
+
+    if (!NT_SUCCESS(Status)) {
+        if (CompiledProgram != NULL) {
+            ExFreePoolWithTag(CompiledProgram, XDP_POOLTAG_PROGRAM);
+        }
+
+        if (ProgramBinding != NULL) {
+            RemoveEntryList(&ProgramBinding->Link);
+            InitializeListHead(&ProgramBinding->Link);
+
+            RemoveEntryList(&ProgramBinding->RxQueueEntry);
+            InitializeListHead(&ProgramBinding->RxQueueEntry);
+
+            XdpRxQueueDeregisterNotifications(ProgramBinding->RxQueue, &ProgramBinding->RxQueueNotificationEntry);
+
+            ASSERT(
+                IsListEmpty(&ProgramBinding->RxQueueEntry) &&
+                IsListEmpty(&ProgramBinding->Link));
+
+            ExFreePoolWithTag(ProgramBinding, XDP_POOLTAG_PROGRAM_BINDING);
+        }
+    }
+
+    return Status;
+}
+
+static
+VOID
+XdpProgramAttach(
+    _In_ XDP_BINDING_WORKITEM *WorkItem
+    )
+{
+    XDP_PROGRAM_WORKITEM *Item = (XDP_PROGRAM_WORKITEM *)WorkItem;
+    XDP_PROGRAM_OBJECT *ProgramObject = Item->ProgramObject;
+    NTSTATUS Status = STATUS_UNSUCCESSFUL;
+    UINT32 QueueIdStart = Item->QueueId;
+    UINT32 QueueIdEnd = Item->QueueId + 1;
+
+    TraceEnter(TRACE_CORE, "ProgramObject=%p", ProgramObject);
+
+    if (Item->HookId.SubLayer != XDP_HOOK_INSPECT) {
+        //
+        // Only RX queue programs are currently supported.
+        //
+        Status = STATUS_NOT_SUPPORTED;
+        goto Exit;
+    }
+
+    if (Item->BindToAllQueues) {
+        XDP_IFSET_HANDLE IfSetHandle = XdpIfGetIfSetHandle(Item->Bind.BindingHandle);
+        VOID *InterfaceOffloadHandle;
+        XDP_RSS_CAPABILITIES RssCapabilities;
+        UINT32 RssCapabilitiesSize = sizeof(RssCapabilities);
+        Status =
+            XdpIfOpenInterfaceOffloadHandle(
+                IfSetHandle, &Item->HookId, &InterfaceOffloadHandle);
+        if (!NT_SUCCESS(Status)) {
+            goto Exit;
+        }
+
+        Status =
+            XdpIfGetInterfaceOffloadCapabilities(
+                IfSetHandle, InterfaceOffloadHandle,
+                XdpOffloadRss, &RssCapabilities, &RssCapabilitiesSize);
+        if (!NT_SUCCESS(Status)) {
+            goto Exit;
+        }
+
+        XdpIfCloseInterfaceOffloadHandle(IfSetHandle, InterfaceOffloadHandle);
+        TraceInfo(
+            TRACE_CORE, "Attaching ProgramObject=%p to all %u queues",
+            ProgramObject, RssCapabilities.NumberOfReceiveQueues);
+        QueueIdStart = 0;
+        QueueIdEnd = RssCapabilities.NumberOfReceiveQueues;
+    }
+
+    for (UINT32 QueueId = QueueIdStart; QueueId < QueueIdEnd; ++QueueId) {
+        Status =
+            XdpProgramBindingAttach(
+                Item->Bind.BindingHandle, &Item->HookId, ProgramObject, QueueId);
+        if (!NT_SUCCESS(Status)) {
+            //
+            // Failed to attach to one of the RX queues.
+            //
+            // TODO: should we allow it to succeed partially?
+            //
+            goto Exit;
+        }
+    }
 
 Exit:
 
@@ -2012,7 +2107,9 @@ XdpIrpCreateProgram(
     XDP_PROGRAM_OBJECT *ProgramObject = NULL;
     NTSTATUS Status;
     CONST UINT32 ValidFlags =
-        XDP_CREATE_PROGRAM_FLAG_GENERIC | XDP_CREATE_PROGRAM_FLAG_NATIVE;
+        XDP_CREATE_PROGRAM_FLAG_GENERIC |
+        XDP_CREATE_PROGRAM_FLAG_NATIVE |
+        XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES;
 
     if (Disposition != FILE_CREATE || InputBufferLength < sizeof(*Params)) {
         Status = STATUS_INVALID_PARAMETER;
@@ -2060,6 +2157,7 @@ RetryBinding:
     KeInitializeEvent(&WorkItem.CompletionEvent, NotificationEvent, FALSE);
     WorkItem.QueueId = Params->QueueId;
     WorkItem.HookId = Params->HookId;
+    WorkItem.BindToAllQueues = !!(Params->Flags & XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
     WorkItem.ProgramObject = ProgramObject;
     WorkItem.Bind.BindingHandle = BindingHandle;
     WorkItem.Bind.WorkRoutine = XdpProgramAttach;

--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -831,6 +831,7 @@ XdpL2Fwd(
 _IRQL_requires_max_(DISPATCH_LEVEL)
 XDP_RX_ACTION
 XdpInspect(
+    _In_ XDP_RX_QUEUE *RxQueue,
     _In_ XDP_PROGRAM *Program,
     _In_ XDP_REDIRECT_CONTEXT *RedirectContext,
     _In_ XDP_RING *FrameRing,
@@ -1062,9 +1063,15 @@ XdpInspect(
             switch (Rule->Action) {
 
             case XDP_PROGRAM_ACTION_REDIRECT:
-                XdpRedirect(
-                    RedirectContext, FrameIndex, FragmentIndex, Rule->Redirect.TargetType,
-                    Rule->Redirect.Target);
+                //
+                // If we are redirecting to an XSK that's not bound to this RX queue,
+                // drop everything.
+                //
+                if (XskIsDatapathHandleQueueMatched(Rule->Redirect.Target, RxQueue)) {
+                    XdpRedirect(
+                        RedirectContext, FrameIndex, FragmentIndex, Rule->Redirect.TargetType,
+                        Rule->Redirect.Target);
+                }
 
                 Action = XDP_RX_ACTION_DROP;
                 break;
@@ -1883,7 +1890,8 @@ XdpProgramBindingAttach(
     _In_ XDP_BINDING_HANDLE XdpBinding,
     _In_ CONST XDP_HOOK_ID *HookId,
     _Inout_ XDP_PROGRAM_OBJECT *ProgramObject,
-    _In_ UINT32 QueueId
+    _In_ UINT32 QueueId,
+    _In_ BOOLEAN BindToAllQueues
     )
 {
     XDP_PROGRAM *Program = &ProgramObject->Program;
@@ -1911,7 +1919,7 @@ XdpProgramBindingAttach(
             switch (Rule->Redirect.TargetType) {
 
             case XDP_REDIRECT_TARGET_TYPE_XSK:
-                Status = XskValidateDatapathHandle(Rule->Redirect.Target, ProgramBinding->RxQueue);
+                Status = XskValidateDatapathHandle(Rule->Redirect.Target, ProgramBinding->RxQueue, BindToAllQueues);
                 if (!NT_SUCCESS(Status)) {
                     goto Exit;
                 }
@@ -2044,7 +2052,8 @@ XdpProgramAttach(
     for (UINT32 QueueId = QueueIdStart; QueueId < QueueIdEnd; ++QueueId) {
         Status =
             XdpProgramBindingAttach(
-                Item->Bind.BindingHandle, &Item->HookId, ProgramObject, QueueId);
+                Item->Bind.BindingHandle, &Item->HookId, ProgramObject,
+                QueueId, Item->BindToAllQueues);
         if (!NT_SUCCESS(Status)) {
             //
             // Failed to attach to one of the RX queues.

--- a/src/xdp/program.h
+++ b/src/xdp/program.h
@@ -17,7 +17,6 @@ typedef struct _XDP_RX_QUEUE XDP_RX_QUEUE;
 _IRQL_requires_max_(DISPATCH_LEVEL)
 XDP_RX_ACTION
 XdpInspect(
-    _In_ XDP_RX_QUEUE *RxQueue,
     _In_ XDP_PROGRAM *Program,
     _In_ XDP_REDIRECT_CONTEXT *RedirectContext,
     _In_ XDP_RING *FrameRing,

--- a/src/xdp/program.h
+++ b/src/xdp/program.h
@@ -8,6 +8,7 @@
 #include "redirect.h"
 
 typedef struct _XDP_PROGRAM XDP_PROGRAM;
+typedef struct _XDP_RX_QUEUE XDP_RX_QUEUE;
 
 //
 // Data path routines.
@@ -16,6 +17,7 @@ typedef struct _XDP_PROGRAM XDP_PROGRAM;
 _IRQL_requires_max_(DISPATCH_LEVEL)
 XDP_RX_ACTION
 XdpInspect(
+    _In_ XDP_RX_QUEUE *RxQueue,
     _In_ XDP_PROGRAM *Program,
     _In_ XDP_REDIRECT_CONTEXT *RedirectContext,
     _In_ XDP_RING *FrameRing,

--- a/src/xdp/redirect.c
+++ b/src/xdp/redirect.c
@@ -68,6 +68,7 @@ XdpRedirect(
         //
         Batch->TargetType = TargetType;
         Batch->Target = Target;
+        Batch->RxQueue = XdpRxQueueFromRedirectContext(Redirect);
     }
 
     //

--- a/src/xdp/redirect.h
+++ b/src/xdp/redirect.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+typedef struct _XDP_RX_QUEUE XDP_RX_QUEUE;
+
 typedef struct _XDP_REDIRECT_FRAME {
     UINT32 FrameIndex;
     UINT32 FragmentIndex;
@@ -12,6 +14,7 @@ typedef struct _XDP_REDIRECT_FRAME {
 
 typedef struct _XDP_REDIRECT_BATCH {
     VOID *Target;
+    XDP_RX_QUEUE *RxQueue;
     XDP_REDIRECT_TARGET_TYPE TargetType;
     UINT32 Count;
     XDP_REDIRECT_FRAME FrameIndexes[32];

--- a/src/xdp/rx.c
+++ b/src/xdp/rx.c
@@ -172,7 +172,7 @@ XdppReceiveBatch(
 
         Action =
             XdpInspect(
-                RxQueue->Program, &RxQueue->RedirectContext, RxQueue->FrameRing, FrameIndex,
+                RxQueue, RxQueue->Program, &RxQueue->RedirectContext, RxQueue->FrameRing, FrameIndex,
                 RxQueue->FragmentRing, &RxQueue->FragmentExtension, FragmentIndex,
                 &RxQueue->VirtualAddressExtension);
 

--- a/src/xdp/rx.c
+++ b/src/xdp/rx.c
@@ -100,6 +100,14 @@ XdpRxQueueFromHandle(
     return CONTAINING_RECORD(XdpRxQueue, XDP_RX_QUEUE, Dispatch);
 }
 
+XDP_RX_QUEUE *
+XdpRxQueueFromRedirectContext(
+    _In_ XDP_REDIRECT_CONTEXT *RedirectContext
+    )
+{
+    return CONTAINING_RECORD(RedirectContext, XDP_RX_QUEUE, RedirectContext);
+}
+
 static
 _IRQL_requires_max_(DISPATCH_LEVEL)
 VOID
@@ -172,7 +180,7 @@ XdppReceiveBatch(
 
         Action =
             XdpInspect(
-                RxQueue, RxQueue->Program, &RxQueue->RedirectContext, RxQueue->FrameRing, FrameIndex,
+                RxQueue->Program, &RxQueue->RedirectContext, RxQueue->FrameRing, FrameIndex,
                 RxQueue->FragmentRing, &RxQueue->FragmentExtension, FragmentIndex,
                 &RxQueue->VirtualAddressExtension);
 

--- a/src/xdp/rx.c
+++ b/src/xdp/rx.c
@@ -983,6 +983,14 @@ XdpRxQueueFindOrCreate(
 }
 
 VOID
+XdpRxQueueInitializeNotificationEntry(
+    _Inout_ XDP_RX_QUEUE_NOTIFICATION_ENTRY *NotifyEntry
+    )
+{
+    InitializeListHead(&NotifyEntry->Link);
+}
+
+VOID
 XdpRxQueueRegisterNotifications(
     _In_ XDP_RX_QUEUE *RxQueue,
     _Inout_ XDP_RX_QUEUE_NOTIFICATION_ENTRY *NotifyEntry,
@@ -1004,8 +1012,14 @@ XdpRxQueueDeregisterNotifications(
     )
 {
     UNREFERENCED_PARAMETER(RxQueue);
-
-    RemoveEntryList(&NotifyEntry->Link);
+    //
+    // Checking if the entry is linked before it is removed makes
+    // the caller's clean-up work easier.
+    //
+    if (!IsListEmpty(&NotifyEntry->Link)) {
+        RemoveEntryList(&NotifyEntry->Link);
+        InitializeListHead(&NotifyEntry->Link);
+    }
 }
 
 VOID

--- a/src/xdp/rx.h
+++ b/src/xdp/rx.h
@@ -88,6 +88,11 @@ XdpRxQueueSetProgram(
     _In_opt_ VOID *ValidationContext
     );
 
+XDP_RX_QUEUE *
+XdpRxQueueFromRedirectContext(
+    _In_ XDP_REDIRECT_CONTEXT *RedirectContext
+    );
+
 LIST_ENTRY *
 XdpRxQueueGetProgramBindingList(
     _In_ XDP_RX_QUEUE *RxQueue

--- a/src/xdp/rx.h
+++ b/src/xdp/rx.h
@@ -44,6 +44,11 @@ typedef struct _XDP_RX_QUEUE_NOTIFY_ENTRY {
 } XDP_RX_QUEUE_NOTIFICATION_ENTRY;
 
 VOID
+XdpRxQueueInitializeNotificationEntry(
+    _Inout_ XDP_RX_QUEUE_NOTIFICATION_ENTRY *NotifyEntry
+    );
+
+VOID
 XdpRxQueueRegisterNotifications(
     _In_ XDP_RX_QUEUE *RxQueue,
     _Inout_ XDP_RX_QUEUE_NOTIFICATION_ENTRY *Entry,

--- a/src/xdp/xsk.c
+++ b/src/xdp/xsk.c
@@ -1660,9 +1660,7 @@ XskNotifyRxQueue(
 
 NTSTATUS
 XskValidateDatapathHandle(
-    _In_ HANDLE XskHandle,
-    _In_ XDP_RX_QUEUE *RxQueue,
-    _In_ BOOLEAN IgnoreQueueMatch
+    _In_ HANDLE XskHandle
     )
 {
     XSK *Xsk = (XSK *)XskHandle;
@@ -1673,11 +1671,6 @@ XskValidateDatapathHandle(
 
     if (Xsk->Rx.Xdp.Queue == NULL) {
         return STATUS_NOT_SUPPORTED;
-    }
-
-    if (!IgnoreQueueMatch &&
-        !XskIsDatapathHandleQueueMatched(XskHandle, RxQueue)) {
-        return STATUS_INVALID_ADDRESS_COMPONENT;
     }
 
     return STATUS_SUCCESS;
@@ -4458,7 +4451,7 @@ XskReceive(
     UINT32 ReservedCount;
     UINT32 RxCount = 0;
 
-    if (!Xsk->Rx.Xdp.Flags.DatapathAttached) {
+    if (!Xsk->Rx.Xdp.Flags.DatapathAttached || Xsk->Rx.Xdp.Queue != Batch->RxQueue) {
         goto Exit;
     }
 

--- a/src/xdp/xsk.c
+++ b/src/xdp/xsk.c
@@ -1661,7 +1661,8 @@ XskNotifyRxQueue(
 NTSTATUS
 XskValidateDatapathHandle(
     _In_ HANDLE XskHandle,
-    _In_ XDP_RX_QUEUE *RxQueue
+    _In_ XDP_RX_QUEUE *RxQueue,
+    _In_ BOOLEAN IgnoreQueueMatch
     )
 {
     XSK *Xsk = (XSK *)XskHandle;
@@ -1674,11 +1675,27 @@ XskValidateDatapathHandle(
         return STATUS_NOT_SUPPORTED;
     }
 
-    if (Xsk->Rx.Xdp.Queue != RxQueue) {
+    if (!IgnoreQueueMatch &&
+        !XskIsDatapathHandleQueueMatched(XskHandle, RxQueue)) {
         return STATUS_INVALID_ADDRESS_COMPONENT;
     }
 
     return STATUS_SUCCESS;
+}
+
+BOOLEAN
+XskIsDatapathHandleQueueMatched(
+    _In_ HANDLE XskHandle,
+    _In_ XDP_RX_QUEUE *RxQueue
+    )
+{
+    XSK *Xsk = (XSK *)XskHandle;
+
+    if (Xsk->Rx.Xdp.Queue != RxQueue) {
+        return FALSE;
+    }
+
+    return TRUE;
 }
 
 static

--- a/src/xdp/xsk.h
+++ b/src/xdp/xsk.h
@@ -38,9 +38,7 @@ XskReferenceDatapathHandle(
 
 NTSTATUS
 XskValidateDatapathHandle(
-    _In_ HANDLE XskHandle,
-    _In_ XDP_RX_QUEUE *RxQueue,
-    _In_ BOOLEAN IgnoreQueueMatch
+    _In_ HANDLE XskHandle
     );
 
 BOOLEAN

--- a/src/xdp/xsk.h
+++ b/src/xdp/xsk.h
@@ -39,6 +39,13 @@ XskReferenceDatapathHandle(
 NTSTATUS
 XskValidateDatapathHandle(
     _In_ HANDLE XskHandle,
+    _In_ XDP_RX_QUEUE *RxQueue,
+    _In_ BOOLEAN IgnoreQueueMatch
+    );
+
+BOOLEAN
+XskIsDatapathHandleQueueMatched(
+    _In_ HANDLE XskHandle,
     _In_ XDP_RX_QUEUE *RxQueue
     );
 

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -2483,9 +2483,7 @@ GenericRxMatch(
         Rule.Pattern.Port = htons(ntohs(LocalPort) - 1);
 
         ProgramHandle =
-            CreateXdpProg(
-                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
-                XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
+            CreateXdpProg(If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
 
         RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
         TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
@@ -2500,8 +2498,7 @@ GenericRxMatch(
         Rule.Pattern.Tuple.SourcePort = htons(ntohs(RemotePort) - 1);
 
         ProgramHandle =
-            CreateXdpProg(
-                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
+            CreateXdpProg(If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
 
         RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
         TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
@@ -2516,8 +2513,7 @@ GenericRxMatch(
         Rule.Pattern.Tuple.DestinationPort = htons(ntohs(LocalPort) - 1);
 
         ProgramHandle =
-            CreateXdpProg(
-                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
+            CreateXdpProg(If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
 
         RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
         TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
@@ -2532,8 +2528,7 @@ GenericRxMatch(
         (*((UCHAR*)&Rule.Pattern.Tuple.SourceAddress))++;
 
         ProgramHandle =
-            CreateXdpProg(
-                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
+            CreateXdpProg(If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
 
         RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
         TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
@@ -2548,8 +2543,7 @@ GenericRxMatch(
         (*((UCHAR*)&Rule.Pattern.Tuple.DestinationAddress))++;
 
         ProgramHandle =
-            CreateXdpProg(
-                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
+            CreateXdpProg(If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
 
         RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
         TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
@@ -2605,8 +2599,7 @@ GenericRxMatch(
             Rule.Pattern.QuicFlow.CidLength);
 
         ProgramHandle =
-            CreateXdpProg(
-                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
+            CreateXdpProg(If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
 
         RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
         TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
@@ -2624,8 +2617,7 @@ GenericRxMatch(
             Rule.Pattern.QuicFlow.CidLength);
 
         ProgramHandle =
-            CreateXdpProg(
-                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
+            CreateXdpProg(If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
 
         RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
         TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
@@ -2671,8 +2663,7 @@ GenericRxMatch(
             (*((UCHAR*)&Rule.Pattern.IpPortSet.Address))++;
 
             ProgramHandle =
-                CreateXdpProg(
-                    If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
+                CreateXdpProg(If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
 
             RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
             TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -2439,8 +2439,7 @@ GenericRxMatch(
 
     ProgramHandle =
         CreateXdpProg(
-            If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
-            XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
+            If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
 
     RX_FRAME Frame;
     RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
@@ -2457,8 +2456,7 @@ GenericRxMatch(
 
     ProgramHandle =
         CreateXdpProg(
-            If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
-            XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
+            If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
 
     if (!IsUdp) {
         TEST_TRUE(
@@ -2503,8 +2501,7 @@ GenericRxMatch(
 
         ProgramHandle =
             CreateXdpProg(
-                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
-                XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
+                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
 
         RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
         TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
@@ -2520,8 +2517,7 @@ GenericRxMatch(
 
         ProgramHandle =
             CreateXdpProg(
-                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
-                XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
+                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
 
         RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
         TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
@@ -2537,8 +2533,7 @@ GenericRxMatch(
 
         ProgramHandle =
             CreateXdpProg(
-                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
-                XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
+                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
 
         RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
         TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
@@ -2554,8 +2549,7 @@ GenericRxMatch(
 
         ProgramHandle =
             CreateXdpProg(
-                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
-                XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
+                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
 
         RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
         TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
@@ -2612,8 +2606,7 @@ GenericRxMatch(
 
         ProgramHandle =
             CreateXdpProg(
-                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
-                XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
+                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
 
         RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
         TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
@@ -2632,8 +2625,7 @@ GenericRxMatch(
 
         ProgramHandle =
             CreateXdpProg(
-                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
-                XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
+                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
 
         RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
         TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
@@ -2680,8 +2672,7 @@ GenericRxMatch(
 
             ProgramHandle =
                 CreateXdpProg(
-                    If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
-                    XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
+                    If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
 
             RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
             TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -2438,8 +2438,7 @@ GenericRxMatch(
     Rule.Action = XDP_PROGRAM_ACTION_PASS;
 
     ProgramHandle =
-        CreateXdpProg(
-            If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
+        CreateXdpProg(If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
 
     RX_FRAME Frame;
     RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
@@ -2455,8 +2454,7 @@ GenericRxMatch(
     Rule.Action = XDP_PROGRAM_ACTION_DROP;
 
     ProgramHandle =
-        CreateXdpProg(
-            If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
+        CreateXdpProg(If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
 
     if (!IsUdp) {
         TEST_TRUE(

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -2223,6 +2223,94 @@ GenericRxBackfillAndTrailer()
 }
 
 VOID
+GenericRxAllQueueRedirect(
+    _In_ ADDRESS_FAMILY Af
+    )
+{
+    auto If = FnMpIf;
+    UINT16 LocalPort;
+    UINT16 RemotePort = htons(1234);
+    ETHERNET_ADDRESS LocalHw, RemoteHw;
+    INET_ADDR LocalIp, RemoteIp;
+
+    auto Socket = CreateUdpSocket(Af, &If, &LocalPort);
+    auto GenericMp = MpOpenGeneric(If.GetIfIndex());
+
+    If.GetHwAddress(&LocalHw);
+    If.GetRemoteHwAddress(&RemoteHw);
+    if (Af == AF_INET) {
+        If.GetIpv4Address(&LocalIp.Ipv4);
+        If.GetRemoteIpv4Address(&RemoteIp.Ipv4);
+    } else {
+        If.GetIpv6Address(&LocalIp.Ipv6);
+        If.GetRemoteIpv6Address(&RemoteIp.Ipv6);
+    }
+
+    auto Xsk =
+        CreateAndBindSocket(
+            If.GetIfIndex(), If.GetQueueId(), TRUE, FALSE, XDP_GENERIC);
+
+    XDP_RULE Rule;
+    Rule.Match = XDP_MATCH_UDP_DST;
+    Rule.Pattern.Port = LocalPort;
+    Rule.Action = XDP_PROGRAM_ACTION_REDIRECT;
+    Rule.Redirect.TargetType = XDP_REDIRECT_TARGET_TYPE_XSK;
+    Rule.Redirect.Target = Xsk.Handle.get();
+
+    wil::unique_handle ProgramHandle =
+        CreateXdpProg(
+            If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
+            XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
+
+    const UCHAR Payload[] = "GenericRxAllQueueRedirect";
+    UINT16 PayloadLength = sizeof(Payload);
+    UCHAR PacketBuffer[UDP_HEADER_STORAGE + sizeof(Payload)];
+    UINT32 PacketBufferLength = sizeof(PacketBuffer);
+
+    SocketProduceRxFill(&Xsk, 2);
+
+    //
+    // Indicate a packet on the wrong RX queue.
+    //
+    RX_FRAME Frame;
+    TEST_TRUE(
+        PktBuildUdpFrame(
+            PacketBuffer, &PacketBufferLength, Payload, PayloadLength, &LocalHw,
+            &RemoteHw, Af, &LocalIp, &RemoteIp, LocalPort, RemotePort));
+    RxInitializeFrame(&Frame, If.GetQueueId() + 1, PacketBuffer, PacketBufferLength);
+    TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
+
+    Sleep(TEST_TIMEOUT_ASYNC_MS * 2);
+
+    UINT32 ConsumerIndex;
+    TEST_EQUAL(0, XskRingConsumerReserve(&Xsk.Rings.Rx, MAXUINT32, &ConsumerIndex));
+
+    //
+    // Indicate a packet on the right RX queue.
+    //
+    TEST_TRUE(
+        PktBuildUdpFrame(
+            PacketBuffer, &PacketBufferLength, Payload, PayloadLength, &LocalHw,
+            &RemoteHw, Af, &LocalIp, &RemoteIp, LocalPort, RemotePort));
+    RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
+    TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
+
+    //
+    // Verify we get the packet that's indicated on the RX queue the rule's bound to.
+    //
+    ConsumerIndex = SocketConsumerReserve(&Xsk.Rings.Rx, 1);
+    TEST_EQUAL(1, XskRingConsumerReserve(&Xsk.Rings.Rx, MAXUINT32, &ConsumerIndex));
+    auto RxDesc = SocketGetAndFreeRxDesc(&Xsk, ConsumerIndex);
+    TEST_EQUAL(PacketBufferLength, RxDesc->length);
+    TEST_TRUE(
+        RtlEqualMemory(
+            Xsk.Umem.Buffer.get() +
+                XskDescriptorGetAddress(RxDesc->address) + XskDescriptorGetOffset(RxDesc->address),
+            PacketBuffer,
+            PacketBufferLength));
+}
+
+VOID
 GenericRxMatch(
     _In_ ADDRESS_FAMILY Af,
     _In_ XDP_MATCH_TYPE MatchType,
@@ -2350,7 +2438,9 @@ GenericRxMatch(
     Rule.Action = XDP_PROGRAM_ACTION_PASS;
 
     ProgramHandle =
-        CreateXdpProg(If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
+        CreateXdpProg(
+            If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
+            XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
 
     RX_FRAME Frame;
     RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
@@ -2366,7 +2456,9 @@ GenericRxMatch(
     Rule.Action = XDP_PROGRAM_ACTION_DROP;
 
     ProgramHandle =
-        CreateXdpProg(If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
+        CreateXdpProg(
+            If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
+            XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
 
     if (!IsUdp) {
         TEST_TRUE(
@@ -2393,7 +2485,9 @@ GenericRxMatch(
         Rule.Pattern.Port = htons(ntohs(LocalPort) - 1);
 
         ProgramHandle =
-            CreateXdpProg(If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
+            CreateXdpProg(
+                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
+                XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
 
         RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
         TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
@@ -2408,7 +2502,9 @@ GenericRxMatch(
         Rule.Pattern.Tuple.SourcePort = htons(ntohs(RemotePort) - 1);
 
         ProgramHandle =
-            CreateXdpProg(If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
+            CreateXdpProg(
+                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
+                XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
 
         RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
         TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
@@ -2423,7 +2519,9 @@ GenericRxMatch(
         Rule.Pattern.Tuple.DestinationPort = htons(ntohs(LocalPort) - 1);
 
         ProgramHandle =
-            CreateXdpProg(If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
+            CreateXdpProg(
+                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
+                XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
 
         RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
         TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
@@ -2438,7 +2536,9 @@ GenericRxMatch(
         (*((UCHAR*)&Rule.Pattern.Tuple.SourceAddress))++;
 
         ProgramHandle =
-            CreateXdpProg(If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
+            CreateXdpProg(
+                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
+                XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
 
         RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
         TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
@@ -2453,7 +2553,9 @@ GenericRxMatch(
         (*((UCHAR*)&Rule.Pattern.Tuple.DestinationAddress))++;
 
         ProgramHandle =
-            CreateXdpProg(If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
+            CreateXdpProg(
+                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
+                XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
 
         RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
         TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
@@ -2509,7 +2611,9 @@ GenericRxMatch(
             Rule.Pattern.QuicFlow.CidLength);
 
         ProgramHandle =
-            CreateXdpProg(If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
+            CreateXdpProg(
+                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
+                XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
 
         RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
         TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
@@ -2527,7 +2631,9 @@ GenericRxMatch(
             Rule.Pattern.QuicFlow.CidLength);
 
         ProgramHandle =
-            CreateXdpProg(If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
+            CreateXdpProg(
+                If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
+                XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
 
         RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
         TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
@@ -2574,7 +2680,8 @@ GenericRxMatch(
 
             ProgramHandle =
                 CreateXdpProg(
-                    If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1);
+                    If.GetIfIndex(), &XdpInspectRxL2, If.GetQueueId(), XDP_GENERIC, &Rule, 1,
+                    XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES);
 
             RxInitializeFrame(&Frame, If.GetQueueId(), PacketBuffer, PacketBufferLength);
             TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));

--- a/test/functional/lib/tests.h
+++ b/test/functional/lib/tests.h
@@ -33,6 +33,11 @@ VOID
 GenericRxBackfillAndTrailer();
 
 VOID
+GenericRxAllQueueRedirect(
+    _In_ ADDRESS_FAMILY Af
+    );
+
+VOID
 GenericRxMatch(
     _In_ ADDRESS_FAMILY Af,
     _In_ XDP_MATCH_TYPE MatchType,

--- a/test/functional/taef/tests.cpp
+++ b/test/functional/taef/tests.cpp
@@ -152,6 +152,14 @@ public:
         ::FnMpNativeHandleTest();
     }
 
+    TEST_METHOD(GenericRxAllQueueRedirectV4) {
+        GenericRxAllQueueRedirect(AF_INET);
+    }
+
+    TEST_METHOD(GenericRxAllQueueRedirectV6) {
+        GenericRxAllQueueRedirect(AF_INET6);
+    }
+
     TEST_METHOD(GenericRxMatchUdpV4) {
         GenericRxMatch(AF_INET, XDP_MATCH_UDP, TRUE);
     }

--- a/test/spinxsk/spinxsk.c
+++ b/test/spinxsk/spinxsk.c
@@ -398,6 +398,10 @@ AttachXdpProgram(
         flags |= XDP_CREATE_PROGRAM_FLAG_NATIVE;
     }
 
+    if (RandUlong() % 8) {
+        flags |= XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES;
+    }
+
     res = Queue->xdpApi->XskGetSockopt(Sock, XSK_SOCKOPT_RX_HOOK_ID, &hookId, &hookIdSize);
     if (FAILED(res)) {
         goto Exit;

--- a/test/spinxsk/spinxsk.c
+++ b/test/spinxsk/spinxsk.c
@@ -398,9 +398,9 @@ AttachXdpProgram(
         flags |= XDP_CREATE_PROGRAM_FLAG_NATIVE;
     }
 
-    // if (RandUlong() % 8) {
-    //     flags |= XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES;
-    // }
+    if (RandUlong() % 8) {
+        flags |= XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES;
+    }
 
     res = Queue->xdpApi->XskGetSockopt(Sock, XSK_SOCKOPT_RX_HOOK_ID, &hookId, &hookIdSize);
     if (FAILED(res)) {

--- a/test/spinxsk/spinxsk.c
+++ b/test/spinxsk/spinxsk.c
@@ -398,9 +398,9 @@ AttachXdpProgram(
         flags |= XDP_CREATE_PROGRAM_FLAG_NATIVE;
     }
 
-    if (RandUlong() % 8) {
-        flags |= XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES;
-    }
+    // if (RandUlong() % 8) {
+    //     flags |= XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES;
+    // }
 
     res = Queue->xdpApi->XskGetSockopt(Sock, XSK_SOCKOPT_RX_HOOK_ID, &hookId, &hookIdSize);
     if (FAILED(res)) {


### PR DESCRIPTION
With this change, when a program is plumbed to all queues, it queries the number of HW queues the underlying interface supports and binds the program to all of them including unused ones.

When redirecting packets, check whether the XSK is bound to the queue that is attempting to redirect to it. If not, drop the packets.