### PR TITLE
Fix bug with xdpmpratesim.ps1 requiring a default AdapterName

### DIFF
--- a/tools/xdpmpratesim.ps1
+++ b/tools/xdpmpratesim.ps1
@@ -3,7 +3,7 @@
 #
 
 param (
-    [Parameter(Mandatory=$true)]
+    [Parameter(Mandatory=$false)]
     [string]$AdapterName = "XDPMP",
 
     [Parameter(Mandatory=$false)]


### PR DESCRIPTION
xdpmpratesim.ps1 specifies a default AdapterName, but the parameter is mandatory, which is not useful. Fix that.