### PR TITLE
Use dynamic linkage to UCRT runtime

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,31 +8,24 @@
 
 XDP for Windows consists of a usermode library (xdpapi.dll) and a driver (xdp.sys).
 
-- XDP requires the Microsoft Visual C++ Redistributable, which is available
-   [here](https://aka.ms/vs/17/release/vc_redist.x64.exe).
+If xdp.sys is not production-signed:
+```PowerShell
+CertUtil.exe -addstore Root CoreNetSignRoot.cer
+CertUtil.exe -addstore TrustedPublisher CoreNetSignRoot.cer
+bcdedit.exe /set testsigning on
+[reboot]
+```
 
-- Since XDP is not production-signed, configure Windows to load the test-signed
-   driver:
+Install:
+```PowerShell
+netcfg.exe -l .\xdp.inf -c s -i ms_xdp
+```
 
-    ```PowerShell
-    CertUtil.exe -addstore Root CoreNetSignRoot.cer
-    CertUtil.exe -addstore TrustedPublisher CoreNetSignRoot.cer
-    bcdedit.exe /set testsigning on
-    [reboot]
-    ```
-
-- Install the XDP driver and usermode library:
-
-    ```PowerShell
-    netcfg.exe -l .\xdp.inf -c s -i ms_xdp
-    ```
-
-- To uninstall the XDP driver and usermode library:
-
-    ```PowerShell
-    netcfg.exe -u ms_xdp
-    pnputil.exe /delete-driver xdp.inf
-    ```
+Uninstall:
+```PowerShell
+netcfg.exe -u ms_xdp
+pnputil.exe /delete-driver xdp.inf
+```
 
 ## Logging
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,24 +8,31 @@
 
 XDP for Windows consists of a usermode library (xdpapi.dll) and a driver (xdp.sys).
 
-If xdp.sys is not production-signed:
-```PowerShell
-CertUtil.exe -addstore Root CoreNetSignRoot.cer
-CertUtil.exe -addstore TrustedPublisher CoreNetSignRoot.cer
-bcdedit.exe /set testsigning on
-[reboot]
-```
+- XDP requires the Microsoft Visual C++ Redistributable, which is available
+   [here](https://aka.ms/vs/17/release/vc_redist.x64.exe).
 
-Install:
-```PowerShell
-netcfg.exe -l .\xdp.inf -c s -i ms_xdp
-```
+- Since XDP is not production-signed, configure Windows to load the test-signed
+   driver:
 
-Uninstall:
-```PowerShell
-netcfg.exe -u ms_xdp
-pnputil.exe /delete-driver xdp.inf
-```
+    ```PowerShell
+    CertUtil.exe -addstore Root CoreNetSignRoot.cer
+    CertUtil.exe -addstore TrustedPublisher CoreNetSignRoot.cer
+    bcdedit.exe /set testsigning on
+    [reboot]
+    ```
+
+- Install the XDP driver and usermode library:
+
+    ```PowerShell
+    netcfg.exe -l .\xdp.inf -c s -i ms_xdp
+    ```
+
+- To uninstall the XDP driver and usermode library:
+
+    ```PowerShell
+    netcfg.exe -u ms_xdp
+    pnputil.exe /delete-driver xdp.inf
+    ```
 
 ## Logging
 

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -125,7 +125,7 @@ function Setup-VcRuntime {
         Remove-Item -Force "artifacts\vc_redist.x64.exe" -ErrorAction Ignore
 
         # Download and install.
-        Invoke-WebRequest-WithRetry -Uri "https://aka.ms/vs/16/release/vc_redist.x64.exe" -OutFile "artifacts\vc_redist.x64.exe"
+        Invoke-WebRequest-WithRetry -Uri "https://aka.ms/vs/17/release/vc_redist.x64.exe" -OutFile "artifacts\vc_redist.x64.exe"
         Invoke-Expression -Command "artifacts\vc_redist.x64.exe /install /passive"
     }
 }

--- a/xdp.cpp.user.props
+++ b/xdp.cpp.user.props
@@ -5,6 +5,9 @@
     <ClCompile>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
+    <Link>
+      <AdditionalOptions>/NODEFAULTLIB:libucrtd.lib /DEFAULTLIB:ucrtd.lib</AdditionalOptions>
+    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
@@ -17,6 +20,7 @@
     </ClCompile>
     <Link>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <AdditionalOptions>/NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup>

--- a/xdp.cpp.user.props
+++ b/xdp.cpp.user.props
@@ -8,7 +8,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDll</RuntimeLibrary>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <PreprocessorDefinitions>
         USER_MODE=1;

--- a/xdp.cpp.user.props
+++ b/xdp.cpp.user.props
@@ -23,7 +23,4 @@
       <AdditionalOptions>/NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup>
-    <Link><AdditionalOptions>/NODEFAULTLIB:libucrt.lib</AdditionalOptions></Link>
-  </ItemDefinitionGroup>
 </Project>

--- a/xdp.cpp.user.props
+++ b/xdp.cpp.user.props
@@ -8,7 +8,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
-      <RuntimeLibrary>MultiThreadedDll</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <PreprocessorDefinitions>
         USER_MODE=1;
@@ -18,5 +18,8 @@
     <Link>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup>
+    <Link><AdditionalOptions>/NODEFAULTLIB:libucrt.lib</AdditionalOptions></Link>
   </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
Dynamically link to the UCRT provided by the OS for both debug and release builds.

The short term motivation is to enable the `errno` macro/variable shared across binary boundaries between eBPF and our tests. This also gives us slightly smaller binaries, servicing by Windows, etc.