### PR TITLE
Fix leaked interface offload handle

### DIFF
--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -2030,11 +2030,11 @@ XdpProgramAttach(
             XdpIfGetInterfaceOffloadCapabilities(
                 IfSetHandle, InterfaceOffloadHandle,
                 XdpOffloadRss, &RssCapabilities, &RssCapabilitiesSize);
+        XdpIfCloseInterfaceOffloadHandle(IfSetHandle, InterfaceOffloadHandle);
         if (!NT_SUCCESS(Status)) {
             goto Exit;
         }
 
-        XdpIfCloseInterfaceOffloadHandle(IfSetHandle, InterfaceOffloadHandle);
         TraceInfo(
             TRACE_CORE, "Attaching ProgramObject=%p to all %u queues",
             ProgramObject, RssCapabilities.NumberOfReceiveQueues);


### PR DESCRIPTION
The interface offload handle opened in XdpProgramAttach is leaked in the failure path. See issue #151.