### PR TITLE
Add rxfilter helper script

### DIFF
--- a/tools/rxfilter.ps1
+++ b/tools/rxfilter.ps1
@@ -1,0 +1,38 @@
+param (
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("Debug", "Release")]
+    [string]$Config = "Debug",
+
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("x64", "arm64")]
+    [string]$Arch = "x64",
+
+    [Parameter(Mandatory = $false)]
+    [string]$AdapterName = "XDPMP",
+
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("System", "Generic", "Native")]
+    [string]$XdpMode = "System",
+
+    [Parameter(Mandatory = $false)]
+    [int]$QueueCount = 1,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Action = "Drop"
+)
+
+Set-StrictMode -Version 'Latest'
+$PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
+
+# Important paths.
+$RootDir = Split-Path $PSScriptRoot -Parent
+$ArtifactsDir = "$RootDir\artifacts\bin\$($Arch)_$($Config)"
+
+. $RootDir\tools\common.ps1
+
+for ($i = 0; $i -lt $QueueCount; $i++) {
+    Start-Process $ArtifactsDir\rxfilter.exe -ArgumentList `
+        "-IfIndex", (Get-NetAdapter -Name $AdapterName).ifIndex, `
+        "-QueueId", $i, "-MatchType" ,"All", "-Action", $Action, `
+        "-XdpMode", $XdpMode
+}


### PR DESCRIPTION
This script helps invoke the `rxfilter` sample program in a more user-friendly way, including scaling across queues.