### PR TITLE
Fix the only AzWatson bugcheck in the last 7 days

### DIFF
--- a/src/xdplwf/ec.c
+++ b/src/xdplwf/ec.c
@@ -363,10 +363,11 @@ XdpEcInitialize(
     Ec->Poll = Poll;
     Ec->PollContext = PollContext;
     Ec->IdealProcessor = IdealProcessor;
+    Ec->OwningProcessor = ReadUInt32NoFence(IdealProcessor);
     Ec->Armed = TRUE;
 
     KeInitializeDpc(&Ec->Dpc, XdpEcDpcThunk, Ec);
-    KeGetProcessorNumberFromIndex(*Ec->IdealProcessor, &ProcessorNumber);
+    KeGetProcessorNumberFromIndex(Ec->OwningProcessor, &ProcessorNumber);
     KeSetTargetProcessorDpcEx(&Ec->Dpc, &ProcessorNumber);
     KeInitializeEvent(&Ec->PassiveEvent, SynchronizationEvent, FALSE);
 

--- a/src/xdplwf/ec.c
+++ b/src/xdplwf/ec.c
@@ -363,7 +363,7 @@ XdpEcInitialize(
     Ec->Poll = Poll;
     Ec->PollContext = PollContext;
     Ec->IdealProcessor = IdealProcessor;
-    Ec->OwningProcessor = ReadUInt32NoFence(IdealProcessor);
+    Ec->OwningProcessor = ReadULongNoFence(IdealProcessor);
     Ec->Armed = TRUE;
 
     KeInitializeDpc(&Ec->Dpc, XdpEcDpcThunk, Ec);


### PR DESCRIPTION
Ensure Ec->OwningProcessor is consistent with Ec->Dpc target processor. In the long haul spinxsk dump, the same EC was running on two processors: inline on CPU 0 and in the DPC on CPU 2. This could happen if the EC ran inline after initialization where the DPC is affinitized to a processor other than the "owning" processor. Ensure these are all consistently initialized.