### PR TITLE
Ensure EC passive worker gets boosted during cleanup

### DIFF
--- a/src/xdplwf/ec.c
+++ b/src/xdplwf/ec.c
@@ -333,6 +333,12 @@ XdpEcCleanup(
         Ec->CleanupComplete = NULL;
 
         Ec->CleanupPassiveThread = TRUE;
+        //
+        // Rather than setting the priority boost while setting the event, which
+        // is effective only if the thread was not already READY, permanently
+        // boost the thread priority to expedite cleanup.
+        //
+        KeSetPriorityThread(Ec->PassiveThread, LOW_REALTIME_PRIORITY);
         KeSetEvent(&Ec->PassiveEvent, 0, FALSE);
         KeWaitForSingleObject(Ec->PassiveThread, Executive, KernelMode, FALSE, NULL);
         ObDereferenceObject(Ec->PassiveThread);


### PR DESCRIPTION
A spinxsk watchdog failure with eBPF is being caused by the EC passive worker sitting in READY state while the data path is running. Ensure the EC passive worker gets to run at high priority during cleanup rundown.