### PR TITLE
XDPMP: conditionally re-copy the pattern buffer into each RX packet

### DIFF
--- a/test/xdpmp/inf/xdpmp.inx
+++ b/test/xdpmp/inf/xdpmp.inx
@@ -119,6 +119,13 @@
  HKR, Ndi\Params\RxPattern,             LimitText,         0, "256"
  HKR, Ndi\Params\RxPattern,             Optional,          0, "1"
 
+; RxPatternCopy
+ HKR, Ndi\Params\RxPatternCopy,         ParamDesc,         0, "RxPatternCopy"
+ HKR, Ndi\Params\RxPatternCopy,         default,           0, "0"
+ HKR, Ndi\Params\RxPatternCopy,         type,              0, "enum"
+ HKR, Ndi\Params\RxPatternCopy\Enum,   "0",               0, %DISABLED_STR%
+ HKR, Ndi\Params\RxPatternCopy\Enum,   "1",               0, %ENABLED_STR%
+
 ; PollProvider
  HKR, Ndi\Params\PollProvider,          ParamDesc,         0, "PollProvider"
  HKR, Ndi\Params\PollProvider,          default,           0, "0"

--- a/test/xdpmp/miniport.c
+++ b/test/xdpmp/miniport.c
@@ -16,6 +16,7 @@ NDIS_STRING RegNumRxBuffers = NDIS_STRING_CONST("NumRxBuffers");
 NDIS_STRING RegRxBufferLength = NDIS_STRING_CONST("RxBufferLength");
 NDIS_STRING RegRxDataLength = NDIS_STRING_CONST("RxDataLength");
 NDIS_STRING RegRxPattern = NDIS_STRING_CONST("RxPattern");
+NDIS_STRING RegRxPatternCopy = NDIS_STRING_CONST("RxPatternCopy");
 NDIS_STRING RegPollProvider = NDIS_STRING_CONST("PollProvider");
 
 PCSTR MpDriverFriendlyName = "XDPMP";
@@ -1024,6 +1025,10 @@ MpReadConfiguration(
             goto Exit;
         }
     }
+
+    Adapter->RxPatternCopy = 0;
+    TRY_READ_INT_CONFIGURATION(ConfigHandle, RegRxPatternCopy, &Adapter->RxPatternCopy);
+    Adapter->RxPatternCopy = !!Adapter->RxPatternCopy;
 
     Adapter->RateSim.IntervalUs = 1000;             // 1ms
     Adapter->RateSim.RxFramesPerInterval = 1000;    // 1Mpps

--- a/test/xdpmp/miniport.h
+++ b/test/xdpmp/miniport.h
@@ -67,6 +67,8 @@ typedef struct _ADAPTER_RX_QUEUE {
     UINT32 BufferLength;
     UINT32 BufferMask;
     UINT32 DataLength;
+    UINT32 PatternLength;
+    CONST UCHAR *PatternBuffer;
     UINT32 RecycleIndex;
     UINT32 RxTxIndex;
 
@@ -189,6 +191,7 @@ typedef struct _ADAPTER_CONTEXT {
     ULONG RxDataLength;
     ULONG RxPatternLength;
     UCHAR RxPattern[128];
+    ULONG RxPatternCopy;
     XDPMP_RATE_SIM_WMI RateSim;
     FNDIS_NPI_CLIENT FndisClient;
     ADAPTER_POLL_PROVIDER PollProvider;


### PR DESCRIPTION
In some scenarios, the upper layer protocol will rewrite packet contents. We don't want XDPMP to needlessly memcpy data on each packet, so add a conditional flag that reinitializes the packet data before each RX.