### PR TITLE
Add bare minimum QEO offload support

### DIFF
--- a/published/external/xdp/rtl.h
+++ b/published/external/xdp/rtl.h
@@ -15,6 +15,11 @@ extern "C" {
     ((VOID *)((ULONG_PTR)(Pointer) + (ULONG_PTR)(Value)))
 #endif
 
+#ifndef RTL_PTR_SUBTRACT
+#define RTL_PTR_SUBTRACT(Pointer, Value) \
+    ((PVOID)((ULONG_PTR)(Pointer) - (ULONG_PTR)(Value)))
+#endif
+
 #if (!defined(NTDDI_WIN10_CO) || (WDK_NTDDI_VERSION < NTDDI_WIN10_CO)) && \
     !defined(UINT32_VOLATILE_ACCESSORS)
 #define UINT32_VOLATILE_ACCESSORS

--- a/published/private/xdpif.h
+++ b/published/private/xdpif.h
@@ -36,6 +36,7 @@
 
 #pragma once
 
+#include <xdpapi.h>
 #include <xdp/control.h>
 #include <xdpifmode.h>
 
@@ -93,6 +94,7 @@ XDP_DELETE_INTERFACE_SET_COMPLETE(
 
 typedef enum {
     XdpOffloadRss,
+    XdpOffloadQeo,
 } XDP_INTERFACE_OFFLOAD_TYPE;
 
 typedef enum {
@@ -145,6 +147,12 @@ typedef struct _XDP_OFFLOAD_PARAMS_RSC {
     XDP_OFFLOAD_STATE Ipv4;
     XDP_OFFLOAD_STATE Ipv6;
 } XDP_OFFLOAD_PARAMS_RSC;
+
+typedef struct _XDP_OFFLOAD_PARAMS_QEO {
+    const XDP_QUIC_CONNECTION *Connections;
+    UINT32 ConnectionsSize;
+    UINT32 ConnectionCount;
+} XDP_OFFLOAD_PARAMS_QEO;
 
 //
 // Open an interface queue offload configuration handle.
@@ -236,7 +244,10 @@ XDP_SET_INTERFACE_OFFLOAD(
     _In_ VOID *InterfaceOffloadHandle,
     _In_ XDP_INTERFACE_OFFLOAD_TYPE OffloadType,
     _In_ VOID *OffloadParams,
-    _In_ UINT32 OffloadParamsSize
+    _In_ UINT32 OffloadParamsSize,
+    _Out_writes_bytes_opt_(*OffloadResultWritten) VOID *OffloadResult,
+    _In_ UINT32 OffloadResultSize,
+    _Out_opt_ UINT32 *OffloadResultWritten
     );
 
 //

--- a/src/xdp/bind.c
+++ b/src/xdp/bind.c
@@ -764,14 +764,19 @@ XdpIfSetInterfaceOffload(
     _In_ VOID *InterfaceOffloadHandle,
     _In_ XDP_INTERFACE_OFFLOAD_TYPE OffloadType,
     _In_ VOID *OffloadParams,
-    _In_ UINT32 OffloadParamsSize
+    _In_ UINT32 OffloadParamsSize,
+    _Out_writes_bytes_opt_(*OffloadResultWritten) VOID *OffloadResult,
+    _In_ UINT32 OffloadResultSize,
+    _Out_opt_ UINT32 *OffloadResultWritten
     )
 {
     XDP_INTERFACE_SET *IfSet = (XDP_INTERFACE_SET *)IfSetHandle;
 
+    #pragma warning(suppress:6001) // Using uninitialized memory '*OffloadResultWritten'
     return
         IfSet->OffloadDispatch->SetInterfaceOffload(
-            InterfaceOffloadHandle, OffloadType, OffloadParams, OffloadParamsSize);
+            InterfaceOffloadHandle, OffloadType, OffloadParams, OffloadParamsSize, OffloadResult,
+            OffloadResultSize, OffloadResultWritten);
 }
 
 NTSTATUS

--- a/src/xdp/bind.h
+++ b/src/xdp/bind.h
@@ -119,7 +119,10 @@ XdpIfSetInterfaceOffload(
     _In_ VOID *InterfaceOffloadHandle,
     _In_ XDP_INTERFACE_OFFLOAD_TYPE OffloadType,
     _In_ VOID *OffloadParams,
-    _In_ UINT32 OffloadParamsSize
+    _In_ UINT32 OffloadParamsSize,
+    _Out_writes_bytes_opt_(*OffloadResultWritten) VOID *OffloadResult,
+    _In_ UINT32 OffloadResultSize,
+    _Out_opt_ UINT32 *OffloadResultWritten
     );
 
 NTSTATUS

--- a/src/xdp/offload.c
+++ b/src/xdp/offload.c
@@ -407,8 +407,8 @@ XdpIrpInterfaceOffloadQeoSet(
         if ((UINT32)ConnectionsIn->Operation > (UINT32)XDP_QUIC_OPERATION_REMOVE ||
             (UINT32)ConnectionsIn->Direction > (UINT32)XDP_QUIC_DIRECTION_RECEIVE ||
             (UINT32)ConnectionsIn->DecryptFailureAction > (UINT32)XDP_QUIC_DECRYPT_FAILURE_ACTION_CONTINUE ||
-            (UINT32)ConnectionsIn->KeyPhase != 0 ||
-            (UINT32)ConnectionsIn->RESERVED != 0 ||
+            ConnectionsIn->KeyPhase != 0 ||
+            ConnectionsIn->RESERVED != 0 ||
             (UINT32)ConnectionsIn->CipherType > (UINT32)XDP_QUIC_CIPHER_TYPE_AEAD_AES_128_CCM ||
             (UINT32)ConnectionsIn->AddressFamily > (UINT32)XDP_QUIC_ADDRESS_FAMILY_INET6 ||
             ConnectionsIn->ConnectionIdLength > sizeof(ConnectionsIn->ConnectionId)) {

--- a/src/xdp/offload.c
+++ b/src/xdp/offload.c
@@ -407,7 +407,6 @@ XdpIrpInterfaceOffloadQeoSet(
         if ((UINT32)ConnectionsIn->Operation > (UINT32)XDP_QUIC_OPERATION_REMOVE ||
             (UINT32)ConnectionsIn->Direction > (UINT32)XDP_QUIC_DIRECTION_RECEIVE ||
             (UINT32)ConnectionsIn->DecryptFailureAction > (UINT32)XDP_QUIC_DECRYPT_FAILURE_ACTION_CONTINUE ||
-            ConnectionsIn->KeyPhase != 0 ||
             ConnectionsIn->RESERVED != 0 ||
             (UINT32)ConnectionsIn->CipherType > (UINT32)XDP_QUIC_CIPHER_TYPE_AEAD_AES_128_CCM ||
             (UINT32)ConnectionsIn->AddressFamily > (UINT32)XDP_QUIC_ADDRESS_FAMILY_INET6 ||

--- a/src/xdp/offload.c
+++ b/src/xdp/offload.c
@@ -341,7 +341,7 @@ XdpIrpInterfaceOffloadRssSet(
     Status =
         XdpIfSetInterfaceOffload(
             InterfaceObject->IfSetHandle, InterfaceObject->InterfaceOffloadHandle,
-            XdpOffloadRss, &RssParams, sizeof(RssParams));
+            XdpOffloadRss, &RssParams, sizeof(RssParams), NULL, 0, NULL);
 
 Exit:
 
@@ -362,10 +362,87 @@ XdpIrpInterfaceOffloadQeoSet(
     _In_ IO_STACK_LOCATION *IrpSp
     )
 {
-    UNREFERENCED_PARAMETER(InterfaceObject);
-    UNREFERENCED_PARAMETER(Irp);
-    UNREFERENCED_PARAMETER(IrpSp);
-    return STATUS_NOT_IMPLEMENTED;
+    NTSTATUS Status;
+    XDP_OFFLOAD_PARAMS_QEO QeoParams = {0};
+    const XDP_QUIC_CONNECTION *ConnectionsIn = Irp->AssociatedIrp.SystemBuffer;
+    UINT32 InputBufferLength = IrpSp->Parameters.DeviceIoControl.InputBufferLength;
+    UINT32 OutputBufferLength = IrpSp->Parameters.DeviceIoControl.InputBufferLength;
+    UINT32 BytesWritten = 0;
+
+    TraceEnter(TRACE_CORE, "Interface=%p", InterfaceObject);
+
+    if (InputBufferLength == 0) {
+        Status = STATUS_INVALID_PARAMETER;
+        goto Exit;
+    }
+
+    QeoParams.Connections = ConnectionsIn;
+    QeoParams.ConnectionsSize = InputBufferLength;
+    QeoParams.ConnectionCount = 0;
+
+    while (InputBufferLength > 0) {
+        //
+        // Validate input.
+        //
+
+        if (InputBufferLength < sizeof(ConnectionsIn->Header) ||
+            InputBufferLength < ConnectionsIn->Header.Size) {
+            TraceError(
+                TRACE_CORE,
+                "Interface=%p Input buffer length too small InputBufferLength=%u",
+                InterfaceObject, InputBufferLength);
+            Status = STATUS_INVALID_PARAMETER;
+            goto Exit;
+        }
+
+        if (ConnectionsIn->Header.Revision != XDP_QUIC_CONNECTION_REVISION_1 ||
+            ConnectionsIn->Header.Size < XDP_SIZEOF_QUIC_CONNECTION_REVISION_1) {
+            TraceError(
+                TRACE_CORE, "Interface=%p Unsupported revision Revision=%u Size=%u",
+                InterfaceObject, ConnectionsIn->Header.Revision, ConnectionsIn->Header.Size);
+            Status = STATUS_INVALID_PARAMETER;
+            goto Exit;
+        }
+
+        if ((UINT32)ConnectionsIn->Operation > (UINT32)XDP_QUIC_OPERATION_REMOVE ||
+            (UINT32)ConnectionsIn->Direction > (UINT32)XDP_QUIC_DIRECTION_RECEIVE ||
+            (UINT32)ConnectionsIn->DecryptFailureAction > (UINT32)XDP_QUIC_DECRYPT_FAILURE_ACTION_CONTINUE ||
+            (UINT32)ConnectionsIn->KeyPhase != 0 ||
+            (UINT32)ConnectionsIn->RESERVED != 0 ||
+            (UINT32)ConnectionsIn->CipherType > (UINT32)XDP_QUIC_CIPHER_TYPE_AEAD_AES_128_CCM ||
+            (UINT32)ConnectionsIn->AddressFamily > (UINT32)XDP_QUIC_ADDRESS_FAMILY_INET6 ||
+            ConnectionsIn->ConnectionIdLength > sizeof(ConnectionsIn->ConnectionId)) {
+            Status = STATUS_INVALID_PARAMETER;
+            goto Exit;
+        }
+
+        InputBufferLength -= ConnectionsIn->Header.Size;
+        ConnectionsIn = RTL_PTR_ADD(ConnectionsIn, ConnectionsIn->Header.Size);
+        QeoParams.ConnectionCount++;
+    }
+
+    ASSERT(InputBufferLength == 0);
+    InputBufferLength = IrpSp->Parameters.DeviceIoControl.InputBufferLength;
+
+    //
+    // Issue the internal request to the interface.
+    //
+    Status =
+        XdpIfSetInterfaceOffload(
+            InterfaceObject->IfSetHandle, InterfaceObject->InterfaceOffloadHandle,
+            XdpOffloadQeo, &QeoParams, sizeof(QeoParams), Irp->AssociatedIrp.SystemBuffer,
+            OutputBufferLength, &BytesWritten);
+    if (!NT_SUCCESS(Status)) {
+        goto Exit;
+    }
+
+    Irp->IoStatus.Information = BytesWritten;
+
+Exit:
+
+    TraceExitStatus(TRACE_CORE);
+
+    return Status;
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL)

--- a/src/xdp/offload.c
+++ b/src/xdp/offload.c
@@ -407,7 +407,6 @@ XdpIrpInterfaceOffloadQeoSet(
         if ((UINT32)ConnectionsIn->Operation > (UINT32)XDP_QUIC_OPERATION_REMOVE ||
             (UINT32)ConnectionsIn->Direction > (UINT32)XDP_QUIC_DIRECTION_RECEIVE ||
             (UINT32)ConnectionsIn->DecryptFailureAction > (UINT32)XDP_QUIC_DECRYPT_FAILURE_ACTION_CONTINUE ||
-            ConnectionsIn->RESERVED != 0 ||
             (UINT32)ConnectionsIn->CipherType > (UINT32)XDP_QUIC_CIPHER_TYPE_AEAD_AES_128_CCM ||
             (UINT32)ConnectionsIn->AddressFamily > (UINT32)XDP_QUIC_ADDRESS_FAMILY_INET6 ||
             ConnectionsIn->ConnectionIdLength > sizeof(ConnectionsIn->ConnectionId)) {

--- a/src/xdpapi/xdpapi.c
+++ b/src/xdpapi/xdpapi.c
@@ -180,16 +180,16 @@ XdpRssGet(
 HRESULT
 XdpQeoSet(
     _In_ HANDLE InterfaceHandle,
-    _In_ CONST XDP_QEO_CONFIGURATION *QeoConfiguration,
-    _In_ UINT32 QeoConfigurationSize
+    _Inout_ XDP_QUIC_CONNECTION *QuicConnections,
+    _In_ UINT32 QuicConnectionsSize
     )
 {
     BOOL Success =
         XdpIoctl(
             InterfaceHandle, IOCTL_INTERFACE_OFFLOAD_QEO_SET,
-            (XDP_QEO_CONFIGURATION *)QeoConfiguration, QeoConfigurationSize,
-            (XDP_QEO_CONFIGURATION *)QeoConfiguration, QeoConfigurationSize,
-            (ULONG *)&QeoConfigurationSize, NULL, TRUE);
+            QuicConnections, QuicConnectionsSize,
+            QuicConnections, QuicConnectionsSize,
+            (ULONG *)&QuicConnectionsSize, NULL, TRUE);
     if (!Success) {
         return HRESULT_FROM_WIN32(GetLastError());
     }

--- a/src/xdplwf/bind.c
+++ b/src/xdplwf/bind.c
@@ -98,9 +98,13 @@ XdpLwfBindStart(
 #if DBG
     FChars.OidRequestHandler                = XdpVfLwfOidRequest;
     FChars.OidRequestCompleteHandler        = XdpVfLwfOidRequestComplete;
+    FChars.DirectOidRequestHandler          = XdpVfLwfDirectOidRequest;
+    FChars.DirectOidRequestCompleteHandler  = XdpVfLwfDirectOidRequestComplete;
 #else
     FChars.OidRequestHandler                = XdpLwfOidRequest;
     FChars.OidRequestCompleteHandler        = XdpLwfOidRequestComplete;
+    FChars.DirectOidRequestHandler          = XdpLwfDirectOidRequest;
+    FChars.DirectOidRequestCompleteHandler  = XdpLwfOidDirectRequestComplete;
 #endif
 
     Status = NdisFRegisterFilterDriver(DriverObject, NULL, &FChars, &XdpLwfNdisDriverHandle);

--- a/src/xdplwf/bind.c
+++ b/src/xdplwf/bind.c
@@ -104,7 +104,7 @@ XdpLwfBindStart(
     FChars.OidRequestHandler                = XdpLwfOidRequest;
     FChars.OidRequestCompleteHandler        = XdpLwfOidRequestComplete;
     FChars.DirectOidRequestHandler          = XdpLwfDirectOidRequest;
-    FChars.DirectOidRequestCompleteHandler  = XdpLwfOidDirectRequestComplete;
+    FChars.DirectOidRequestCompleteHandler  = XdpLwfDirectOidRequestComplete;
 #endif
 
     Status = NdisFRegisterFilterDriver(DriverObject, NULL, &FChars, &XdpLwfNdisDriverHandle);

--- a/src/xdplwf/native.c
+++ b/src/xdplwf/native.c
@@ -57,8 +57,8 @@ XdpNativeAttachInterface(
 
     Status =
         XdpLwfOidInternalRequest(
-            Native->NdisFilterHandle, NdisRequestQueryInformation,
-            OID_XDP_QUERY_CAPABILITIES, NULL, 0, 0, 0, &BytesReturned);
+            Native->NdisFilterHandle, XDP_OID_REQUEST_INTERFACE_REGULAR,
+            NdisRequestQueryInformation, OID_XDP_QUERY_CAPABILITIES, NULL, 0, 0, 0, &BytesReturned);
 
     if (Status != STATUS_BUFFER_TOO_SMALL) {
         if (!NT_VERIFY(!NT_SUCCESS(Status))) {
@@ -91,8 +91,8 @@ XdpNativeAttachInterface(
 
     Status =
         XdpLwfOidInternalRequest(
-            Native->NdisFilterHandle, NdisRequestQueryInformation,
-            OID_XDP_QUERY_CAPABILITIES, CapabilitiesEx,
+            Native->NdisFilterHandle, XDP_OID_REQUEST_INTERFACE_REGULAR,
+            NdisRequestQueryInformation, OID_XDP_QUERY_CAPABILITIES, CapabilitiesEx,
             BytesReturned, 0, 0, &BytesReturned);
     if (!NT_SUCCESS(Status)) {
         goto Exit;

--- a/src/xdplwf/offload.c
+++ b/src/xdplwf/offload.c
@@ -1217,12 +1217,11 @@ XdpLwfOffloadQeoSet(
 
     TraceEnter(TRACE_LWF, "Filter=%p OffloadContext=%p", Filter, OffloadContext);
 
-    ASSERT(XdpQeoParams != NULL && XdpQeoParamsSize == sizeof(*XdpQeoParams));
-    ASSERT(XdpQeoParams->ConnectionCount > 0);
-
     RtlAcquirePushLockExclusive(&Filter->Offload.Lock);
 
-    if (OffloadResultSize < XdpQeoParams->ConnectionsSize) {
+    if (XdpQeoParamsSize != sizeof(*XdpQeoParams) ||
+        XdpQeoParams->ConnectionCount == 0 ||
+        OffloadResultSize < XdpQeoParams->ConnectionsSize) {
         Status = STATUS_INVALID_PARAMETER;
         goto Exit;
     }

--- a/src/xdplwf/offload.c
+++ b/src/xdplwf/offload.c
@@ -30,53 +30,12 @@ typedef struct _XDP_LWF_INTERFACE_OFFLOAD_CONTEXT {
 
 #define RSS_HASH_SECRET_KEY_MAX_SIZE NDIS_RSS_HASH_SECRET_KEY_MAX_SIZE_REVISION_2
 
-static
-NTSTATUS
-XdpLwfOpenInterfaceOffloadHandle(
-    _In_ XDP_LWF_FILTER *Filter,
-    _In_ CONST XDP_HOOK_ID *HookId,
-    _Out_ VOID **InterfaceOffloadHandle
-    );
-
-static
-VOID
-XdpLwfCloseInterfaceOffloadHandle(
-    _In_ VOID *InterfaceOffloadHandle
-    );
-
-static
-NTSTATUS
-XdpLwfGetInterfaceOffloadCapabilities(
-    _In_ VOID *InterfaceOffloadHandle,
-    _In_ XDP_INTERFACE_OFFLOAD_TYPE OffloadType,
-    _Out_opt_ VOID *OffloadCapabilities,
-    _Inout_ UINT32 *OffloadCapabilitiesSize
-    );
-
-static
-NTSTATUS
-XdpLwfGetInterfaceOffload(
-    _In_ VOID *InterfaceOffloadHandle,
-    _In_ XDP_INTERFACE_OFFLOAD_TYPE OffloadType,
-    _Out_opt_ VOID *OffloadParams,
-    _Inout_ UINT32 *OffloadParamsSize
-    );
-
-static
-NTSTATUS
-XdpLwfSetInterfaceOffload(
-    _In_ VOID *InterfaceOffloadHandle,
-    _In_ XDP_INTERFACE_OFFLOAD_TYPE OffloadType,
-    _In_ VOID *OffloadParams,
-    _In_ UINT32 OffloadParamsSize
-    );
-
-static
-NTSTATUS
-XdpLwfReferenceInterfaceOffload(
-    _In_ VOID *InterfaceOffloadHandle,
-    _In_ XDP_INTERFACE_OFFLOAD_TYPE OffloadType
-    );
+static XDP_OPEN_INTERFACE_OFFLOAD_HANDLE XdpLwfOpenInterfaceOffloadHandle;
+static XDP_GET_INTERFACE_OFFLOAD_CAPABILITIES XdpLwfGetInterfaceOffloadCapabilities;
+static XDP_GET_INTERFACE_OFFLOAD XdpLwfGetInterfaceOffload;
+static XDP_SET_INTERFACE_OFFLOAD XdpLwfSetInterfaceOffload;
+static XDP_REFERENCE_INTERFACE_OFFLOAD XdpLwfReferenceInterfaceOffload;
+static XDP_CLOSE_INTERFACE_OFFLOAD_HANDLE XdpLwfCloseInterfaceOffloadHandle;
 
 CONST XDP_OFFLOAD_DISPATCH XdpLwfOffloadDispatch = {
     .OpenInterfaceOffloadHandle = XdpLwfOpenInterfaceOffloadHandle,
@@ -638,7 +597,7 @@ RemoveLowerEdgeRssSetting(
 
     Status =
         XdpLwfOidInternalRequest(
-            Filter->NdisFilterHandle, NdisRequestSetInformation,
+            Filter->NdisFilterHandle, XDP_OID_REQUEST_INTERFACE_REGULAR, NdisRequestSetInformation,
             OID_GEN_RECEIVE_SCALE_PARAMETERS, NdisRssParams, NdisRssParamsLength, 0, 0,
             &BytesReturned);
     if (!NT_SUCCESS(Status)) {
@@ -690,17 +649,16 @@ DereferenceRssSetting(
 }
 
 static
-_Requires_lock_held_(&Filter->Offload.Lock)
 NTSTATUS
 XdpLwfOffloadRssSet(
     _In_ XDP_LWF_FILTER *Filter,
     _In_ XDP_LWF_INTERFACE_OFFLOAD_CONTEXT *OffloadContext,
     _In_ XDP_OFFLOAD_PARAMS_RSS *RssParams,
-    _In_ UINT32 RssParamsLength,
-    _Out_ BOOLEAN *AttachRxDatapath
+    _In_ UINT32 RssParamsLength
     )
 {
     NTSTATUS Status;
+    BOOLEAN AttachRxDatapath = FALSE;
     ULONG *BitmapBuffer = NULL;
     XDP_LWF_OFFLOAD_SETTING_RSS *RssSetting = NULL;
     XDP_LWF_OFFLOAD_SETTING_RSS *OldRssSetting = NULL;
@@ -713,7 +671,16 @@ XdpLwfOffloadRssSet(
     ASSERT(RssParams != NULL);
     ASSERT(RssParamsLength == sizeof(*RssParams));
 
-    *AttachRxDatapath = FALSE;
+    RtlAcquirePushLockExclusive(&Filter->Offload.Lock);
+
+    if (OffloadContext->IsInvalid) {
+        TraceError(
+            TRACE_LWF,
+            "OffloadContext=%p Interface offload context invalidated",
+            OffloadContext);
+        Status = STATUS_INVALID_DEVICE_STATE;
+        goto Exit;
+    }
 
     //
     // Determine the appropriate edge.
@@ -920,7 +887,7 @@ XdpLwfOffloadRssSet(
 
     Status =
         XdpLwfOidInternalRequest(
-            Filter->NdisFilterHandle, NdisRequestSetInformation,
+            Filter->NdisFilterHandle, XDP_OID_REQUEST_INTERFACE_REGULAR, NdisRequestSetInformation,
             OID_GEN_RECEIVE_SCALE_PARAMETERS, NdisRssParams, NdisRssParamsLength, 0, 0,
             &BytesReturned);
     if (!NT_SUCCESS(Status)) {
@@ -943,7 +910,7 @@ XdpLwfOffloadRssSet(
     RssSetting = NULL;
 
     if (OldRssSetting == NULL) {
-        *AttachRxDatapath = TRUE;
+        AttachRxDatapath = TRUE;
     } else {
         DereferenceRssSetting(OldRssSetting, Filter);
     }
@@ -965,6 +932,12 @@ Exit:
     }
 
     XdpGenericRssFreeIndirection(&Indirection);
+
+    RtlReleasePushLockExclusive(&Filter->Offload.Lock);
+
+    if (AttachRxDatapath) {
+        XdpGenericAttachDatapath(&Filter->Generic, TRUE, FALSE);
+    }
 
     return Status;
 }
@@ -1126,8 +1099,8 @@ XdpLwfOffloadRssInitialize(
 
     Status =
         XdpLwfOidInternalRequest(
-            Filter->NdisFilterHandle, NdisRequestQueryInformation,
-            OID_GEN_RECEIVE_SCALE_CAPABILITIES, &RssCaps,
+            Filter->NdisFilterHandle, XDP_OID_REQUEST_INTERFACE_REGULAR,
+            NdisRequestQueryInformation, OID_GEN_RECEIVE_SCALE_CAPABILITIES, &RssCaps,
             sizeof(RssCaps), 0, 0, &BytesReturned);
     if (!NT_SUCCESS(Status) && Status != STATUS_NOT_SUPPORTED) {
         TraceError(
@@ -1147,8 +1120,8 @@ XdpLwfOffloadRssInitialize(
 
     Status =
         XdpLwfOidInternalRequest(
-            Filter->NdisFilterHandle, NdisRequestQueryInformation,
-            OID_GEN_RECEIVE_SCALE_PARAMETERS, NdisRssParams, 0, 0, 0,
+            Filter->NdisFilterHandle, XDP_OID_REQUEST_INTERFACE_REGULAR,
+            NdisRequestQueryInformation, OID_GEN_RECEIVE_SCALE_PARAMETERS, NdisRssParams, 0, 0, 0,
             &BytesReturned);
     if (Status != STATUS_BUFFER_TOO_SMALL || BytesReturned == 0) {
         if (Status == STATUS_NOT_SUPPORTED) {
@@ -1173,9 +1146,9 @@ XdpLwfOffloadRssInitialize(
 
     Status =
         XdpLwfOidInternalRequest(
-            Filter->NdisFilterHandle, NdisRequestQueryInformation,
-            OID_GEN_RECEIVE_SCALE_PARAMETERS, NdisRssParams, BytesReturned, 0, 0,
-            &BytesReturned);
+            Filter->NdisFilterHandle, XDP_OID_REQUEST_INTERFACE_REGULAR,
+            NdisRequestQueryInformation, OID_GEN_RECEIVE_SCALE_PARAMETERS, NdisRssParams,
+            BytesReturned, 0, 0, &BytesReturned);
     if (!NT_SUCCESS(Status)) {
         TraceError(
             TRACE_LWF,
@@ -1226,13 +1199,256 @@ XdpLwfOffloadRssDeactivate(
 
 static
 NTSTATUS
-XdpLwfOpenInterfaceOffloadHandle(
+XdpLwfOffloadQeoSet(
     _In_ XDP_LWF_FILTER *Filter,
+    _In_ XDP_LWF_INTERFACE_OFFLOAD_CONTEXT *OffloadContext,
+    _In_ const XDP_OFFLOAD_PARAMS_QEO *XdpQeoParams,
+    _In_ UINT32 XdpQeoParamsSize,
+    _Out_opt_ VOID *OffloadResult,
+    _In_ UINT32 OffloadResultSize,
+    _Out_opt_ UINT32 *OffloadResultWritten
+    )
+{
+    NTSTATUS Status;
+    const XDP_QUIC_CONNECTION *XdpQeoConnection;
+    NDIS_QUIC_CONNECTION *NdisConnections = NULL;
+    UINT32 NdisConnectionsSize;
+    ULONG NdisBytesReturned;
+
+    TraceEnter(TRACE_LWF, "Filter=%p OffloadContext=%p", Filter, OffloadContext);
+
+    ASSERT(XdpQeoParams != NULL && XdpQeoParamsSize == sizeof(*XdpQeoParams));
+    ASSERT(XdpQeoParams->ConnectionCount > 0);
+
+    RtlAcquirePushLockExclusive(&Filter->Offload.Lock);
+
+    if (OffloadResultSize < XdpQeoParams->ConnectionsSize) {
+        Status = STATUS_INVALID_PARAMETER;
+        goto Exit;
+    }
+
+    if (OffloadContext->IsInvalid) {
+        TraceError(
+            TRACE_LWF,
+            "OffloadContext=%p Interface offload context invalidated",
+            OffloadContext);
+        Status = STATUS_INVALID_DEVICE_STATE;
+        goto Exit;
+    }
+
+    if (OffloadContext->Edge != XdpOffloadEdgeLower) {
+        Status = STATUS_NOT_SUPPORTED;
+        goto Exit;
+    }
+
+    //
+    // Clone the input params.
+    //
+
+    Status =
+        RtlUInt32Mult(
+            XdpQeoParams->ConnectionCount, sizeof(*NdisConnections), &NdisConnectionsSize);
+    if (!NT_SUCCESS(Status)) {
+        goto Exit;
+    }
+
+    NdisConnections = ExAllocatePoolZero(NonPagedPoolNx, NdisConnectionsSize, POOLTAG_OFFLOAD);
+    if (NdisConnections == NULL) {
+        TraceError(
+            TRACE_LWF, "OffloadContext=%p Failed to allocate NDIS connections", OffloadContext);
+        Status = STATUS_NO_MEMORY;
+        goto Exit;
+    }
+
+    //
+    // Form and issue the OID.
+    //
+
+    XdpQeoConnection = XdpQeoParams->Connections;
+
+    for (UINT32 i = 0; i < XdpQeoParams->ConnectionCount; i++) {
+        NDIS_QUIC_CONNECTION *NdisConnection = &NdisConnections[i];
+
+        switch (XdpQeoConnection->Operation) {
+        case XDP_QUIC_OPERATION_ADD:
+            NdisConnection->Operation = NDIS_QUIC_OPERATION_ADD;
+            break;
+        case XDP_QUIC_OPERATION_REMOVE:
+            NdisConnection->Operation = NDIS_QUIC_OPERATION_REMOVE;
+            break;
+        default:
+            ASSERT(FALSE);
+            Status = STATUS_INVALID_PARAMETER;
+            goto Exit;
+        }
+
+        switch (XdpQeoConnection->Direction) {
+        case XDP_QUIC_DIRECTION_TRANSMIT:
+            NdisConnection->Operation = NDIS_QUIC_DIRECTION_TRANSMIT;
+            break;
+        case XDP_QUIC_DIRECTION_RECEIVE:
+            NdisConnection->Operation = NDIS_QUIC_DIRECTION_RECEIVE;
+            break;
+        default:
+            ASSERT(FALSE);
+            Status = STATUS_INVALID_PARAMETER;
+            goto Exit;
+        }
+
+        switch (XdpQeoConnection->DecryptFailureAction) {
+        case XDP_QUIC_DECRYPT_FAILURE_ACTION_DROP:
+            NdisConnection->Operation = NDIS_QUIC_DECRYPT_FAILURE_ACTION_DROP;
+            break;
+        case XDP_QUIC_DECRYPT_FAILURE_ACTION_CONTINUE:
+            NdisConnection->Operation = NDIS_QUIC_DECRYPT_FAILURE_ACTION_CONTINUE;
+            break;
+        default:
+            ASSERT(FALSE);
+            Status = STATUS_INVALID_PARAMETER;
+            goto Exit;
+        }
+
+        switch (XdpQeoConnection->CipherType) {
+        case XDP_QUIC_CIPHER_TYPE_AEAD_AES_128_GCM:
+            NdisConnection->Operation = NDIS_QUIC_CIPHER_TYPE_AEAD_AES_128_GCM;
+            break;
+        case XDP_QUIC_CIPHER_TYPE_AEAD_AES_256_GCM:
+            NdisConnection->Operation = NDIS_QUIC_CIPHER_TYPE_AEAD_AES_256_GCM;
+            break;
+        case XDP_QUIC_CIPHER_TYPE_AEAD_CHACHA20_POLY1305:
+            NdisConnection->Operation = NDIS_QUIC_CIPHER_TYPE_AEAD_CHACHA20_POLY1305;
+            break;
+        case XDP_QUIC_CIPHER_TYPE_AEAD_AES_128_CCM:
+            NdisConnection->Operation = NDIS_QUIC_CIPHER_TYPE_AEAD_AES_128_CCM;
+            break;
+        default:
+            ASSERT(FALSE);
+            Status = STATUS_INVALID_PARAMETER;
+            goto Exit;
+        }
+
+        switch (XdpQeoConnection->AddressFamily) {
+        case XDP_QUIC_ADDRESS_FAMILY_INET4:
+            NdisConnection->Operation = NDIS_QUIC_ADDRESS_FAMILY_INET4;
+            break;
+        case XDP_QUIC_ADDRESS_FAMILY_INET6:
+            NdisConnection->Operation = NDIS_QUIC_ADDRESS_FAMILY_INET6;
+            break;
+        default:
+            ASSERT(FALSE);
+            Status = STATUS_INVALID_PARAMETER;
+            goto Exit;
+        }
+
+        NdisConnection->UdpPort = XdpQeoConnection->UdpPort;
+        NdisConnection->NextPacketNumber = XdpQeoConnection->NextPacketNumber;
+        NdisConnection->ConnectionIdLength = XdpQeoConnection->ConnectionIdLength;
+
+        C_ASSERT(sizeof(NdisConnection->Address) >= sizeof(XdpQeoConnection->Address));
+        RtlCopyMemory(
+            NdisConnection->Address, XdpQeoConnection->Address,
+            sizeof(XdpQeoConnection->Address));
+
+        C_ASSERT(sizeof(NdisConnection->ConnectionId) >= sizeof(XdpQeoConnection->ConnectionId));
+        RtlCopyMemory(
+            NdisConnection->ConnectionId, XdpQeoConnection->ConnectionId,
+            sizeof(XdpQeoConnection->ConnectionId));
+
+        C_ASSERT(sizeof(NdisConnection->PayloadKey) >= sizeof(XdpQeoConnection->PayloadKey));
+        RtlCopyMemory(
+            NdisConnection->PayloadKey, XdpQeoConnection->PayloadKey,
+            sizeof(XdpQeoConnection->PayloadKey));
+
+        C_ASSERT(sizeof(NdisConnection->HeaderKey) >= sizeof(XdpQeoConnection->HeaderKey));
+        RtlCopyMemory(
+            NdisConnection->HeaderKey, XdpQeoConnection->HeaderKey,
+            sizeof(XdpQeoConnection->HeaderKey));
+
+        C_ASSERT(sizeof(NdisConnection->PayloadIv) >= sizeof(XdpQeoConnection->PayloadIv));
+        RtlCopyMemory(
+            NdisConnection->PayloadIv, XdpQeoConnection->PayloadIv,
+            sizeof(XdpQeoConnection->PayloadIv));
+
+        NdisConnection->Status = NDIS_STATUS_PENDING;
+
+        //
+        // Advance to the next input connection.
+        //
+        XdpQeoConnection = RTL_PTR_ADD(XdpQeoConnection, XdpQeoConnection->Header.Size);
+    }
+
+    Status =
+        XdpLwfOidInternalRequest(
+            Filter->NdisFilterHandle, XDP_OID_REQUEST_INTERFACE_DIRECT, NdisRequestMethod,
+            OID_QUIC_CONNECTION_ENCRYPTION, NdisConnections, NdisConnectionsSize,
+            NdisConnectionsSize, 0, &NdisBytesReturned);
+    if (!NT_SUCCESS(Status)) {
+        TraceError(
+            TRACE_LWF,
+            "OffloadContext=%p Failed OID_QUIC_CONNECTION_ENCRYPTION Status=%!STATUS!",
+            OffloadContext, Status);
+        goto Exit;
+    }
+
+    if (!NT_VERIFY(NdisBytesReturned == NdisConnectionsSize)) {
+        TraceError(
+            TRACE_LWF,
+            "OffloadContext=%p OID_QUIC_CONNECTION_ENCRYPTION unexpected NdisBytesReturned=%u",
+            OffloadContext, NdisBytesReturned);
+        Status = STATUS_DEVICE_DATA_ERROR;
+        goto Exit;
+    }
+
+    //
+    // Initialize the XDP output buffer with the data from the input buffer
+    // before updating each connection's offload status code.
+    //
+    RtlMoveMemory(OffloadResult, XdpQeoParams->Connections, XdpQeoParams->ConnectionsSize);
+
+    //
+    // Use the immutable, validated input buffer to walk the output array: the
+    // output buffer may be writable by user mode, so we treat it as strictly
+    // write-only.
+    //
+    XdpQeoConnection = XdpQeoParams->Connections;
+
+    for (UINT32 i = 0; i < XdpQeoParams->ConnectionCount; i++) {
+        NDIS_QUIC_CONNECTION *NdisConnection = &NdisConnections[i];
+        XDP_QUIC_CONNECTION *XdpQeoConnectionResult =
+            RTL_PTR_ADD(OffloadResult,
+                RTL_PTR_SUBTRACT(XdpQeoConnection, XdpQeoParams->Connections));
+
+        XdpQeoConnectionResult->Status =
+            HRESULT_FROM_WIN32(RtlNtStatusToDosErrorNoTeb(NdisConnection->Status));
+
+        XdpQeoConnection = RTL_PTR_ADD(XdpQeoConnection, XdpQeoConnection->Header.Size);
+    }
+
+    *OffloadResultWritten = XdpQeoParams->ConnectionsSize;
+
+Exit:
+
+    if (NdisConnections != NULL) {
+        ExFreePoolWithTag(NdisConnections, POOLTAG_OFFLOAD);
+    }
+
+    RtlReleasePushLockExclusive(&Filter->Offload.Lock);
+
+    TraceExitStatus(TRACE_LWF);
+
+    return Status;
+}
+
+static
+NTSTATUS
+XdpLwfOpenInterfaceOffloadHandle(
+    _In_ VOID *InterfaceContext,
     _In_ CONST XDP_HOOK_ID *HookId,
     _Out_ VOID **InterfaceOffloadHandle
     )
 {
     NTSTATUS Status;
+    XDP_LWF_FILTER *Filter = InterfaceContext;
     XDP_LWF_INTERFACE_OFFLOAD_CONTEXT *OffloadContext = NULL;
 
     RtlAcquirePushLockExclusive(&Filter->Offload.Lock);
@@ -1418,45 +1634,36 @@ XdpLwfSetInterfaceOffload(
     _In_ VOID *InterfaceOffloadHandle,
     _In_ XDP_INTERFACE_OFFLOAD_TYPE OffloadType,
     _In_ VOID *OffloadParams,
-    _In_ UINT32 OffloadParamsSize
+    _In_ UINT32 OffloadParamsSize,
+    _Out_writes_bytes_opt_(*OffloadResultWritten) VOID *OffloadResult,
+    _In_ UINT32 OffloadResultSize,
+    _Out_opt_ UINT32 *OffloadResultWritten
     )
 {
     NTSTATUS Status;
     XDP_LWF_INTERFACE_OFFLOAD_CONTEXT *OffloadContext = InterfaceOffloadHandle;
     XDP_LWF_FILTER *Filter = OffloadContext->Filter;
-    BOOLEAN AttachRxDatapath = FALSE;
 
     TraceEnter(TRACE_LWF, "OffloadContext=%p OffloadType=%u", OffloadContext, OffloadType);
 
-    RtlAcquirePushLockExclusive(&Filter->Offload.Lock);
-
-    if (OffloadContext->IsInvalid) {
-        TraceError(
-            TRACE_LWF,
-            "OffloadContext=%p Interface offload context invalidated",
-            OffloadContext);
-        Status = STATUS_INVALID_DEVICE_STATE;
-        goto Exit;
+    if (OffloadResultWritten != NULL) {
+        *OffloadResultWritten = 0;
     }
 
     switch (OffloadType) {
     case XdpOffloadRss:
+        Status = XdpLwfOffloadRssSet(Filter, OffloadContext, OffloadParams, OffloadParamsSize);
+        break;
+    case XdpOffloadQeo:
         Status =
-            XdpLwfOffloadRssSet(
-                Filter, OffloadContext, OffloadParams, OffloadParamsSize, &AttachRxDatapath);
+            XdpLwfOffloadQeoSet(
+                Filter, OffloadContext, OffloadParams, OffloadParamsSize, OffloadResult,
+                OffloadResultSize, OffloadResultWritten);
         break;
     default:
         TraceError(TRACE_LWF, "OffloadContext=%p Unsupported offload", OffloadContext);
         Status = STATUS_NOT_SUPPORTED;
         break;
-    }
-
-Exit:
-
-    RtlReleasePushLockExclusive(&Filter->Offload.Lock);
-
-    if (AttachRxDatapath) {
-        XdpGenericAttachDatapath(&Filter->Generic, TRUE, FALSE);
     }
 
     TraceExitStatus(TRACE_LWF);

--- a/src/xdplwf/offload.c
+++ b/src/xdplwf/offload.c
@@ -1284,10 +1284,10 @@ XdpLwfOffloadQeoSet(
 
         switch (XdpQeoConnection->Direction) {
         case XDP_QUIC_DIRECTION_TRANSMIT:
-            NdisConnection->Operation = NDIS_QUIC_DIRECTION_TRANSMIT;
+            NdisConnection->Direction = NDIS_QUIC_DIRECTION_TRANSMIT;
             break;
         case XDP_QUIC_DIRECTION_RECEIVE:
-            NdisConnection->Operation = NDIS_QUIC_DIRECTION_RECEIVE;
+            NdisConnection->Direction = NDIS_QUIC_DIRECTION_RECEIVE;
             break;
         default:
             ASSERT(FALSE);
@@ -1297,10 +1297,10 @@ XdpLwfOffloadQeoSet(
 
         switch (XdpQeoConnection->DecryptFailureAction) {
         case XDP_QUIC_DECRYPT_FAILURE_ACTION_DROP:
-            NdisConnection->Operation = NDIS_QUIC_DECRYPT_FAILURE_ACTION_DROP;
+            NdisConnection->DecryptFailureAction = NDIS_QUIC_DECRYPT_FAILURE_ACTION_DROP;
             break;
         case XDP_QUIC_DECRYPT_FAILURE_ACTION_CONTINUE:
-            NdisConnection->Operation = NDIS_QUIC_DECRYPT_FAILURE_ACTION_CONTINUE;
+            NdisConnection->DecryptFailureAction = NDIS_QUIC_DECRYPT_FAILURE_ACTION_CONTINUE;
             break;
         default:
             ASSERT(FALSE);
@@ -1310,16 +1310,16 @@ XdpLwfOffloadQeoSet(
 
         switch (XdpQeoConnection->CipherType) {
         case XDP_QUIC_CIPHER_TYPE_AEAD_AES_128_GCM:
-            NdisConnection->Operation = NDIS_QUIC_CIPHER_TYPE_AEAD_AES_128_GCM;
+            NdisConnection->CipherType = NDIS_QUIC_CIPHER_TYPE_AEAD_AES_128_GCM;
             break;
         case XDP_QUIC_CIPHER_TYPE_AEAD_AES_256_GCM:
-            NdisConnection->Operation = NDIS_QUIC_CIPHER_TYPE_AEAD_AES_256_GCM;
+            NdisConnection->CipherType = NDIS_QUIC_CIPHER_TYPE_AEAD_AES_256_GCM;
             break;
         case XDP_QUIC_CIPHER_TYPE_AEAD_CHACHA20_POLY1305:
-            NdisConnection->Operation = NDIS_QUIC_CIPHER_TYPE_AEAD_CHACHA20_POLY1305;
+            NdisConnection->CipherType = NDIS_QUIC_CIPHER_TYPE_AEAD_CHACHA20_POLY1305;
             break;
         case XDP_QUIC_CIPHER_TYPE_AEAD_AES_128_CCM:
-            NdisConnection->Operation = NDIS_QUIC_CIPHER_TYPE_AEAD_AES_128_CCM;
+            NdisConnection->CipherType = NDIS_QUIC_CIPHER_TYPE_AEAD_AES_128_CCM;
             break;
         default:
             ASSERT(FALSE);
@@ -1329,10 +1329,10 @@ XdpLwfOffloadQeoSet(
 
         switch (XdpQeoConnection->AddressFamily) {
         case XDP_QUIC_ADDRESS_FAMILY_INET4:
-            NdisConnection->Operation = NDIS_QUIC_ADDRESS_FAMILY_INET4;
+            NdisConnection->AddressFamily = NDIS_QUIC_ADDRESS_FAMILY_INET4;
             break;
         case XDP_QUIC_ADDRESS_FAMILY_INET6:
-            NdisConnection->Operation = NDIS_QUIC_ADDRESS_FAMILY_INET6;
+            NdisConnection->AddressFamily = NDIS_QUIC_ADDRESS_FAMILY_INET6;
             break;
         default:
             ASSERT(FALSE);

--- a/src/xdplwf/offload.c
+++ b/src/xdplwf/offload.c
@@ -1308,6 +1308,8 @@ XdpLwfOffloadQeoSet(
             goto Exit;
         }
 
+        NdisConnection->KeyPhase = XdpQeoConnection->KeyPhase;
+
         switch (XdpQeoConnection->CipherType) {
         case XDP_QUIC_CIPHER_TYPE_AEAD_AES_128_GCM:
             NdisConnection->CipherType = NDIS_QUIC_CIPHER_TYPE_AEAD_AES_128_GCM;

--- a/src/xdplwf/oid.h
+++ b/src/xdplwf/oid.h
@@ -12,16 +12,26 @@ typedef enum _XDP_OID_ACTION {
 
 FILTER_OID_REQUEST XdpLwfOidRequest;
 FILTER_OID_REQUEST_COMPLETE XdpLwfOidRequestComplete;
+FILTER_DIRECT_OID_REQUEST XdpLwfDirectOidRequest;
+FILTER_DIRECT_OID_REQUEST_COMPLETE XdpLwfDirectOidRequestComplete;
 
 #if DBG
 FILTER_OID_REQUEST XdpVfLwfOidRequest;
 FILTER_OID_REQUEST_COMPLETE XdpVfLwfOidRequestComplete;
+FILTER_DIRECT_OID_REQUEST XdpVfLwfDirectOidRequest;
+FILTER_DIRECT_OID_REQUEST_COMPLETE XdpVfLwfDirectOidRequestComplete;
 #endif
+
+typedef enum _XDP_OID_REQUEST_INTERFACE {
+    XDP_OID_REQUEST_INTERFACE_REGULAR,
+    XDP_OID_REQUEST_INTERFACE_DIRECT,
+} XDP_OID_REQUEST_INTERFACE;
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
 XdpLwfOidInternalRequest(
     _In_ NDIS_HANDLE NdisFilterHandle,
+    _In_ XDP_OID_REQUEST_INTERFACE RequestInterface,
     _In_ NDIS_REQUEST_TYPE RequestType,
     _In_ NDIS_OID Oid,
     _Inout_updates_bytes_to_(InformationBufferLength, *pBytesProcessed)

--- a/src/xdplwf/precomp.h
+++ b/src/xdplwf/precomp.h
@@ -16,6 +16,7 @@
 #include <ndis/ndl/nblclassify.h>
 #include <netiodef.h>
 #include <qeo_ndis.h>
+#include <winerror.h>
 
 #define XDPEXPORT(RoutineName) RoutineName##Thunk
 

--- a/src/xdplwf/rss.c
+++ b/src/xdplwf/rss.c
@@ -371,8 +371,8 @@ XdpGenericRssInitialize(
 
     Status =
         XdpLwfOidInternalRequest(
-            Generic->NdisFilterHandle, NdisRequestQueryInformation,
-            OID_GEN_RECEIVE_SCALE_CAPABILITIES, &RssCaps,
+            Generic->NdisFilterHandle, XDP_OID_REQUEST_INTERFACE_REGULAR,
+            NdisRequestQueryInformation, OID_GEN_RECEIVE_SCALE_CAPABILITIES, &RssCaps,
             sizeof(RssCaps), 0, 0, &BytesReturned);
     if (!NT_SUCCESS(Status) && Status != STATUS_NOT_SUPPORTED) {
         goto Exit;
@@ -459,8 +459,8 @@ XdpGenericRssInitialize(
 
     Status =
         XdpLwfOidInternalRequest(
-            Generic->NdisFilterHandle, NdisRequestQueryInformation,
-            OID_GEN_RECEIVE_SCALE_PARAMETERS, RssParams, 0, 0, 0,
+            Generic->NdisFilterHandle, XDP_OID_REQUEST_INTERFACE_REGULAR,
+            NdisRequestQueryInformation, OID_GEN_RECEIVE_SCALE_PARAMETERS, RssParams, 0, 0, 0,
             &BytesReturned);
     if (Status != STATUS_BUFFER_TOO_SMALL || BytesReturned == 0) {
         if (Status == STATUS_NOT_SUPPORTED) {
@@ -479,9 +479,9 @@ XdpGenericRssInitialize(
 
     Status =
         XdpLwfOidInternalRequest(
-            Generic->NdisFilterHandle, NdisRequestQueryInformation,
-            OID_GEN_RECEIVE_SCALE_PARAMETERS, RssParams, BytesReturned, 0, 0,
-            &BytesReturned);
+            Generic->NdisFilterHandle, XDP_OID_REQUEST_INTERFACE_REGULAR,
+            NdisRequestQueryInformation, OID_GEN_RECEIVE_SCALE_PARAMETERS, RssParams, BytesReturned,
+            0, 0, &BytesReturned);
     if (!NT_SUCCESS(Status)) {
         goto Exit;
     }

--- a/test/common/inc/xdpndisuser.h
+++ b/test/common/inc/xdpndisuser.h
@@ -20,7 +20,7 @@ extern "C" {
 #define OID_TCP_OFFLOAD_CURRENT_CONFIG          0xFC01020B  // query only, handled by NDIS
 #define OID_TCP_OFFLOAD_PARAMETERS              0xFC01020C  // set only
 #define OID_TCP_OFFLOAD_HARDWARE_CAPABILITIES   0xFC01020D  // query only
-
+#define OID_TCP_TASK_IPSEC_OFFLOAD_V2_UPDATE_SA 0xFC030204
 
 typedef ULONG NDIS_OID, *PNDIS_OID;
 

--- a/test/common/lib/util/util.cpp
+++ b/test/common/lib/util/util.cpp
@@ -171,7 +171,7 @@ StartServiceAsync(
 
     FRE_ASSERT(CloseServiceHandle(SvcHandle));
 
-    return S_OK;
+    return Result;
 }
 
 EXTERN_C

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -6530,6 +6530,7 @@ OffloadQeoConnection()
     for (const auto &Operation : QeoOperationMap) {
     for (const auto &Direction : QeoDirectionMap) {
     for (const auto &DecryptFailureAction : QeoDecryptFailureActionMap) {
+    for (const auto &KeyPhase : {0U, 1U}) {
     for (const auto &CipherType : QeoCipherTypeMap) {
     for (const auto &AddressFamily : QeoAddressFamilyMap) {
         auto If = FnMpIf;
@@ -6544,6 +6545,7 @@ OffloadQeoConnection()
         Connection.Operation = Operation.Xdp;
         Connection.Direction = Direction.Xdp;
         Connection.DecryptFailureAction = DecryptFailureAction.Xdp;
+        Connection.KeyPhase = KeyPhase;
         Connection.CipherType = CipherType.Xdp;
         Connection.AddressFamily = AddressFamily.Xdp;
         Connection.UdpPort = htons(1234);
@@ -6591,6 +6593,7 @@ OffloadQeoConnection()
         TEST_EQUAL((UINT32)Operation.Ndis, NdisConnection->Operation);
         TEST_EQUAL((UINT32)Direction.Ndis, NdisConnection->Direction);
         TEST_EQUAL((UINT32)DecryptFailureAction.Ndis, NdisConnection->DecryptFailureAction);
+        TEST_EQUAL(KeyPhase, NdisConnection->KeyPhase);
         TEST_EQUAL((UINT32)CipherType.Ndis, NdisConnection->CipherType);
         TEST_EQUAL(AddressFamily.Ndis, NdisConnection->AddressFamily);
         TEST_EQUAL(Connection.UdpPort, NdisConnection->UdpPort);
@@ -6637,7 +6640,7 @@ OffloadQeoConnection()
         // status.
         //
         TEST_HRESULT(Connection.Status);
-    }}}}}
+    }}}}}}
 }
 
 /**

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -6458,113 +6458,186 @@ GenericXskQueryAffinity()
     }
 }
 
+static const struct {
+    XDP_QUIC_OPERATION Xdp;
+    NDIS_QUIC_OPERATION Ndis;
+} QeoOperationMap[] = {
+    {
+        XDP_QUIC_OPERATION_ADD, NDIS_QUIC_OPERATION_ADD
+    },
+    {
+        XDP_QUIC_OPERATION_REMOVE, NDIS_QUIC_OPERATION_REMOVE
+    },
+};
+
+static const struct {
+    XDP_QUIC_DIRECTION Xdp;
+    NDIS_QUIC_DIRECTION Ndis;
+} QeoDirectionMap[] = {
+    {
+        XDP_QUIC_DIRECTION_TRANSMIT, NDIS_QUIC_DIRECTION_TRANSMIT
+    },
+    {
+        XDP_QUIC_DIRECTION_RECEIVE, NDIS_QUIC_DIRECTION_RECEIVE
+    },
+};
+
+static const struct {
+    XDP_QUIC_DECRYPT_FAILURE_ACTION Xdp;
+    NDIS_QUIC_DECRYPT_FAILURE_ACTION Ndis;
+} QeoDecryptFailureActionMap[] = {
+    {
+        XDP_QUIC_DECRYPT_FAILURE_ACTION_DROP, NDIS_QUIC_DECRYPT_FAILURE_ACTION_DROP
+    },
+    {
+        XDP_QUIC_DECRYPT_FAILURE_ACTION_CONTINUE, NDIS_QUIC_DECRYPT_FAILURE_ACTION_CONTINUE
+    },
+};
+
+static const struct {
+    XDP_QUIC_CIPHER_TYPE Xdp;
+    NDIS_QUIC_CIPHER_TYPE Ndis;
+} QeoCipherTypeMap[] = {
+    {
+        XDP_QUIC_CIPHER_TYPE_AEAD_AES_128_GCM, NDIS_QUIC_CIPHER_TYPE_AEAD_AES_128_GCM
+    },
+    {
+        XDP_QUIC_CIPHER_TYPE_AEAD_AES_256_GCM, NDIS_QUIC_CIPHER_TYPE_AEAD_AES_256_GCM
+    },
+    {
+        XDP_QUIC_CIPHER_TYPE_AEAD_CHACHA20_POLY1305, NDIS_QUIC_CIPHER_TYPE_AEAD_CHACHA20_POLY1305
+    },
+    {
+        XDP_QUIC_CIPHER_TYPE_AEAD_AES_128_CCM, NDIS_QUIC_CIPHER_TYPE_AEAD_AES_128_CCM
+    },
+};
+
+static const struct {
+    XDP_QUIC_ADDRESS_FAMILY Xdp;
+    NDIS_QUIC_ADDRESS_FAMILY Ndis;
+} QeoAddressFamilyMap[] = {
+    {
+        XDP_QUIC_ADDRESS_FAMILY_INET4, NDIS_QUIC_ADDRESS_FAMILY_INET4
+    },
+    {
+        XDP_QUIC_ADDRESS_FAMILY_INET6, NDIS_QUIC_ADDRESS_FAMILY_INET6
+    },
+};
+
 VOID
-OffloadQeoSingleAdd()
+OffloadQeoConnection()
 {
-    auto If = FnMpIf;
-    auto InterfaceHandle = InterfaceOpen(If.GetIfIndex());
-    auto AdapterMp = MpOpenAdapter(If.GetIfIndex());
+    for (const auto &Operation : QeoOperationMap) {
+    for (const auto &Direction : QeoDirectionMap) {
+    for (const auto &DecryptFailureAction : QeoDecryptFailureActionMap) {
+    for (const auto &CipherType : QeoCipherTypeMap) {
+    for (const auto &AddressFamily : QeoAddressFamilyMap) {
+        auto If = FnMpIf;
+        auto AdapterMp = MpOpenAdapter(If.GetIfIndex());
+        auto InterfaceHandle = InterfaceOpen(If.GetIfIndex());
 
-    //
-    // Initialize the connection for the add operation.
-    //
-    XDP_QUIC_CONNECTION Connection;
-    XdpInitializeQuicConnection(&Connection, sizeof(Connection));
-    Connection.Operation = XDP_QUIC_OPERATION_ADD;
-    Connection.Direction = XDP_QUIC_DIRECTION_TRANSMIT;
-    Connection.DecryptFailureAction = XDP_QUIC_DECRYPT_FAILURE_ACTION_DROP;
-    Connection.CipherType = XDP_QUIC_CIPHER_TYPE_AEAD_AES_128_GCM;
-    Connection.AddressFamily = XDP_QUIC_ADDRESS_FAMILY_INET4;
-    Connection.UdpPort = htons(1234);
-    Connection.NextPacketNumber = 5678;
-    Connection.ConnectionIdLength = 3;
-    RtlCopyMemory(Connection.Address, &in4addr_loopback, sizeof(in4addr_loopback));
-    strcpy_s((CHAR *)Connection.ConnectionId, sizeof(Connection.ConnectionId), "Id");
-    strcpy_s((CHAR *)Connection.PayloadKey, sizeof(Connection.PayloadKey), "PayloadKey");
-    strcpy_s((CHAR *)Connection.HeaderKey, sizeof(Connection.HeaderKey), "HeaderKey");
-    strcpy_s((CHAR *)Connection.PayloadIv, sizeof(Connection.PayloadIv), "PayloadIv");
-    Connection.Status = E_FAIL;
+        //
+        // Initialize the connection for the add operation.
+        //
+        XDP_QUIC_CONNECTION Connection;
+        XdpInitializeQuicConnection(&Connection, sizeof(Connection));
+        Connection.Operation = Operation.Xdp;
+        Connection.Direction = Direction.Xdp;
+        Connection.DecryptFailureAction = DecryptFailureAction.Xdp;
+        Connection.CipherType = CipherType.Xdp;
+        Connection.AddressFamily = AddressFamily.Xdp;
+        Connection.UdpPort = htons(1234);
+        Connection.NextPacketNumber = 5678;
+        Connection.ConnectionIdLength = 3;
+        strcpy_s((CHAR *)Connection.Address, sizeof(Connection.Address), "Address");
+        strcpy_s((CHAR *)Connection.ConnectionId, sizeof(Connection.ConnectionId), "Id");
+        strcpy_s((CHAR *)Connection.PayloadKey, sizeof(Connection.PayloadKey), "PayloadKey");
+        strcpy_s((CHAR *)Connection.HeaderKey, sizeof(Connection.HeaderKey), "HeaderKey");
+        strcpy_s((CHAR *)Connection.PayloadIv, sizeof(Connection.PayloadIv), "PayloadIv");
+        Connection.Status = E_FAIL;
 
-    //
-    // Configure the functional miniport to capture the offload request OID.
-    //
-    OID_KEY Key;
-    InitializeOidKey(
-        &Key, OID_QUIC_CONNECTION_ENCRYPTION, NdisRequestMethod, OID_REQUEST_INTERFACE_DIRECT);
-    MpOidFilter(AdapterMp, &Key, 1);
+        //
+        // Configure the functional miniport to capture the offload request OID.
+        //
+        OID_KEY Key;
+        InitializeOidKey(
+            &Key, OID_QUIC_CONNECTION_ENCRYPTION, NdisRequestMethod, OID_REQUEST_INTERFACE_DIRECT);
+        MpOidFilter(AdapterMp, &Key, 1);
 
-    //
-    // Initiate the offload request on a separate thread: the operation will
-    // block until the OID is completed, which won't happen until the miniport
-    // handle is reset below.
-    //
-    auto AsyncThread = std::async(
-        std::launch::async,
-        [&] {
-            return TryQeoSet(InterfaceHandle.get(), &Connection, sizeof(Connection));
-        }
-    );
+        //
+        // Initiate the offload request on a separate thread: the operation will
+        // block until the OID is completed, which won't happen until the miniport
+        // handle is reset below.
+        //
+        auto AsyncThread = std::async(
+            std::launch::async,
+            [&] {
+                return TryQeoSet(InterfaceHandle.get(), &Connection, sizeof(Connection));
+            }
+        );
 
-    //
-    // Retrieve the captured offload OID from the functional miniport.
-    //
-    UINT32 OidInfoBufferLength;
-    unique_malloc_ptr<VOID> OidInfoBuffer =
-        MpOidAllocateAndGetRequest(AdapterMp, Key, &OidInfoBufferLength);
+        //
+        // Retrieve the captured offload OID from the functional miniport.
+        //
+        UINT32 OidInfoBufferLength;
+        unique_malloc_ptr<VOID> OidInfoBuffer =
+            MpOidAllocateAndGetRequest(AdapterMp, Key, &OidInfoBufferLength);
 
-    //
-    // Verify the OID parameters match the XDP connection request.
-    //
-    NDIS_QUIC_CONNECTION *NdisConnection = (NDIS_QUIC_CONNECTION *)OidInfoBuffer.get();
-    TEST_EQUAL(NDIS_QUIC_OPERATION_ADD, NdisConnection->Operation);
-    TEST_EQUAL(NDIS_QUIC_DIRECTION_TRANSMIT, NdisConnection->Direction);
-    TEST_EQUAL(NDIS_QUIC_DECRYPT_FAILURE_ACTION_DROP, NdisConnection->DecryptFailureAction);
-    TEST_EQUAL(NDIS_QUIC_CIPHER_TYPE_AEAD_AES_128_GCM, NdisConnection->CipherType);
-    TEST_EQUAL(NDIS_QUIC_ADDRESS_FAMILY_INET4, NdisConnection->AddressFamily);
-    TEST_EQUAL(Connection.UdpPort, NdisConnection->UdpPort);
-    TEST_EQUAL(Connection.NextPacketNumber, NdisConnection->NextPacketNumber);
-    TEST_EQUAL(Connection.ConnectionIdLength, NdisConnection->ConnectionIdLength);
+        //
+        // Verify the OID parameters match the XDP connection request.
+        //
+        NDIS_QUIC_CONNECTION *NdisConnection = (NDIS_QUIC_CONNECTION *)OidInfoBuffer.get();
 
-    C_ASSERT(sizeof(Connection.Address) == sizeof(NdisConnection->Address));
-    TEST_TRUE(RtlEqualMemory(
-        Connection.Address, NdisConnection->Address, sizeof(Connection.Address)));
+        TEST_EQUAL((UINT32)Operation.Ndis, NdisConnection->Operation);
+        TEST_EQUAL((UINT32)Direction.Ndis, NdisConnection->Direction);
+        TEST_EQUAL((UINT32)DecryptFailureAction.Ndis, NdisConnection->DecryptFailureAction);
+        TEST_EQUAL((UINT32)CipherType.Ndis, NdisConnection->CipherType);
+        TEST_EQUAL(AddressFamily.Ndis, NdisConnection->AddressFamily);
+        TEST_EQUAL(Connection.UdpPort, NdisConnection->UdpPort);
+        TEST_EQUAL(Connection.NextPacketNumber, NdisConnection->NextPacketNumber);
+        TEST_EQUAL(Connection.ConnectionIdLength, NdisConnection->ConnectionIdLength);
 
-    C_ASSERT(sizeof(Connection.ConnectionId) == sizeof(NdisConnection->ConnectionId));
-    TEST_TRUE(RtlEqualMemory(
-        Connection.ConnectionId, NdisConnection->ConnectionId, Connection.ConnectionIdLength));
+        C_ASSERT(sizeof(Connection.Address) == sizeof(NdisConnection->Address));
+        TEST_TRUE(RtlEqualMemory(
+            Connection.Address, NdisConnection->Address, sizeof(Connection.Address)));
 
-    C_ASSERT(sizeof(Connection.PayloadKey) == sizeof(NdisConnection->PayloadKey));
-    TEST_TRUE(RtlEqualMemory(
-        Connection.PayloadKey, NdisConnection->PayloadKey, sizeof(Connection.PayloadKey)));
+        C_ASSERT(sizeof(Connection.ConnectionId) == sizeof(NdisConnection->ConnectionId));
+        TEST_TRUE(RtlEqualMemory(
+            Connection.ConnectionId, NdisConnection->ConnectionId, Connection.ConnectionIdLength));
 
-    C_ASSERT(sizeof(Connection.HeaderKey) == sizeof(NdisConnection->HeaderKey));
-    TEST_TRUE(RtlEqualMemory(
-        Connection.HeaderKey, NdisConnection->HeaderKey, sizeof(Connection.HeaderKey)));
+        C_ASSERT(sizeof(Connection.PayloadKey) == sizeof(NdisConnection->PayloadKey));
+        TEST_TRUE(RtlEqualMemory(
+            Connection.PayloadKey, NdisConnection->PayloadKey, sizeof(Connection.PayloadKey)));
 
-    C_ASSERT(sizeof(Connection.PayloadIv) == sizeof(NdisConnection->PayloadIv));
-    TEST_TRUE(RtlEqualMemory(
-        Connection.PayloadIv, NdisConnection->PayloadIv, sizeof(Connection.PayloadIv)));
+        C_ASSERT(sizeof(Connection.HeaderKey) == sizeof(NdisConnection->HeaderKey));
+        TEST_TRUE(RtlEqualMemory(
+            Connection.HeaderKey, NdisConnection->HeaderKey, sizeof(Connection.HeaderKey)));
 
-    //
-    // Reset the miniport handle, allowing the captured OID to be completed.
-    //
-    AdapterMp.reset();
+        C_ASSERT(sizeof(Connection.PayloadIv) == sizeof(NdisConnection->PayloadIv));
+        TEST_TRUE(RtlEqualMemory(
+            Connection.PayloadIv, NdisConnection->PayloadIv, sizeof(Connection.PayloadIv)));
 
-    //
-    // Verify the XDP request is completed once the OID completes.
-    //
-    TEST_EQUAL(AsyncThread.wait_for(TEST_TIMEOUT_ASYNC), std::future_status::ready);
+        //
+        // Reset the miniport handle, allowing the captured OID to be completed.
+        //
+        AdapterMp.reset();
 
-    //
-    // Verify the XDP offload API succeeded.
-    //
-    TEST_HRESULT(AsyncThread.get());
+        //
+        // Verify the XDP offload API is completed once the OID completes.
+        //
+        TEST_EQUAL(AsyncThread.wait_for(TEST_TIMEOUT_ASYNC), std::future_status::ready);
 
-    //
-    // Verify the connection's status field was updated with the miniport
-    // status.
-    //
-    TEST_HRESULT(Connection.Status);
+        //
+        // Verify the XDP offload API succeeded.
+        //
+        TEST_HRESULT(AsyncThread.get());
+
+        //
+        // Verify the connection's status field was updated with the miniport
+        // status.
+        //
+        TEST_HRESULT(Connection.Status);
+    }}}}}
 }
 
 /**

--- a/test/functional/lib/tests.h
+++ b/test/functional/lib/tests.h
@@ -202,4 +202,4 @@ VOID
 GenericXskQueryAffinity();
 
 VOID
-OffloadQeoSingleAdd();
+OffloadQeoConnection();

--- a/test/functional/lib/tests.h
+++ b/test/functional/lib/tests.h
@@ -200,3 +200,6 @@ OffloadSetHardwareCapabilities();
 
 VOID
 GenericXskQueryAffinity();
+
+VOID
+OffloadQeoSingleAdd();

--- a/test/functional/lib/xdptests.vcxproj
+++ b/test/functional/lib/xdptests.vcxproj
@@ -47,6 +47,7 @@
         $(SolutionDir)test\functional\lwf\inc;
         $(SolutionDir)test\functional\mp\inc;
         $(SolutionDir)test\pkthlp;
+        $(SolutionDir)submodules\quic-offloads\include;
         $(SolutionDir)submodules\wil\include;
         $(IntDir);
         %(AdditionalIncludeDirectories)

--- a/test/functional/taef/tests.cpp
+++ b/test/functional/taef/tests.cpp
@@ -479,4 +479,8 @@ public:
     TEST_METHOD(GenericXskQueryAffinity) {
         ::GenericXskQueryAffinity();
     }
+
+    TEST_METHOD(OffloadQeoSingleAdd) {
+        ::OffloadQeoSingleAdd();
+    }
 };

--- a/test/functional/taef/tests.cpp
+++ b/test/functional/taef/tests.cpp
@@ -480,7 +480,7 @@ public:
         ::GenericXskQueryAffinity();
     }
 
-    TEST_METHOD(OffloadQeoSingleAdd) {
-        ::OffloadQeoSingleAdd();
+    TEST_METHOD(OffloadQeoConnection) {
+        ::OffloadQeoConnection();
     }
 };


### PR DESCRIPTION
- Add plumbing for direct OID injection to XDP LWF
- Implement XDP offload API for QEO and pass to the LWF, which passes it to NDIS
- Add minimal implementation of the QEO offload API to the functional miniport
- Add minimal functional and stress test coverage
- Fix a few minor bugs

This does not address #213 or the other nontrivial offload bugs or design issues.
