### PR TITLE
Add TCP rules for CIBIR

### DIFF
--- a/published/external/xdp/program.h
+++ b/published/external/xdp/program.h
@@ -90,6 +90,17 @@ typedef enum _XDP_MATCH_TYPE {
     // The port number is specified by field Port in XDP_MATCH_PATTERN.
     //
     XDP_MATCH_TCP_DST,
+    //
+    // Match TCP destination port and QUIC source connection IDs in long header
+    // QUIC packets. The supplied buffer must match the CID at the given offset.
+    //
+    XDP_MATCH_TCP_QUIC_FLOW_SRC_CID,
+    //
+    // Match TCP destination port and QUIC destination connection IDs in short
+    // header QUIC packets. The supplied buffer must match the CID at the given
+    // offset.
+    //
+    XDP_MATCH_TCP_QUIC_FLOW_DST_CID,
 } XDP_MATCH_TYPE;
 
 typedef union _XDP_INET_ADDR {

--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -640,7 +640,9 @@ QuicCidMatch(
     _In_ CONST XDP_QUIC_FLOW *Flow
     )
 {
-    if ((Type == XDP_MATCH_QUIC_FLOW_SRC_CID) != (QuicHeader->QuicIsLongHeader == 1)) {
+    if ((Type == XDP_MATCH_QUIC_FLOW_SRC_CID ||
+         Type == XDP_MATCH_TCP_QUIC_FLOW_SRC_CID) !=
+        (QuicHeader->QuicIsLongHeader == 1)) {
         return FALSE;
     }
     ASSERT(Flow->CidOffset + Flow->CidLength <= QUIC_MAX_CID_LENGTH);
@@ -1046,6 +1048,34 @@ XdpInspect(
             }
             if (FrameCache.TcpValid &&
                 FrameCache.TcpHdr->th_dport == Rule->Pattern.Port) {
+                Matched = TRUE;
+            }
+            break;
+
+        case XDP_MATCH_TCP_QUIC_FLOW_SRC_CID:
+        case XDP_MATCH_TCP_QUIC_FLOW_DST_CID:
+            if (!FrameCache.TcpCached || !FrameCache.TransportPayloadCached) {
+                XdpParseFrame(
+                    Frame, FragmentRing, FragmentExtension, FragmentIndex, VirtualAddressExtension,
+                    &FrameCache, &Program->FrameStorage);
+            }
+
+            if (!FrameCache.TcpValid || !FrameCache.TransportPayloadValid ||
+                FrameCache.TcpHdr->th_dport != Rule->Pattern.QuicFlow.UdpPort) {
+                break;
+            }
+
+            if (!FrameCache.QuicCached) {
+                XdpParseQuicHeader(
+                    Frame, FragmentRing, FragmentExtension, FragmentIndex, VirtualAddressExtension,
+                    &FrameCache.TransportPayload, &Program->FrameStorage, &FrameCache);
+            }
+
+            if (FrameCache.QuicValid &&
+                QuicCidMatch(
+                    Rule->Match,
+                    &FrameCache,
+                    &Rule->Pattern.QuicFlow)) {
                 Matched = TRUE;
             }
             break;
@@ -1721,7 +1751,7 @@ XdpCaptureProgram(
         RtlZeroMemory(ValidatedRule, sizeof(*ValidatedRule));
         Program->RuleCount++;
 
-        if (UserRule.Match < XDP_MATCH_ALL || UserRule.Match > XDP_MATCH_TCP_DST) {
+        if (UserRule.Match < XDP_MATCH_ALL || UserRule.Match > XDP_MATCH_TCP_QUIC_FLOW_DST_CID) {
             Status = STATUS_INVALID_PARAMETER;
             goto Exit;
         }

--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -1232,10 +1232,30 @@ XdpProgramTraceObject(
                 WppHexDump(Rule->Pattern.QuicFlow.CidData, Rule->Pattern.QuicFlow.CidLength));
             break;
 
+        case XDP_MATCH_TCP_QUIC_FLOW_SRC_CID:
+            TraceInfo(
+                TRACE_CORE,
+                "Program=%p Rule[%u]=XDP_MATCH_TCP_QUIC_FLOW_SRC_CID "
+                "Port=%u CidOffset=%u CidLength=%u CidData=%!HEXDUMP!",
+                ProgramObject, i, ntohs(Rule->Pattern.QuicFlow.UdpPort),
+                Rule->Pattern.QuicFlow.CidOffset, Rule->Pattern.QuicFlow.CidLength,
+                WppHexDump(Rule->Pattern.QuicFlow.CidData, Rule->Pattern.QuicFlow.CidLength));
+            break;
+
         case XDP_MATCH_QUIC_FLOW_DST_CID:
             TraceInfo(
                 TRACE_CORE,
                 "Program=%p Rule[%u]=XDP_MATCH_QUIC_FLOW_DST_CID "
+                "Port=%u CidOffset=%u CidLength=%u CidData=%!HEXDUMP!",
+                ProgramObject, i, ntohs(Rule->Pattern.QuicFlow.UdpPort),
+                Rule->Pattern.QuicFlow.CidOffset, Rule->Pattern.QuicFlow.CidLength,
+                WppHexDump(Rule->Pattern.QuicFlow.CidData, Rule->Pattern.QuicFlow.CidLength));
+            break;
+
+        case XDP_MATCH_TCP_QUIC_FLOW_DST_CID:
+            TraceInfo(
+                TRACE_CORE,
+                "Program=%p Rule[%u]=XDP_MATCH_TCP_QUIC_FLOW_DST_CID "
                 "Port=%u CidOffset=%u CidLength=%u CidData=%!HEXDUMP!",
                 ProgramObject, i, ntohs(Rule->Pattern.QuicFlow.UdpPort),
                 Rule->Pattern.QuicFlow.CidOffset, Rule->Pattern.QuicFlow.CidLength,
@@ -1765,6 +1785,8 @@ XdpCaptureProgram(
         switch (ValidatedRule->Match) {
         case XDP_MATCH_QUIC_FLOW_SRC_CID:
         case XDP_MATCH_QUIC_FLOW_DST_CID:
+        case XDP_MATCH_TCP_QUIC_FLOW_SRC_CID:
+        case XDP_MATCH_TCP_QUIC_FLOW_DST_CID:
             if (UserRule.Pattern.QuicFlow.CidLength > RTL_FIELD_SIZE(XDP_QUIC_FLOW, CidData)) {
                 Status = STATUS_INVALID_PARAMETER;
                 goto Exit;

--- a/test/functional/lib/tests.h
+++ b/test/functional/lib/tests.h
@@ -65,7 +65,8 @@ GenericRxUdpFragmentQuicShortHeader(
 
 VOID
 GenericRxUdpFragmentQuicLongHeader(
-    _In_ ADDRESS_FAMILY Af
+    _In_ ADDRESS_FAMILY Af,
+    _In_ BOOLEAN IsUdp
     );
 
 VOID

--- a/test/functional/taef/tests.cpp
+++ b/test/functional/taef/tests.cpp
@@ -200,6 +200,22 @@ public:
         GenericRxMatch(AF_INET6, XDP_MATCH_QUIC_FLOW_DST_CID, TRUE);
     }
 
+    TEST_METHOD(GenericRxMatchTcpQuicSrcV4) {
+        GenericRxMatch(AF_INET, XDP_MATCH_TCP_QUIC_FLOW_SRC_CID, FALSE);
+    }
+
+    TEST_METHOD(GenericRxMatchTcpQuicSrcV6) {
+        GenericRxMatch(AF_INET6, XDP_MATCH_TCP_QUIC_FLOW_SRC_CID, FALSE);
+    }
+
+    TEST_METHOD(GenericRxMatchTcpQuicDstV4) {
+        GenericRxMatch(AF_INET, XDP_MATCH_TCP_QUIC_FLOW_DST_CID, FALSE);
+    }
+
+    TEST_METHOD(GenericRxMatchTcpQuicDstV6) {
+        GenericRxMatch(AF_INET6, XDP_MATCH_TCP_QUIC_FLOW_DST_CID, FALSE);
+    }
+
     TEST_METHOD(GenericRxMatchIpPrefixV4) {
         GenericRxMatchIpPrefix(AF_INET);
     }
@@ -277,11 +293,19 @@ public:
     }
 
     TEST_METHOD(GenericRxUdpFragmentQuicLongHeaderV4) {
-        GenericRxUdpFragmentQuicLongHeader(AF_INET);
+        GenericRxUdpFragmentQuicLongHeader(AF_INET, TRUE);
     }
 
     TEST_METHOD(GenericRxUdpFragmentQuicLongHeaderV6) {
-        GenericRxUdpFragmentQuicLongHeader(AF_INET6);
+        GenericRxUdpFragmentQuicLongHeader(AF_INET6, TRUE);
+    }
+
+    TEST_METHOD(GenericRxTcpFragmentQuicLongHeaderV4) {
+        GenericRxUdpFragmentQuicLongHeader(AF_INET, FALSE);
+    }
+
+    TEST_METHOD(GenericRxTcpFragmentQuicLongHeaderV6) {
+        GenericRxUdpFragmentQuicLongHeader(AF_INET6, FALSE);
     }
 
     TEST_METHOD(GenericRxUdpFragmentQuicShortHeaderV4) {


### PR DESCRIPTION
Added `XDP_MATCH_TCP_QUIC_FLOW_SRC_CID` and `XDP_MATCH_TCP_QUIC_FLOW_DST_CID` for QTIP to work in MsQuic.