### PR TITLE
Enable 1GB in-memory circular buffer for eBPF logging in spinxsk

### DIFF
--- a/tools/spinxsk.ps1
+++ b/tools/spinxsk.ps1
@@ -116,6 +116,7 @@ while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes))
     try {
         if (!$NoLogs) {
             & "$RootDir\tools\log.ps1" -Start -Name spinxsk -Profile SpinXsk.Verbose -Config $Config -Arch $Arch
+            & "$RootDir\tools\log.ps1" -Start -Name spinxskebpf -Profile SpinXskEbpf.Verbose -LogMode Memory -Config $Config -Arch $Arch
             & "$RootDir\tools\log.ps1" -Start -Name spinxskcpu -Profile CpuCswitchSample.Verbose -Config $Config -Arch $Arch
         }
         if ($XdpmpPollProvider -eq "FNDIS") {
@@ -180,6 +181,7 @@ while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes))
         }
         if (!$NoLogs) {
             & "$RootDir\tools\log.ps1" -Stop -Name spinxskcpu -Config $Config -Arch $Arch -ErrorAction 'Continue'
+            & "$RootDir\tools\log.ps1" -Stop -Name spinxskebpf -Config $Config -Arch $Arch -ErrorAction 'Continue'
             & "$RootDir\tools\log.ps1" -Stop -Name spinxsk -Config $Config -Arch $Arch -ErrorAction 'Continue'
         }
     }

--- a/tools/xdptrace.wprp
+++ b/tools/xdptrace.wprp
@@ -11,6 +11,10 @@
             <Buffers Value="5" PercentageOfTotalMemory="true"/>
         </EventCollector>
 
+        <EventCollector Id="EC_HighVolume1GB" Name="High Volume (1GB limit)" Base="EC_HighVolume">
+            <Buffers Value="20" PercentageOfTotalMemory="true" MaximumBufferSpace="1024"/>
+        </EventCollector>
+
         <SystemProvider Id="SystemProviderCpu">
             <Keywords>
                 <Keyword Value="ProcessThread"/>
@@ -132,6 +136,16 @@
             DetailLevel = "Verbose"
             Name = "SpinXsk"
             Description = "XDP SpinXsk Stress Test"/>
+
+        <Profile Id="SpinXskEbpf.Verbose.Memory" Name="SpinXskEbpf" Description="XDP SpinXsk Stress Test (eBPF)" LoggingMode="Memory" DetailLevel="Verbose">
+            <Collectors>
+                <EventCollectorId Value="EC_HighVolume1GB">
+                    <EventProviders>
+                        <EventProviderId Value="EP_EbpfEtw" />
+                    </EventProviders>
+                </EventCollectorId>
+            </Collectors>
+        </Profile>
 
         <Profile Id="CpuCswitchSample.Verbose.File" Name="CpuCswitchSample" Description="CPU precise and sampled profile" LoggingMode="File" DetailLevel="Verbose">
             <Collectors>


### PR DESCRIPTION
To capture eBPF logs without producing monstrous files or losing the traces when the kernel crashes, enable a 1GB in-memory circular buffer for eBPF logging in spinxsk.

#201 