### PR TITLE
Relax assert for detached XSKs in RX bypass

### DIFF
--- a/src/rtl/inc/xdpassert.h
+++ b/src/rtl/inc/xdpassert.h
@@ -14,7 +14,14 @@
 #endif
 
 #ifdef KERNEL_MODE
+#if DBG
+// Ensure the system bugchecks if KD is disabled.
+#define ASSERT(e) \
+    ((NT_ASSERT_ASSUME(e)) ? \
+        TRUE : (KD_DEBUGGER_ENABLED ? FALSE : (RtlFailFast(FAST_FAIL_INVALID_ARG), FALSE)))
+#else
 #define ASSERT(e) NT_ASSERT_ASSUME(e)
+#endif
 #else
 #if DBG
 #define ASSERT(e) ((e) ? TRUE : (DbgRaiseAssertionFailure(), FALSE))

--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -1103,7 +1103,7 @@ XdpProgramGetXskBypassTarget(
     _In_ XDP_RX_QUEUE *RxQueue
     )
 {
-    UNREFERENCED_PARAMETER(RxQueue);
+    DBG_UNREFERENCED_PARAMETER(RxQueue);
 
     ASSERT(XdpProgramCanXskBypass(Program, RxQueue));
     return Program->Rules[0].Redirect.Target;
@@ -1635,7 +1635,7 @@ XdpProgramCanXskBypass(
         Program->Rules[0].Match == XDP_MATCH_ALL &&
         Program->Rules[0].Action == XDP_PROGRAM_ACTION_REDIRECT &&
         Program->Rules[0].Redirect.TargetType == XDP_REDIRECT_TARGET_TYPE_XSK &&
-        XskIsDatapathHandleQueueMatched(Program->Rules[0].Redirect.Target, RxQueue);
+        XskCanBypass(Program->Rules[0].Redirect.Target, RxQueue);
 }
 
 static

--- a/src/xdp/xsk.c
+++ b/src/xdp/xsk.c
@@ -1677,12 +1677,20 @@ XskValidateDatapathHandle(
 }
 
 BOOLEAN
-XskIsDatapathHandleQueueMatched(
+XskCanBypass(
     _In_ HANDLE XskHandle,
     _In_ XDP_RX_QUEUE *RxQueue
     )
 {
     XSK *Xsk = (XSK *)XskHandle;
+
+    //
+    // Allow XSKs that are terminally disconnected to bypass on any queue since
+    // the receive path becomes a NOP.
+    //
+    if (Xsk->State > XskActive && !Xsk->Rx.Xdp.Flags.DatapathAttached) {
+        return TRUE;
+    }
 
     if (Xsk->Rx.Xdp.Queue != RxQueue) {
         return FALSE;

--- a/src/xdp/xsk.h
+++ b/src/xdp/xsk.h
@@ -42,7 +42,7 @@ XskValidateDatapathHandle(
     );
 
 BOOLEAN
-XskIsDatapathHandleQueueMatched(
+XskCanBypass(
     _In_ HANDLE XskHandle,
     _In_ XDP_RX_QUEUE *RxQueue
     );


### PR DESCRIPTION
I'm hit an assert in local spinxsk testing where an XSK was fully disconnected while the RX queue was in bypass mode. This is a legitimate scenario, so relax the constraints to allow disconnected XSKs on this code path.

Also, ensure asserts in CI/CD on debug builds cause the machine to bugcheck - apparently Windows may absorb assertions depending on the system config.