### PR TITLE
configure linker to load xdpapi dependencies only from system32

### DIFF
--- a/src/xdpapi/xdpapi.vcxproj
+++ b/src/xdpapi/xdpapi.vcxproj
@@ -103,6 +103,10 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <AdditionalDependencies>ntdll.lib;onecore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>
+        /DEPENDENTLOADFLAG:0x800
+        %(AdditionalOptions)
+      </AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-security and https://learn.microsoft.com/en-us/cpp/build/reference/dependentloadflag.