### PR TITLE
Revert "Use dynamic linkage to UCRT runtime"

### DIFF
--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -125,7 +125,7 @@ function Setup-VcRuntime {
         Remove-Item -Force "artifacts\vc_redist.x64.exe" -ErrorAction Ignore
 
         # Download and install.
-        Invoke-WebRequest-WithRetry -Uri "https://aka.ms/vs/17/release/vc_redist.x64.exe" -OutFile "artifacts\vc_redist.x64.exe"
+        Invoke-WebRequest-WithRetry -Uri "https://aka.ms/vs/16/release/vc_redist.x64.exe" -OutFile "artifacts\vc_redist.x64.exe"
         Invoke-Expression -Command "artifacts\vc_redist.x64.exe /install /passive"
     }
 }

--- a/xdp.cpp.user.props
+++ b/xdp.cpp.user.props
@@ -5,9 +5,6 @@
     <ClCompile>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
-    <Link>
-      <AdditionalOptions>/NODEFAULTLIB:libucrtd.lib /DEFAULTLIB:ucrtd.lib</AdditionalOptions>
-    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
@@ -20,7 +17,6 @@
     </ClCompile>
     <Link>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
-      <AdditionalOptions>/NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
Reverts microsoft/xdp-for-windows#160
Resolves #165 

#160 left WS2019 machines without a clean mechanism to install the UCRT dependencies. For now, just revert and go back to the static VCRT.