### PR TITLE
Add -Unlimited switch to xdpmpratesim.ps1

### DIFF
--- a/tools/xdpmpratesim.ps1
+++ b/tools/xdpmpratesim.ps1
@@ -10,11 +10,19 @@ param (
     [UInt32]$RxFramesPerInterval = 0,
 
     [Parameter(Mandatory=$false)]
-    [UInt32]$TxFramesPerInterval = 0
+    [UInt32]$TxFramesPerInterval = 0,
+
+    [Parameter(Mandatory=$false)]
+    [switch]$Unlimited = $false
 )
 
 $Adapter = Get-NetAdapter -Name $AdapterName
 $IfDesc = $Adapter.InterfaceDescription
+
+if ($Unlimited) {
+    $RxFramesPerInterval = "0xFFFFFFFF"
+    $TxFramesPerInterval = "0xFFFFFFFF"
+}
 
 #
 # If the adapter was freshly restarted, this configuration can race with various

--- a/tools/xdpmpratesim.ps1
+++ b/tools/xdpmpratesim.ps1
@@ -4,7 +4,7 @@
 
 param (
     [Parameter(Mandatory=$true)]
-    [string]$AdapterName,
+    [string]$AdapterName = "XDPMP",
 
     [Parameter(Mandatory=$false)]
     [UInt32]$RxFramesPerInterval = 0,


### PR DESCRIPTION
It's currently unwieldy to allow XDPMP to run at full speed, so add a simple switch to the rate sim script.

Also set the default adapter name.

Before:
```.\tools\xdpmpratesim.ps1 -AdapterName XDPMP -RxFramesPerInterval "0xFFFFFFFF" -TxFramesPerInterval "0xFFFFFFFF"```

After:
```.\tools\xdpmpratesim.ps1 -Unlimited```