### PR TITLE
Mtfriesen/xdp device security

### DIFF
--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -29,7 +29,7 @@ When the XDP driver is started, it is in a passive state; it does not inspect, m
 
 These results actions may be taken directly while handling the IOCTL, or when shared objects created by the IOCTL are later modified. Several components within XDP, most notably `AF_XDP` sockets, establish shared buffers between
 
-In either case, securing the IOCTL interface is the first mitigation against threats. Today, XDP requires full administrator privileges to open any IOCTL handle to the driver.
+In either case, securing the IOCTL interface is the first mitigation against threats. By default, XDP requires full administrator privileges to open any IOCTL handle to the driver; administrators can grant XDP privileges to additional users as needed.
 
 ### Memory mapped in shared user-kernel buffers
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -94,6 +94,16 @@ a network interface. The XDP queue IDs are assigned [0, N-1] for an interface
 with N configured RSS queues. XDP programs and AF_XDP applications bind to RSS
 queues using this queue ID space.
 
+### XDP access control
+
+Access to XDP is restricted to `SYSTEM` and the built-in administrators group by default. The `xdpcfg.exe` tool can be used to add or remove privileges. For example, to grant access to `SYSTEM`, built-in administrators, and the user or group represented by the `S-1-5-21-1626206346-3338949459-3778528156-1001` SID:
+
+```PowerShell
+xdpcfg.exe SetDeviceSddl "D:P(A;;GA;;;SY)(A;;GA;;;BA)(A;;GA;;;S-1-5-21-1626206346-3338949459-3778528156-1001)"
+```
+
+The XDP driver must be restarted for these changes to take effect.
+
 ## AF_XDP
 
 AF_XDP is the API for redirecting traffic to a usermode application. To use the API,

--- a/published/private/xdpioctl.h
+++ b/published/private/xdpioctl.h
@@ -17,6 +17,13 @@
 
 #define XDP_OPEN_PACKET_NAME "XdpOpenPacket000"
 
+CONST GUID DECLSPEC_SELECTANY XDP_DEVICE_CLASS_GUID = { /* 28f93d3f-4c0a-4a7c-8ff1-96b24e19b856 */
+    0x28f93d3f,
+    0x4c0a,
+    0x4a7c,
+    {0x8f, 0xf1, 0x96, 0xb2, 0x4e, 0x19, 0xb8, 0x56}
+};
+
 //
 // Type of XDP object to create or open.
 //

--- a/src/xdp/dispatch.c
+++ b/src/xdp/dispatch.c
@@ -31,13 +31,6 @@ static RTL_OSVERSIONINFOW XdpOsVersion;
 static WCHAR XdpParametersKeyStorage[256] = { 0 };
 CONST WCHAR *XDP_PARAMETERS_KEY = XdpParametersKeyStorage;
 
-static CONST GUID XdpDeviceClassGuid = { /* 28f93d3f-4c0a-4a7c-8ff1-96b24e19b856 */
-    0x28f93d3f,
-    0x4c0a,
-    0x4a7c,
-    {0x8f, 0xf1, 0x96, 0xb2, 0x4e, 0x19, 0xb8, 0x56}
-};
-
 DRIVER_OBJECT *XdpDriverObject;
 DEVICE_OBJECT *XdpDeviceObject;
 XDP_REG_WATCHER *XdpRegWatcher;
@@ -497,7 +490,7 @@ XdpStart(
     Status =
         IoCreateDeviceSecure(
             XdpDriverObject, 0, (PUNICODE_STRING)&DeviceName, FILE_DEVICE_NETWORK,
-            FILE_DEVICE_SECURE_OPEN, FALSE, &SDDL_DEVOBJ_SYS_ALL_ADM_ALL, &XdpDeviceClassGuid,
+            FILE_DEVICE_SECURE_OPEN, FALSE, &SDDL_DEVOBJ_SYS_ALL_ADM_ALL, &XDP_DEVICE_CLASS_GUID,
             &XdpDeviceObject);
     if (!NT_SUCCESS(Status)) {
         goto Exit;

--- a/src/xdp/dispatch.c
+++ b/src/xdp/dispatch.c
@@ -31,6 +31,13 @@ static RTL_OSVERSIONINFOW XdpOsVersion;
 static WCHAR XdpParametersKeyStorage[256] = { 0 };
 CONST WCHAR *XDP_PARAMETERS_KEY = XdpParametersKeyStorage;
 
+static CONST GUID XdpDeviceClassGuid = { /* 28f93d3f-4c0a-4a7c-8ff1-96b24e19b856 */
+    0x28f93d3f,
+    0x4c0a,
+    0x4a7c,
+    {0x8f, 0xf1, 0x96, 0xb2, 0x4e, 0x19, 0xb8, 0x56}
+};
+
 DRIVER_OBJECT *XdpDriverObject;
 DEVICE_OBJECT *XdpDeviceObject;
 XDP_REG_WATCHER *XdpRegWatcher;
@@ -488,9 +495,10 @@ XdpStart(
     }
 
     Status =
-        IoCreateDevice(
+        IoCreateDeviceSecure(
             XdpDriverObject, 0, (PUNICODE_STRING)&DeviceName, FILE_DEVICE_NETWORK,
-            FILE_DEVICE_SECURE_OPEN, FALSE, &XdpDeviceObject);
+            FILE_DEVICE_SECURE_OPEN, FALSE, &SDDL_DEVOBJ_SYS_ALL_ADM_ALL, &XdpDeviceClassGuid,
+            &XdpDeviceObject);
     if (!NT_SUCCESS(Status)) {
         goto Exit;
     }

--- a/src/xdp/precomp.h
+++ b/src/xdp/precomp.h
@@ -12,6 +12,8 @@
 #include <ntifs.h>
 #include <ntintsafe.h>
 #include <ndis.h>
+#include <wdmsec.h>
+
 //
 // The stdint.h header is included by eBPF headers, and stdint.h throws
 // warnings. Include it directly and suppress the warnings.

--- a/src/xdp/xdp.vcxproj
+++ b/src/xdp/xdp.vcxproj
@@ -143,6 +143,16 @@
       <WppScanConfigurationData>$(SolutionDir)src\xdp\inc\xdptrace.h</WppScanConfigurationData>
       <WppRecorderEnabled>true</WppRecorderEnabled>
     </ClCompile>
+    <Link>
+      <AdditionalDependencies>
+        msnetioid.lib;
+        ndis.lib;
+        netio.lib;
+        uuid.lib;
+        wdmsec.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
+    </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <Inf Include="xdp.inx">

--- a/src/xdpcfg/xdpcfg.c
+++ b/src/xdpcfg/xdpcfg.c
@@ -4,41 +4,47 @@
 //
 
 #include <windows.h>
-#include <sddl.h>
+#include <setupapi.h>
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <xdpioctl.h>
+
+static
 VOID
 Usage(
     VOID
     )
 {
-    fprintf(stderr, "Usage: TODO\n");
+    fprintf(stderr,
+        "Usage: xdpcfg.exe <SetDeviceSddl> [OPTIONS ...]\n"
+        "\n"
+        "OPTIONS:\n"
+        "\n"
+        "    SetDeviceSddl <SDDL>\n");
     exit(EXIT_FAILURE);
 }
 
+static
 INT
-AddXdpSid(
-    INT ArgC,
-    WCHAR **ArgV
+SetDeviceSddl(
+    _In_ INT ArgC,
+    _In_ WCHAR **ArgV
     )
 {
-    SID Sid;
-    HANDLE CfgMutex = NULL;
 
     if (ArgC < 3) {
         Usage();
     }
 
-    if (!ConvertStringSidToSidW(ArgV[2], &Sid)) {
-        fprintf(stderr, "Invalid SID\n");
-        Usage();
+    if (!SetupDiSetClassRegistryPropertyW(
+        &XDP_DEVICE_CLASS_GUID, SPCRP_SECURITY_SDS, (BYTE *)ArgV[2],
+        wcslen(ArgV[2]) * sizeof(WCHAR) + sizeof(UNICODE_NULL), NULL, NULL)) {
+        fprintf(stderr, "SetupDiSetClassRegistryPropertyW failed: 0x%x\n", GetLastError());
+        return EXIT_FAILURE;
     }
 
-    //
-    // TODO: protect with a mutex? how do we secure the mutex?
-    //
-
+    return EXIT_SUCCESS;
 }
 
 INT
@@ -52,8 +58,8 @@ wmain(
         Usage();
     }
 
-    if (!_wcsicmp(ArgV[1], L"AddXdpSid")) {
-        return AddXdpSid(ArgC, ArgV);
+    if (!_wcsicmp(ArgV[1], L"SetDeviceSddl")) {
+        return SetDeviceSddl(ArgC, ArgV);
     } else {
         Usage();
     }

--- a/src/xdpcfg/xdpcfg.c
+++ b/src/xdpcfg/xdpcfg.c
@@ -1,0 +1,62 @@
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+
+#include <windows.h>
+#include <sddl.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+VOID
+Usage(
+    VOID
+    )
+{
+    fprintf(stderr, "Usage: TODO\n");
+    exit(EXIT_FAILURE);
+}
+
+INT
+AddXdpSid(
+    INT ArgC,
+    WCHAR **ArgV
+    )
+{
+    SID Sid;
+    HANDLE CfgMutex = NULL;
+
+    if (ArgC < 3) {
+        Usage();
+    }
+
+    if (!ConvertStringSidToSidW(ArgV[2], &Sid)) {
+        fprintf(stderr, "Invalid SID\n");
+        Usage();
+    }
+
+    //
+    // TODO: protect with a mutex? how do we secure the mutex?
+    //
+
+}
+
+INT
+__cdecl
+wmain(
+    INT ArgC,
+    WCHAR **ArgV
+    )
+{
+    if (ArgC < 2) {
+        Usage();
+    }
+
+    if (!_wcsicmp(ArgV[1], L"AddXdpSid")) {
+        return AddXdpSid(ArgC, ArgV);
+    } else {
+        Usage();
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/src/xdpcfg/xdpcfg.vcxproj
+++ b/src/xdpcfg/xdpcfg.vcxproj
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(SolutionDir)xdp.props" />
+  <!--The following lines configure the properties needed for sourcelink support -->
+  <Import Project="$(SolutionDir)packages\Microsoft.SourceLink.AzureRepos.Git.1.0.0\build\Microsoft.SourceLink.AzureRepos.Git.props" Condition="Exists('$(SolutionDir)packages\Microsoft.SourceLink.AzureRepos.Git.1.0.0\build\Microsoft.SourceLink.AzureRepos.Git.props')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props" Condition="Exists('$(SolutionDir)packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props" Condition="Exists('$(SolutionDir)packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props')" />
+  <Import Project="$(SolutionDir)packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props')" />
+  <ItemGroup>
+    <ClCompile Include="xdpcfg.c" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{e64ccf9c-9d27-4aac-8119-197faba5e8c2}</ProjectGuid>
+    <RootNamespace>xdpcfg</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>$(XdpPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.user.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <TargetName>xdpcfg</TargetName>
+    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>
+        $(SolutionDir)published\private;
+        %(AdditionalIncludeDirectories)
+      </AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>
+        ntdll.lib;
+        onecore.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <!-- The following lines configure the targets necessary for sourcelink -->
+  <ItemGroup>
+    <None Include="$(SolutionDir)src\xdp\packages.config" />
+  </ItemGroup>
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.targets')" />
+    <Import Project="$(SolutionDir)packages\Microsoft.SourceLink.AzureRepos.Git.1.0.0\build\Microsoft.SourceLink.AzureRepos.Git.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.SourceLink.AzureRepos.Git.1.0.0\build\Microsoft.SourceLink.AzureRepos.Git.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.SourceLink.AzureRepos.Git.1.0.0\build\Microsoft.SourceLink.AzureRepos.Git.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.SourceLink.AzureRepos.Git.1.0.0\build\Microsoft.SourceLink.AzureRepos.Git.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.SourceLink.AzureRepos.Git.1.0.0\build\Microsoft.SourceLink.AzureRepos.Git.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.SourceLink.AzureRepos.Git.1.0.0\build\Microsoft.SourceLink.AzureRepos.Git.targets'))" />
+  </Target>
+</Project>

--- a/test/fakendis/fndis.vcxproj
+++ b/test/fakendis/fndis.vcxproj
@@ -67,6 +67,10 @@
     </ClCompile>
     <Link>
       <ModuleDefinitionFile>fndis.def</ModuleDefinitionFile>
+      <AdditionalDependencies>
+        ndis.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/test/functional/lwf/sys/xdpfnlwf.vcxproj
+++ b/test/functional/lwf/sys/xdpfnlwf.vcxproj
@@ -82,6 +82,12 @@
       <WppRecorderEnabled>true</WppRecorderEnabled>
       <WppAdditionalOptions>-p:xdpfnlwf</WppAdditionalOptions>
     </ClCompile>
+    <Link>
+      <AdditionalDependencies>
+        ndis.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
+    </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <Inf Include="inf\xdpfnlwf.inx">

--- a/test/functional/mp/sys/xdpfnmp.vcxproj
+++ b/test/functional/mp/sys/xdpfnmp.vcxproj
@@ -91,6 +91,13 @@
       <WppRecorderEnabled>true</WppRecorderEnabled>
       <WppAdditionalOptions>-p:xdpfnmp</WppAdditionalOptions>
     </ClCompile>
+    <Link>
+      <AdditionalDependencies>
+        ndis.lib;
+        netio.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
+    </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <Inf Include="inf\xdpfnmp.inx">

--- a/test/xdpmp/xdpmp.vcxproj
+++ b/test/xdpmp/xdpmp.vcxproj
@@ -85,7 +85,12 @@ wmimofck.exe -h$(IntDir)xdpmpwmi.h $(IntDir)xdpmp.bmf</Command>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</AdditionalLibraryDirectories>
-      <AdditionalDependencies>fndis.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>
+        fndis.lib;
+        ndis.lib;
+        netio.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/tools/create-devkit.ps1
+++ b/tools/create-devkit.ps1
@@ -33,6 +33,7 @@ copy "artifacts\bin\$($Platform)_$($Config)\xdp\xdp.inf" $DstPath\bin
 copy "artifacts\bin\$($Platform)_$($Config)\xdp\xdp.sys" $DstPath\bin
 copy "artifacts\bin\$($Platform)_$($Config)\xdp\xdp.cat" $DstPath\bin
 copy "artifacts\bin\$($Platform)_$($Config)\xdp\xdpapi.dll" $DstPath\bin
+copy "artifacts\bin\$($Platform)_$($Config)\xdp\xdpcfg.exe" $DstPath\bin
 copy "artifacts\bin\$($Platform)_$($Config)\pktcmd.exe" $DstPath\bin
 copy "artifacts\bin\$($Platform)_$($Config)\rxfilter.exe" $DstPath\bin
 copy "artifacts\bin\$($Platform)_$($Config)\xskbench.exe" $DstPath\bin
@@ -40,6 +41,7 @@ copy "artifacts\bin\$($Platform)_$($Config)\xskbench.exe" $DstPath\bin
 New-Item -Path $DstPath\symbols -ItemType Directory > $null
 copy "artifacts\bin\$($Platform)_$($Config)\xdp.pdb"   $DstPath\symbols
 copy "artifacts\bin\$($Platform)_$($Config)\xdpapi.pdb" $DstPath\symbols
+copy "artifacts\bin\$($Platform)_$($Config)\xdpcfg.pdb" $DstPath\symbols
 copy "artifacts\bin\$($Platform)_$($Config)\pktcmd.pdb" $DstPath\symbols
 copy "artifacts\bin\$($Platform)_$($Config)\rxfilter.pdb" $DstPath\symbols
 copy "artifacts\bin\$($Platform)_$($Config)\xskbench.pdb" $DstPath\symbols

--- a/tools/create-runtime-kit.ps1
+++ b/tools/create-runtime-kit.ps1
@@ -36,11 +36,12 @@ copy "artifacts\bin\$($Platform)_$($Config)\xdp\xdp.inf" $DstPath\bin
 copy "artifacts\bin\$($Platform)_$($Config)\xdp\xdp.sys" $DstPath\bin
 copy "artifacts\bin\$($Platform)_$($Config)\xdp\xdp.cat" $DstPath\bin
 copy "artifacts\bin\$($Platform)_$($Config)\xdp\xdpapi.dll" $DstPath\bin
+copy "artifacts\bin\$($Platform)_$($Config)\xdp\xdpcfg.exe" $DstPath\bin
 
 New-Item -Path $DstPath\symbols -ItemType Directory > $null
 copy "artifacts\bin\$($Platform)_$($Config)\xdp.pdb"   $DstPath\symbols
 copy "artifacts\bin\$($Platform)_$($Config)\xdpapi.pdb" $DstPath\symbols
-
+copy "artifacts\bin\$($Platform)_$($Config)\xdpcfg.pdb" $DstPath\symbols
 
 [xml]$XdpVersion = Get-Content $RootDir\xdp.props
 $Major = $XdpVersion.Project.PropertyGroup.XdpMajorVersion

--- a/xdp.cpp.kernel.props
+++ b/xdp.cpp.kernel.props
@@ -20,7 +20,6 @@
     </ClCompile>
     <Link>
       <AdditionalOptions>/kernel /NOOPTIDATA /pdbcompress /MERGE:.gfids=GFIDS /MERGE:.orpc=.text /MERGE:_PAGE=PAGE /MERGE:_RDATA=.rdata /MERGE:_TEXT=.text /section:GFIDS,d</AdditionalOptions>
-      <AdditionalDependencies>msnetioid.lib;ndis.lib;netio.lib;uuid.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>

--- a/xdp.sln
+++ b/xdp.sln
@@ -67,6 +67,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "rxfilter", "samples\rxfilte
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "bpf", "test\bpf\bpf.vcxproj", "{5DE7385C-80B3-40CD-97D0-7C24DEC2F95C}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "xdpcfg", "src\xdpcfg\xdpcfg.vcxproj", "{E64CCF9C-9D27-4AAC-8119-197FABA5E8C2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -407,6 +409,18 @@ Global
 		{5DE7385C-80B3-40CD-97D0-7C24DEC2F95C}.Release|x64.ActiveCfg = Release|x64
 		{5DE7385C-80B3-40CD-97D0-7C24DEC2F95C}.Release|x64.Build.0 = Release|x64
 		{5DE7385C-80B3-40CD-97D0-7C24DEC2F95C}.Release|x64.Deploy.0 = Release|x64
+		{E64CCF9C-9D27-4AAC-8119-197FABA5E8C2}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{E64CCF9C-9D27-4AAC-8119-197FABA5E8C2}.Debug|ARM64.Build.0 = Debug|ARM64
+		{E64CCF9C-9D27-4AAC-8119-197FABA5E8C2}.Debug|ARM64.Deploy.0 = Debug|ARM64
+		{E64CCF9C-9D27-4AAC-8119-197FABA5E8C2}.Debug|x64.ActiveCfg = Debug|x64
+		{E64CCF9C-9D27-4AAC-8119-197FABA5E8C2}.Debug|x64.Build.0 = Debug|x64
+		{E64CCF9C-9D27-4AAC-8119-197FABA5E8C2}.Debug|x64.Deploy.0 = Debug|x64
+		{E64CCF9C-9D27-4AAC-8119-197FABA5E8C2}.Release|ARM64.ActiveCfg = Release|ARM64
+		{E64CCF9C-9D27-4AAC-8119-197FABA5E8C2}.Release|ARM64.Build.0 = Release|ARM64
+		{E64CCF9C-9D27-4AAC-8119-197FABA5E8C2}.Release|ARM64.Deploy.0 = Release|ARM64
+		{E64CCF9C-9D27-4AAC-8119-197FABA5E8C2}.Release|x64.ActiveCfg = Release|x64
+		{E64CCF9C-9D27-4AAC-8119-197FABA5E8C2}.Release|x64.Build.0 = Release|x64
+		{E64CCF9C-9D27-4AAC-8119-197FABA5E8C2}.Release|x64.Deploy.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- use `IoCreateDeviceSecure` to create a device object with a default security descriptor and a class GUID to allow security descriptor configuration
- add xdpcfg tool to adjust XDP device object security descriptor
- add documentation
- tighten up kernel link dependencies per project

#24 