### PR TITLE
Use volatile accessors for reads from user mode

### DIFF
--- a/src/rtl/inc/xdprtl.h
+++ b/src/rtl/inc/xdprtl.h
@@ -63,7 +63,7 @@ RtlUInt32RoundUpToPowerOfTwo(
     _In_ UINT32 Value,
     _Out_ UINT32 *Result
     );
-    
+
 _IRQL_requires_max_(APC_LEVEL)
 _Acquires_exclusive_lock_(Lock)
 VOID
@@ -91,6 +91,27 @@ VOID
 RtlReleasePushLockShared(
     _Inout_ EX_PUSH_LOCK *Lock
     );
+
+__forceinline
+VOID
+RtlCopyVolatileMemory(
+    _Out_writes_bytes_(Size) VOID *Destination,
+    _In_reads_bytes_(Size) volatile const VOID *Source,
+    _In_ SIZE_T Size
+    )
+{
+    RtlCopyMemory(Destination, (const VOID *)Source, Size);
+    _ReadWriteBarrier();
+}
+
+__forceinline
+HANDLE
+ReadHandleNoFence(
+    _In_reads_bytes_(sizeof(HANDLE)) volatile CONST HANDLE *Address
+    )
+{
+    return (HANDLE)ReadPointerNoFence((PVOID *)Address);
+}
 
 #else
 

--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -2057,7 +2057,7 @@ XdpCaptureProgram(
         if (RequestorMode != KernelMode) {
             ProbeForRead((VOID*)Rules, sizeof(*Rules) * RuleCount, PROBE_ALIGNMENT(XDP_RULE));
         }
-        RtlCopyMemory(ProgramObject->Program.Rules, Rules, sizeof(*Rules) * RuleCount);
+        RtlCopyVolatileMemory(ProgramObject->Program.Rules, Rules, sizeof(*Rules) * RuleCount);
     } __except (EXCEPTION_EXECUTE_HANDLER) {
         Status = GetExceptionCode();
         goto Exit;

--- a/src/xdp/xsk.c
+++ b/src/xdp/xsk.c
@@ -912,7 +912,7 @@ XskReferenceDatapathHandle(
     if (RequestorMode != KernelMode && !HandleBounced) {
         __try {
             ProbeForRead((VOID *)HandleBuffer, sizeof(HANDLE), PROBE_ALIGNMENT(HANDLE));
-            TargetHandle = ReadHandleNoFence(HandleBuffer);
+            TargetHandle = ReadHandleNoFence((volatile const HANDLE *)HandleBuffer);
         } __except (EXCEPTION_EXECUTE_HANDLER) {
             Status = GetExceptionCode();
             goto Exit;
@@ -3070,7 +3070,7 @@ XskSockoptShareUmem(
                 (VOID*)SockoptInputBuffer, SockoptInputBufferLength,
                 PROBE_ALIGNMENT(HANDLE));
         }
-        SharedUmemSock = ReadHandleNoFence(SockoptInputBuffer);
+        SharedUmemSock = ReadHandleNoFence((volatile const HANDLE *)SockoptInputBuffer);
     } __except (EXCEPTION_EXECUTE_HANDLER) {
         Status = GetExceptionCode();
         goto Exit;

--- a/src/xdp/xsk.c
+++ b/src/xdp/xsk.c
@@ -912,13 +912,13 @@ XskReferenceDatapathHandle(
     if (RequestorMode != KernelMode && !HandleBounced) {
         __try {
             ProbeForRead((VOID *)HandleBuffer, sizeof(HANDLE), PROBE_ALIGNMENT(HANDLE));
-            TargetHandle = *(HANDLE *)HandleBuffer;
+            TargetHandle = ReadHandleNoFence(HandleBuffer);
         } __except (EXCEPTION_EXECUTE_HANDLER) {
             Status = GetExceptionCode();
             goto Exit;
         }
     } else {
-        TargetHandle = *(HANDLE*)HandleBuffer;
+        TargetHandle = *(HANDLE *)HandleBuffer;
     }
 
     Status =
@@ -2924,7 +2924,7 @@ XskSockoptSetUmem(
                 (VOID*)SockoptInputBuffer, SockoptInputBufferLength,
                 PROBE_ALIGNMENT(XSK_UMEM_REG));
         }
-        Umem->Reg = *(XSK_UMEM_REG*)SockoptInputBuffer;
+        RtlCopyVolatileMemory(&Umem->Reg, SockoptInputBuffer, sizeof(XSK_UMEM_REG));
     } __except (EXCEPTION_EXECUTE_HANDLER) {
         Status = GetExceptionCode();
         goto Exit;
@@ -3070,7 +3070,7 @@ XskSockoptShareUmem(
                 (VOID*)SockoptInputBuffer, SockoptInputBufferLength,
                 PROBE_ALIGNMENT(HANDLE));
         }
-        SharedUmemSock = *(HANDLE*)SockoptInputBuffer;
+        SharedUmemSock = ReadHandleNoFence(SockoptInputBuffer);
     } __except (EXCEPTION_EXECUTE_HANDLER) {
         Status = GetExceptionCode();
         goto Exit;
@@ -3165,7 +3165,7 @@ XskSockoptSetRingSize(
         if (RequestorMode != KernelMode) {
             ProbeForRead((VOID*)SockoptInputBuffer, SockoptInputBufferLength, PROBE_ALIGNMENT(UINT32));
         }
-        NumDescriptors = *(UINT32 *)SockoptInputBuffer;
+        NumDescriptors = ReadUInt32NoFence(SockoptInputBuffer);
     } __except (EXCEPTION_EXECUTE_HANDLER) {
         Status = GetExceptionCode();
         goto Exit;
@@ -3408,7 +3408,7 @@ XskSockoptSetHookId(
         if (RequestorMode != KernelMode) {
             ProbeForRead((VOID*)SockoptIn, SockoptInSize, PROBE_ALIGNMENT(XDP_HOOK_ID));
         }
-        HookId = *(CONST XDP_HOOK_ID *)SockoptIn;
+        RtlCopyVolatileMemory(&HookId, SockoptIn, sizeof(XDP_HOOK_ID));
     } __except (EXCEPTION_EXECUTE_HANDLER) {
         Status = GetExceptionCode();
         goto Exit;
@@ -3718,7 +3718,7 @@ XskSockoptSetPollMode(
             ProbeForRead(
                 (VOID*)SockoptInputBuffer, SockoptInputBufferLength, PROBE_ALIGNMENT(XSK_POLL_MODE));
         }
-        PollMode = *(XSK_POLL_MODE *)SockoptInputBuffer;
+        RtlCopyVolatileMemory(&PollMode, SockoptInputBuffer, sizeof(XSK_POLL_MODE));
     } __except (EXCEPTION_EXECUTE_HANDLER) {
         Status = GetExceptionCode();
         goto Exit;
@@ -3978,9 +3978,9 @@ XskNotifyValidateParams(
                 (VOID*)InputBuffer, InputBufferLength, PROBE_ALIGNMENT(XSK_NOTIFY_IN));
         }
 
-        *InFlags = ((XSK_NOTIFY_IN*)InputBuffer)->Flags;
+        *InFlags = ReadUInt32NoFence((UINT32 *)&((XSK_NOTIFY_IN *)InputBuffer)->Flags);
         *TimeoutMilliseconds =
-            ((XSK_NOTIFY_IN*)InputBuffer)->WaitTimeoutMilliseconds;
+            ReadUInt32NoFence(&((XSK_NOTIFY_IN *)InputBuffer)->WaitTimeoutMilliseconds);
     } __except (EXCEPTION_EXECUTE_HANDLER) {
         return GetExceptionCode();
     }

--- a/test/common/lib/bounce/bounce.c
+++ b/test/common/lib/bounce/bounce.c
@@ -4,6 +4,7 @@
 //
 
 #include <ntddk.h>
+#include <xdprtl.h>
 #include "bounce.h"
 
 #define POOLTAG_BOUNCE          'BnfX' // XfnB
@@ -77,7 +78,7 @@ BounceBuffer(
 
     __try {
         ProbeForRead((VOID *)Buffer, BufferSize, Alignment);
-        RtlCopyMemory(Bounce->Buffer, Buffer, BufferSize);
+        RtlCopyVolatileMemory(Bounce->Buffer, Buffer, BufferSize);
     } __except (EXCEPTION_EXECUTE_HANDLER) {
         Status = GetExceptionCode();
         goto Exit;

--- a/test/common/lib/bounce/bounce.vcxproj
+++ b/test/common/lib/bounce/bounce.vcxproj
@@ -38,6 +38,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>
+        $(SolutionDir)src\rtl\inc;
         $(SolutionDir)test\common\inc;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>


### PR DESCRIPTION
Use volatile accessors for IO reads to avoid TOCTOU (i.e. double fetches) from user mode.

Resolves #179