### PR TITLE
XDPMP: add support for XDP_RX_ACTION_TX

### DIFF
--- a/test/xdpmp/miniport.c
+++ b/test/xdpmp/miniport.c
@@ -996,7 +996,8 @@ MpReadConfiguration(
     Adapter->RxBufferLength = DEFAULT_RX_BUFFER_LENGTH;
     TRY_READ_INT_CONFIGURATION(ConfigHandle, RegRxBufferLength, &Adapter->RxBufferLength);
     if (Adapter->RxBufferLength < MIN_RX_BUFFER_LENGTH ||
-        Adapter->RxBufferLength > MAX_RX_BUFFER_LENGTH) {
+        Adapter->RxBufferLength > MAX_RX_BUFFER_LENGTH ||
+        !RTL_IS_POWER_OF_TWO(Adapter->RxBufferLength)) {
         Status = NDIS_STATUS_INVALID_PARAMETER;
         goto Exit;
     }

--- a/test/xdpmp/miniport.h
+++ b/test/xdpmp/miniport.h
@@ -46,7 +46,10 @@ typedef struct {
     TX_SOURCE Source;
 } TX_SHADOW_DESCRIPTOR;
 
-typedef struct {
+typedef struct _ADAPTER_RX_QUEUE ADAPTER_RX_QUEUE;
+typedef struct _ADAPTER_TX_QUEUE ADAPTER_TX_QUEUE;
+
+typedef struct _ADAPTER_RX_QUEUE {
     XDP_QUEUE_STATE XdpState;
     BOOLEAN NeedFlush;
 
@@ -58,10 +61,14 @@ typedef struct {
     HW_RING *HwRing;
     UCHAR *BufferArray;
     UINT32 *RecycleArray;
+    UINT32 *RxTxArray;
+    CONST ADAPTER_TX_QUEUE *Tq;
     UINT32 NumBuffers;
     UINT32 BufferLength;
+    UINT32 BufferMask;
     UINT32 DataLength;
     UINT32 RecycleIndex;
+    UINT32 RxTxIndex;
 
     UINT32 RateSimFramesAvailable;
 
@@ -78,7 +85,7 @@ typedef struct {
     KEVENT *DeleteComplete;
 } ADAPTER_RX_QUEUE;
 
-typedef struct {
+typedef struct _ADAPTER_TX_QUEUE {
     XDP_QUEUE_STATE XdpState;
     BOOLEAN NeedFlush;
 
@@ -89,6 +96,7 @@ typedef struct {
 
     HW_RING *HwRing;
     TX_SHADOW_DESCRIPTOR *ShadowRing;
+    CONST ADAPTER_RX_QUEUE *Rq;
 
     UINT32 RateSimFramesAvailable;
 
@@ -107,7 +115,7 @@ typedef struct {
     KEVENT *DeleteComplete;
 } ADAPTER_TX_QUEUE;
 
-typedef struct DECLSPEC_CACHEALIGN {
+typedef struct DECLSPEC_CACHEALIGN _ADAPTER_QUEUE {
     UINT32 QueueId;
 
     ADAPTER_RX_QUEUE Rq;

--- a/test/xdpmp/rss.c
+++ b/test/xdpmp/rss.c
@@ -158,12 +158,12 @@ MpPopulateRssQueues(
         RssQueue->QueueId = Index;
         RssQueue->Adapter = Adapter;
 
-        Status = MpInitializeReceiveQueue(&RssQueue->Rq, Adapter);
+        Status = MpInitializeReceiveQueue(&RssQueue->Rq, RssQueue);
         if (Status != NDIS_STATUS_SUCCESS) {
             goto Exit;
         }
 
-        Status = MpInitializeTransmitQueue(&RssQueue->Tq, Adapter);
+        Status = MpInitializeTransmitQueue(&RssQueue->Tq, RssQueue);
         if (Status != NDIS_STATUS_SUCCESS) {
             goto Exit;
         }

--- a/test/xdpmp/rx.h
+++ b/test/xdpmp/rx.h
@@ -15,10 +15,23 @@ MpReceive(
     _Inout_ XDP_POLL_RECEIVE_DATA *XdpPoll
     );
 
+_IRQL_requires_max_(DISPATCH_LEVEL)
+VOID
+MpReceiveCompleteRxTx(
+    _In_ CONST ADAPTER_RX_QUEUE *Rq,
+    _In_ UINT64 LogicalAddress
+    );
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+VOID
+MpReceiveFlushRxTx(
+    _In_ CONST ADAPTER_RX_QUEUE *Rq
+    );
+
 NDIS_STATUS
 MpInitializeReceiveQueue(
     _Inout_ ADAPTER_RX_QUEUE *Rq,
-    _In_ CONST ADAPTER_CONTEXT *Adapter
+    _In_ CONST ADAPTER_QUEUE *RssQueue
     );
 
 VOID

--- a/test/xdpmp/tx.c
+++ b/test/xdpmp/tx.c
@@ -79,6 +79,7 @@ MpTransmitProcessCompletions(
     XDP_RING *FrameRing = NULL;
     UINT32 PreviousXdpConsumerIndex = 0;
     UINT32 XdpFramesCompleted = 0;
+    BOOLEAN RxTxCompleted = FALSE;
 
     if (XdpActive) {
         FrameRing = Tq->FrameRing;
@@ -102,7 +103,10 @@ MpTransmitProcessCompletions(
             Tq->Stats.TxFrames++;
             Tq->Stats.TxBytes += HwDescriptor->Length;
 
-            if (ShadowDescriptor->Source == TxSourceNdis) {
+            switch (ShadowDescriptor->Source) {
+
+            case TxSourceNdis:
+            {
                 NET_BUFFER_LIST **OwningNbl = MP_NB_GET_OWNING_NBL(ShadowDescriptor->Nb);
                 ULONG *OwningNblRefCount = MP_NBL_GET_REF_COUNT(*OwningNbl);
 
@@ -115,7 +119,12 @@ MpTransmitProcessCompletions(
                     //
                     Quota--;
                 }
-            } else {
+
+                break;
+            }
+
+            case TxSourceXdpTx:
+            {
                 ASSERT(XdpActive);
                 ASSERT((FrameRing->InterfaceReserved - FrameRing->ConsumerIndex) > 0);
 #if DBG
@@ -128,6 +137,21 @@ MpTransmitProcessCompletions(
                 Tq->XdpHwDescriptorsAvailable++;
                 XdpFramesCompleted++;
                 Quota--;
+
+                break;
+            }
+
+            case TxSourceXdpRx:
+            {
+                MpReceiveCompleteRxTx(Tq->Rq, HwDescriptor->LogicalAddress);
+                RxTxCompleted = TRUE;
+                XdpFramesCompleted++;
+                Quota--;
+                break;
+            }
+
+            default:
+                ASSERT(FALSE);
             }
         }
 
@@ -139,6 +163,10 @@ MpTransmitProcessCompletions(
         }
 
         HwRingConsPopElements(Tq->HwRing, Count);
+
+        if (RxTxCompleted) {
+            MpReceiveFlushRxTx(Tq->Rq);
+        }
     }
 
     if (NblChain->Count > 0) {
@@ -146,6 +174,24 @@ MpTransmitProcessCompletions(
     }
 
     return XdpFramesCompleted;
+}
+
+_IRQL_requires_max_(DISPATCH_LEVEL)
+VOID
+MpTransmitRxTx(
+    _In_ CONST ADAPTER_TX_QUEUE *Tq,
+    _In_ UINT32 HwIndex,
+    _In_ UINT64 LogicalAddress,
+    _In_ UINT32 DataLength
+    )
+{
+    TX_HW_DESCRIPTOR *HwDescriptor =
+        HwRingGetElement(Tq->HwRing, HwIndex & Tq->HwRing->Mask);
+    TX_SHADOW_DESCRIPTOR *ShadowDescriptor = &Tq->ShadowRing[(HwIndex) & Tq->HwRing->Mask];
+
+    HwDescriptor->LogicalAddress = LogicalAddress;
+    HwDescriptor->Length = DataLength;
+    ShadowDescriptor->Source = TxSourceXdpRx;
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL)
@@ -412,15 +458,17 @@ MpCleanupTransmitQueue(
 NDIS_STATUS
 MpInitializeTransmitQueue(
     _Inout_ ADAPTER_TX_QUEUE *Tq,
-    _In_ CONST ADAPTER_CONTEXT *Adapter
+    _In_ CONST ADAPTER_QUEUE *RssQueue
     )
 {
     NDIS_STATUS Status;
+    CONST ADAPTER_CONTEXT *Adapter = RssQueue->Adapter;
 
     Tq->NbQueueCount = 0;
     Tq->NbQueueHead = NULL;
     Tq->NbQueueTail = &Tq->NbQueueHead;
     Tq->NblRundown = Adapter->NblRundown;
+    Tq->Rq = &RssQueue->Rq;
     KeInitializeSpinLock(&Tq->NbQueueLock);
 
     Tq->XdpHwDescriptorsAvailable = Adapter->TxRingSize * Adapter->TxXdpQosPct / 100;

--- a/test/xdpmp/tx.h
+++ b/test/xdpmp/tx.h
@@ -15,10 +15,19 @@ MpTransmit(
     _Inout_ XDP_POLL_TRANSMIT_DATA *XdpPoll
     );
 
+_IRQL_requires_max_(DISPATCH_LEVEL)
+VOID
+MpTransmitRxTx(
+    _In_ CONST ADAPTER_TX_QUEUE *Tq,
+    _In_ UINT32 HwIndex,
+    _In_ UINT64 LogicalAddress,
+    _In_ UINT32 DataLength
+    );
+
 NDIS_STATUS
 MpInitializeTransmitQueue(
     _Inout_ ADAPTER_TX_QUEUE *Tq,
-    _In_ CONST ADAPTER_CONTEXT *Adapter
+    _In_ CONST ADAPTER_QUEUE *RssQueue
     );
 
 VOID


### PR DESCRIPTION
Add support for XDP_RX_ACTION_TX to XDPMP, which unblocks testing of _all_ eBPF programs via a native XDP driver.

Without support for XDP_RX_ACTION_TX or currently unobtainable static verifier analysis of the eBPF program, we don't know if it will return the TX action. Therefore, XDP must assume eBPF will return the TX action and reject any bindings to interfaces that do not support TX yet.