### PR TITLE
Ensure functional test RAII cleanup occurs

### DIFF
--- a/test/common/inc/testframeworkapi.h
+++ b/test/common/inc/testframeworkapi.h
@@ -12,10 +12,6 @@
 
 #include <windows.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 VOID
 StopTest();
 
@@ -36,7 +32,3 @@ LogTestWarning(
     _Printf_format_string_ PCWSTR Format,
     ...
     );
-
-#ifdef __cplusplus
-} /* extern "C" */
-#endif


### PR DESCRIPTION
After much litmus testing, it turns out that the `StopTest` function in the TAEF module is defined as `extern C` in the shared test framework header, which somehow allows exceptions to propagate across module boundaries, prevents exception-handling cleanup from occurring, but allows exceptions to be caught. The exact mechanics of this problem are beyond my understanding, but the fix to make RAII work as expected is simple: do not declare C++ functions as `extern C` within our functional test code.