### PR TITLE
Use consistent -Config parameter across scripts

### DIFF
--- a/.azure/templates/devkit.yml
+++ b/.azure/templates/devkit.yml
@@ -27,13 +27,13 @@ jobs:
     displayName: Create Dev Kit
     inputs:
       filePath: tools/create-devkit.ps1
-      arguments: -Flavor ${{ parameters.config }} -Platform ${{ parameters.arch }}
+      arguments: -Config ${{ parameters.config }} -Platform ${{ parameters.arch }}
 
   - task: PowerShell@2
     displayName: Create Runtime Kit
     inputs:
       filePath: tools/create-runtime-kit.ps1
-      arguments: -Flavor ${{ parameters.config }} -Platform ${{ parameters.arch }}
+      arguments: -Config ${{ parameters.config }} -Platform ${{ parameters.arch }}
 
   - task: PublishBuildArtifacts@1
     displayName: Upload Artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,10 +209,10 @@ jobs:
         path: artifacts/bin
     - name: Create Dev Kit
       shell: pwsh
-      run: tools/create-devkit.ps1 -Flavor ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
+      run: tools/create-devkit.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
     - name: Create Runtime Kit
       shell: pwsh
-      run: tools/create-runtime-kit.ps1 -Flavor ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
+      run: tools/create-runtime-kit.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
     - name: Upload Kit
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
       with:

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -9,7 +9,7 @@ param (
 
     [ValidateSet("Debug", "Release")]
     [Parameter(Mandatory=$false)]
-    [string]$Flavor = "Debug",
+    [string]$Config = "Debug",
 
     [Parameter(Mandatory = $false)]
     [switch]$NoClean = $false,
@@ -41,7 +41,7 @@ msbuild.exe xdp.sln `
     /t:restore `
     /p:RestorePackagesConfig=true `
     /p:RestoreConfigFile=src\nuget.config `
-    /p:Configuration=$Flavor `
+    /p:Configuration=$Config `
     /p:Platform=$Platform
 if (!$?) {
     Write-Verbose "Restoring NuGet packages failed: $LastExitCode"
@@ -51,7 +51,7 @@ if (!$?) {
 tools/prepare-machine.ps1 -ForEbpfBuild
 
 msbuild.exe xdp.sln `
-    /p:Configuration=$Flavor `
+    /p:Configuration=$Config `
     /p:Platform=$Platform `
     /t:$($Tasks -join ",") `
     /maxCpuCount
@@ -61,13 +61,13 @@ if (!$?) {
 }
 
 if (!$NoSign) {
-    tools/sign.ps1 -Config $Flavor -Arch $Platform
+    tools/sign.ps1 -Config $Config -Arch $Platform
 }
 
 if ($DevKit) {
-    tools/create-devkit.ps1 -Flavor $Flavor
+    tools/create-devkit.ps1 -Config $Config
 }
 
 if ($RuntimeKit) {
-    tools/create-runtime-kit.ps1 -Flavor $Flavor
+    tools/create-runtime-kit.ps1 -Config $Config
 }

--- a/tools/create-devkit.ps1
+++ b/tools/create-devkit.ps1
@@ -10,14 +10,14 @@ param (
 
     [ValidateSet("Debug", "Release")]
     [Parameter(Mandatory=$false)]
-    [string]$Flavor = "Debug"
+    [string]$Config = "Debug"
 )
 
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
 
 $Name = "xdp-devkit-$Platform"
-if ($Flavor -eq "Debug") {
+if ($Config -eq "Debug") {
     $Name += "-debug"
 }
 $DstPath = "artifacts\kit\$Name"
@@ -28,31 +28,31 @@ New-Item -Path $DstPath -ItemType Directory > $null
 copy docs\usage.md $DstPath
 
 New-Item -Path $DstPath\bin -ItemType Directory > $null
-copy "artifacts\bin\$($Platform)_$($Flavor)\CoreNetSignRoot.cer" $DstPath\bin
-copy "artifacts\bin\$($Platform)_$($Flavor)\xdp\xdp.inf" $DstPath\bin
-copy "artifacts\bin\$($Platform)_$($Flavor)\xdp\xdp.sys" $DstPath\bin
-copy "artifacts\bin\$($Platform)_$($Flavor)\xdp\xdp.cat" $DstPath\bin
-copy "artifacts\bin\$($Platform)_$($Flavor)\xdp\xdpapi.dll" $DstPath\bin
-copy "artifacts\bin\$($Platform)_$($Flavor)\pktcmd.exe" $DstPath\bin
-copy "artifacts\bin\$($Platform)_$($Flavor)\rxfilter.exe" $DstPath\bin
-copy "artifacts\bin\$($Platform)_$($Flavor)\xskbench.exe" $DstPath\bin
+copy "artifacts\bin\$($Platform)_$($Config)\CoreNetSignRoot.cer" $DstPath\bin
+copy "artifacts\bin\$($Platform)_$($Config)\xdp\xdp.inf" $DstPath\bin
+copy "artifacts\bin\$($Platform)_$($Config)\xdp\xdp.sys" $DstPath\bin
+copy "artifacts\bin\$($Platform)_$($Config)\xdp\xdp.cat" $DstPath\bin
+copy "artifacts\bin\$($Platform)_$($Config)\xdp\xdpapi.dll" $DstPath\bin
+copy "artifacts\bin\$($Platform)_$($Config)\pktcmd.exe" $DstPath\bin
+copy "artifacts\bin\$($Platform)_$($Config)\rxfilter.exe" $DstPath\bin
+copy "artifacts\bin\$($Platform)_$($Config)\xskbench.exe" $DstPath\bin
 
 New-Item -Path $DstPath\symbols -ItemType Directory > $null
-copy "artifacts\bin\$($Platform)_$($Flavor)\xdp.pdb"   $DstPath\symbols
-copy "artifacts\bin\$($Platform)_$($Flavor)\xdpapi.pdb" $DstPath\symbols
-copy "artifacts\bin\$($Platform)_$($Flavor)\pktcmd.pdb" $DstPath\symbols
-copy "artifacts\bin\$($Platform)_$($Flavor)\rxfilter.pdb" $DstPath\symbols
-copy "artifacts\bin\$($Platform)_$($Flavor)\xskbench.pdb" $DstPath\symbols
+copy "artifacts\bin\$($Platform)_$($Config)\xdp.pdb"   $DstPath\symbols
+copy "artifacts\bin\$($Platform)_$($Config)\xdpapi.pdb" $DstPath\symbols
+copy "artifacts\bin\$($Platform)_$($Config)\pktcmd.pdb" $DstPath\symbols
+copy "artifacts\bin\$($Platform)_$($Config)\rxfilter.pdb" $DstPath\symbols
+copy "artifacts\bin\$($Platform)_$($Config)\xskbench.pdb" $DstPath\symbols
 
 New-Item -Path $DstPath\include -ItemType Directory > $null
 copy -Recurse published\external\* $DstPath\include
 
 New-Item -Path $DstPath\lib -ItemType Directory > $null
-copy "artifacts\bin\$($Platform)_$($Flavor)\xdpapi.lib" $DstPath\lib
-copy "artifacts\bin\$($Platform)_$($Flavor)\xdpnmr.lib" $DstPath\lib
+copy "artifacts\bin\$($Platform)_$($Config)\xdpapi.lib" $DstPath\lib
+copy "artifacts\bin\$($Platform)_$($Config)\xdpnmr.lib" $DstPath\lib
 # Package the NMR symbols alongside its static library: consuming projects will
 # throw build exceptions if symbols are missing for statically linked code.
-copy "artifacts\bin\$($Platform)_$($Flavor)\xdpnmr.pdb" $DstPath\lib
+copy "artifacts\bin\$($Platform)_$($Config)\xdpnmr.pdb" $DstPath\lib
 
 [xml]$XdpVersion = Get-Content $RootDir\xdp.props
 $Major = $XdpVersion.Project.PropertyGroup.XdpMajorVersion

--- a/tools/create-runtime-kit.ps1
+++ b/tools/create-runtime-kit.ps1
@@ -13,14 +13,14 @@ param (
 
     [ValidateSet("Debug", "Release")]
     [Parameter(Mandatory=$false)]
-    [string]$Flavor = "Debug"
+    [string]$Config = "Debug"
 )
 
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
 
 $Name = "xdp-runtime-$Platform"
-if ($Flavor -eq "Debug") {
+if ($Config -eq "Debug") {
     $Name += "-debug"
 }
 $DstPath = "artifacts\kit\$Name"
@@ -31,15 +31,15 @@ New-Item -Path $DstPath -ItemType Directory > $null
 copy docs\usage.md $DstPath
 
 New-Item -Path $DstPath\bin -ItemType Directory > $null
-copy "artifacts\bin\$($Platform)_$($Flavor)\CoreNetSignRoot.cer" $DstPath\bin
-copy "artifacts\bin\$($Platform)_$($Flavor)\xdp\xdp.inf" $DstPath\bin
-copy "artifacts\bin\$($Platform)_$($Flavor)\xdp\xdp.sys" $DstPath\bin
-copy "artifacts\bin\$($Platform)_$($Flavor)\xdp\xdp.cat" $DstPath\bin
-copy "artifacts\bin\$($Platform)_$($Flavor)\xdp\xdpapi.dll" $DstPath\bin
+copy "artifacts\bin\$($Platform)_$($Config)\CoreNetSignRoot.cer" $DstPath\bin
+copy "artifacts\bin\$($Platform)_$($Config)\xdp\xdp.inf" $DstPath\bin
+copy "artifacts\bin\$($Platform)_$($Config)\xdp\xdp.sys" $DstPath\bin
+copy "artifacts\bin\$($Platform)_$($Config)\xdp\xdp.cat" $DstPath\bin
+copy "artifacts\bin\$($Platform)_$($Config)\xdp\xdpapi.dll" $DstPath\bin
 
 New-Item -Path $DstPath\symbols -ItemType Directory > $null
-copy "artifacts\bin\$($Platform)_$($Flavor)\xdp.pdb"   $DstPath\symbols
-copy "artifacts\bin\$($Platform)_$($Flavor)\xdpapi.pdb" $DstPath\symbols
+copy "artifacts\bin\$($Platform)_$($Config)\xdp.pdb"   $DstPath\symbols
+copy "artifacts\bin\$($Platform)_$($Config)\xdpapi.pdb" $DstPath\symbols
 
 
 [xml]$XdpVersion = Get-Content $RootDir\xdp.props


### PR DESCRIPTION
Some of our scripts take a `-Flavor` parameter and others use `-Config`. Use one term.

Resolves #145 