### PR TITLE
Trigger Azure Pipelines directly from GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,17 @@ concurrency:
 permissions: read-all
 
 jobs:
+  azure_ci:
+    name: Azure Pipelines CI
+    runs-on: ubuntu-latest
+    steps:
+    - name: Azure Pipelines CI
+      uses: Azure/pipelines@v1
+      with:
+        azure-devops-project-url: https://dev.azure.com/mscodehub/WindowsXDP
+        azure-pipeline-name: 'CI'
+        azure-devops-token: ${{ secrets.AZDO_PAT }}
+
   build:
     name: Build
     runs-on: windows-2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       with:
         azure-devops-project-url: https://dev.azure.com/mscodehub/WindowsXDP
         azure-pipeline-name: 'CI'
+        azure-pipelines-variables: '{"git_repo": "${{github.repository}}", "git_branch": "${{github.ref_name}}", "git_sha": "${{github.sha}}", "git_actor": "${{github.actor}}", "git_owner": "${{github.repository_owner}}"}'
         azure-devops-token: ${{ secrets.AZDO_PAT }}
 
   build:


### PR DESCRIPTION
Our Azure CI pipeline can't be run on branches outside this repo. Try triggering the pipeline directly from GitHub Actions.

Resolves #186 