### PR TITLE
Fix deadlock in LWF unload

### DIFF
--- a/src/xdplwf/offload.c
+++ b/src/xdplwf/offload.c
@@ -468,7 +468,7 @@ XdpLwfOffloadUnInitialize(
     TraceEnter(TRACE_LWF, "Filter=%p", Filter);
 
     if (Filter->Offload.WorkQueue != NULL) {
-        XdpShutdownWorkQueue(Filter->Offload.WorkQueue, TRUE);
+        XdpShutdownWorkQueue(Filter->Offload.WorkQueue, FALSE);
         Filter->Offload.WorkQueue = NULL;
     }
 


### PR DESCRIPTION
Resolves #225 

It turns out our functional tests were not failing due to a race condition in the tests, but a subtle deadlock introduced in the driver: the `DriverUnload` completes successfully, but a work item deadlocks, which prevents unloading the `xdp.sys` image. Remove the deadlock.