### PR TITLE
Bump functional test timeouts

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -17,13 +17,13 @@ variables:
     spinxskRuntime: 60
     spinxskTimeout: 65
     spinxskJobTimeout: 75
-    functionalRuntime: 60
+    functionalRuntime: 120
     functionalIterations: 10
   ${{ if ne(variables['Build.Reason'], 'BatchedCI') }}:
     spinxskRuntime: 10
     spinxskTimeout: 15
     spinxskJobTimeout: 25
-    functionalRuntime: 10
+    functionalRuntime: 15
     functionalIterations: 1
 
 stages:

--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -114,7 +114,7 @@ stages:
       arch: x64
       config: Release
       osName: latest
-      timeoutInMinutes: 10
+      timeoutInMinutes: 15
       iterations: 1
   - template: ./templates/tests.yml
     parameters:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,10 +77,10 @@ jobs:
     needs: build
     env:
       # For 'main' commits
-      fullRuntime: 60 # minutes
+      fullRuntime: 120 # minutes
       fullIters: 10
       # For PRs
-      prRuntime: 5 # minutes
+      prRuntime: 15 # minutes
       prIters: 1
     strategy:
       fail-fast: false


### PR DESCRIPTION
We're seeing runs get cancelled due to slightly exceeding the timeouts, so bump them now that we have more test coverage. Resolves #243 