### PR TITLE
Add TCP control rule

### DIFF
--- a/published/external/xdp/program.h
+++ b/published/external/xdp/program.h
@@ -101,6 +101,12 @@ typedef enum _XDP_MATCH_TYPE {
     // offset.
     //
     XDP_MATCH_TCP_QUIC_FLOW_DST_CID,
+    //
+    // Match frames with a specific TCP port number as their destination port and
+    // TCP control flags (SYN, FIN and RST). The port number is specified by field
+    // Port in XDP_MATCH_PATTERN.
+    //
+    XDP_MATCH_TCP_CONTROL_DST,
 } XDP_MATCH_TYPE;
 
 typedef union _XDP_INET_ADDR {

--- a/test/functional/lib/tests.h
+++ b/test/functional/lib/tests.h
@@ -38,6 +38,11 @@ GenericRxAllQueueRedirect(
     );
 
 VOID
+GenericRxTcpControl(
+    _In_ ADDRESS_FAMILY Af
+    );
+
+VOID
 GenericRxMatch(
     _In_ ADDRESS_FAMILY Af,
     _In_ XDP_MATCH_TYPE MatchType,

--- a/test/functional/taef/tests.cpp
+++ b/test/functional/taef/tests.cpp
@@ -152,6 +152,14 @@ public:
         ::FnMpNativeHandleTest();
     }
 
+    TEST_METHOD(GenericRxTcpControlV4) {
+        GenericRxTcpControl(AF_INET);
+    }
+
+    TEST_METHOD(GenericRxTcpControlV6) {
+        GenericRxTcpControl(AF_INET6);
+    }
+
     TEST_METHOD(GenericRxAllQueueRedirectV4) {
         GenericRxAllQueueRedirect(AF_INET);
     }


### PR DESCRIPTION
Due to the issue described in https://github.com/microsoft/msquic/pull/3462#issuecomment-1442727739, we need an extra rule to redirect packets with TCP controls (SYN/FIN/RST). I originally came up with the idea where the new rule should capture packets with actual payload but dealing with control flags is even simpler than checking IP payload length which has to done for both v4 and v6.