### PR TITLE
program: discard IPv4 packets with options

### DIFF
--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -459,7 +459,7 @@ XdpParseFragmentedIp4(
         XdpGetContiguousHeader(
             Frame, Buffer, BufferDataOffset, FragmentIndex, FragmentsRemaining, FragmentRing,
             VirtualAddressExtension, &Storage->Ip4Hdr, sizeof(Storage->Ip4Hdr), &Cache->Ip4Hdr) &&
-        (((UINT64) Cache->Ip4Hdr->HeaderLength) << 2) == sizeof(*Cache->Ip4Hdr);
+        (((UINT64)Cache->Ip4Hdr->HeaderLength) << 2) == sizeof(*Cache->Ip4Hdr);
 }
 
 static
@@ -692,7 +692,7 @@ XdpParseFrame(
             goto BufferTooSmall;
         }
         Cache->Ip4Hdr = (IPV4_HEADER *)&Va[Offset];
-        if ((((UINT64) Cache->Ip4Hdr->HeaderLength) << 2) != sizeof(*Cache->Ip4Hdr)) {
+        if ((((UINT64)Cache->Ip4Hdr->HeaderLength) << 2) != sizeof(*Cache->Ip4Hdr)) {
             return;
         }
         Cache->Ip4Valid = TRUE;

--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -458,7 +458,8 @@ XdpParseFragmentedIp4(
     Cache->Ip4Valid =
         XdpGetContiguousHeader(
             Frame, Buffer, BufferDataOffset, FragmentIndex, FragmentsRemaining, FragmentRing,
-            VirtualAddressExtension, &Storage->Ip4Hdr, sizeof(Storage->Ip4Hdr), &Cache->Ip4Hdr);
+            VirtualAddressExtension, &Storage->Ip4Hdr, sizeof(Storage->Ip4Hdr), &Cache->Ip4Hdr) &&
+        (((UINT64) Cache->Ip4Hdr->HeaderLength) << 2) == sizeof(*Cache->Ip4Hdr);
 }
 
 static
@@ -691,6 +692,9 @@ XdpParseFrame(
             goto BufferTooSmall;
         }
         Cache->Ip4Hdr = (IPV4_HEADER *)&Va[Offset];
+        if ((((UINT64) Cache->Ip4Hdr->HeaderLength) << 2) != sizeof(*Cache->Ip4Hdr)) {
+            return;
+        }
         Cache->Ip4Valid = TRUE;
         Offset += sizeof(*Cache->Ip4Hdr);
         IpProto = Cache->Ip4Hdr->Protocol;


### PR DESCRIPTION
IPv4 header is not always 20 bytes, as it can contain options (i.e. when HeaderLength > 5)