### PR TITLE
Always test eBPF in spinxsk CI

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -173,36 +173,6 @@ stages:
       timeoutMinutes: ${{ variables.spinxskTimeout }}
       jobTimeoutMinutes: ${{ variables.spinxskJobTimeout }}
 
-- stage: stress_ebpf_debug
-  displayName: Stress eBPF (Debug)
-  dependsOn:
-  - build_debug
-  jobs:
-  - template: ./templates/spinxsk.yml
-    parameters:
-      pool: XDP-CI-1ES-Spinxsk-2
-      image: WS2019-Spinxsk
-      arch: x64
-      config: Debug
-      osName: 2019
-      xdpmpPollProvider: FNDIS
-      runtimeMinutes: ${{ variables.spinxskRuntime }}
-      timeoutMinutes: ${{ variables.spinxskTimeout }}
-      jobTimeoutMinutes: ${{ variables.spinxskJobTimeout }}
-      enableEbpf: true
-  - template: ./templates/spinxsk.yml
-    parameters:
-      pool: XDP-CI-1ES-Spinxsk-2
-      image: WS2022-Spinxsk
-      arch: x64
-      config: Debug
-      osName: 2022
-      xdpmpPollProvider: FNDIS
-      runtimeMinutes: ${{ variables.spinxskRuntime }}
-      timeoutMinutes: ${{ variables.spinxskTimeout }}
-      jobTimeoutMinutes: ${{ variables.spinxskJobTimeout }}
-      enableEbpf: true
-
 - stage: stress_release
   displayName: Stress (Release)
   dependsOn:
@@ -240,36 +210,6 @@ stages:
       runtimeMinutes: ${{ variables.spinxskRuntime }}
       timeoutMinutes: ${{ variables.spinxskTimeout }}
       jobTimeoutMinutes: ${{ variables.spinxskJobTimeout }}
-
-- stage: stress_ebpf_release
-  displayName: Stress eBPF (Release)
-  dependsOn:
-  - build_release
-  jobs:
-  - template: ./templates/spinxsk.yml
-    parameters:
-      pool: XDP-CI-1ES-Spinxsk-2
-      image: WS2019-Spinxsk
-      arch: x64
-      config: Release
-      osName: 2019
-      xdpmpPollProvider: FNDIS
-      runtimeMinutes: ${{ variables.spinxskRuntime }}
-      timeoutMinutes: ${{ variables.spinxskTimeout }}
-      jobTimeoutMinutes: ${{ variables.spinxskJobTimeout }}
-      enableEbpf: true
-  - template: ./templates/spinxsk.yml
-    parameters:
-      pool: XDP-CI-1ES-Spinxsk-2
-      image: WS2022-Spinxsk
-      arch: x64
-      config: Release
-      osName: 2022
-      xdpmpPollProvider: FNDIS
-      runtimeMinutes: ${{ variables.spinxskRuntime }}
-      timeoutMinutes: ${{ variables.spinxskTimeout }}
-      jobTimeoutMinutes: ${{ variables.spinxskJobTimeout }}
-      enableEbpf: true
 
 - stage: devkit
   displayName: Dev Kit

--- a/.azure/azure-pipelines.longhaul.yml
+++ b/.azure/azure-pipelines.longhaul.yml
@@ -51,30 +51,3 @@ stages:
       runtimeMinutes: ${{ variables.spinxskRuntime }}
       timeoutMinutes: ${{ variables.spinxskTimeout }}
       jobTimeoutMinutes: ${{ variables.spinxskJobTimeout }}
-  # Additional runs with eBPF enabled and failures ignored:
-  - template: ./templates/spinxsk.yml
-    parameters:
-      pool: XDP-CI-1ES-Spinxsk-2
-      image: WS2019-Spinxsk
-      arch: x64
-      config: Debug
-      osName: 2019
-      xdpmpPollProvider: FNDIS
-      runtimeMinutes: ${{ variables.spinxskRuntime }}
-      timeoutMinutes: ${{ variables.spinxskTimeout }}
-      jobTimeoutMinutes: ${{ variables.spinxskJobTimeout }}
-      ignoreFailures: true
-      enableEbpf: true
-  - template: ./templates/spinxsk.yml
-    parameters:
-      pool: XDP-CI-1ES-Spinxsk-2
-      image: WS2022-Spinxsk
-      arch: x64
-      config: Debug
-      osName: 2022
-      xdpmpPollProvider: FNDIS
-      runtimeMinutes: ${{ variables.spinxskRuntime }}
-      timeoutMinutes: ${{ variables.spinxskTimeout }}
-      jobTimeoutMinutes: ${{ variables.spinxskJobTimeout }}
-      ignoreFailures: true
-      enableEbpf: true

--- a/.azure/templates/spinxsk.yml
+++ b/.azure/templates/spinxsk.yml
@@ -27,13 +27,10 @@ parameters:
 - name: xdpmpPollProvider
   default: 'NDIS'
 - name: osName
-- name: enableEbpf
-  type: boolean
-  default: false
 
 jobs:
-- job: spinxsk_${{ replace(replace(parameters.enableEbpf, 'True', 'Ebpf'), 'False', '') }}_${{ parameters.arch }}_${{ parameters.config }}_${{ parameters.osName }}_${{ replace(parameters.pool, '-', '_') }}
-  displayName: spinxsk-${{ replace(replace(parameters.enableEbpf, 'True', 'ebpf-'), 'False', '') }}${{ parameters.osName }}-${{ parameters.arch }}_${{ parameters.config }} (${{ parameters.pool }})
+- job: spinxsk__${{ parameters.arch }}_${{ parameters.config }}_${{ parameters.osName }}_${{ replace(parameters.pool, '-', '_') }}
+  displayName: spinxsk-${{ parameters.osName }}-${{ parameters.arch }}_${{ parameters.config }} (${{ parameters.pool }})
 
   # Either run on our self-hosted 'pool' or an AZP managed 'image'.
   ${{ if ne(parameters.pool, '') }}:
@@ -82,7 +79,7 @@ jobs:
       arguments: -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -QueueCount 2
         -Minutes ${{ parameters.runtimeMinutes }} -XdpmpPollProvider ${{ parameters.xdpmpPollProvider }}
         -Verbose -Stats -SuccessThresholdPercent ${{ parameters.successThresholdPercent }}
-        -EnableEbpf:$${{ parameters.enableEbpf }}
+        -EnableEbpf
 
   - task: PowerShell@2
     displayName: Convert logs
@@ -97,7 +94,7 @@ jobs:
     inputs:
       sourceFolder: artifacts/logs
       contents: '**/!(*.ilk|*.exp|*.lastcodeanalysissucceeded)'
-      targetFolder: $(Build.ArtifactStagingDirectory)/logs/spinxsk_${{ replace(replace(parameters.enableEbpf, 'True', 'ebpf_'), 'False', '') }}${{ parameters.arch }}_${{ parameters.config }}_${{ parameters.osName }}_${{ parameters.pool }}
+      targetFolder: $(Build.ArtifactStagingDirectory)/logs/spinxsk_${{ parameters.arch }}_${{ parameters.config }}_${{ parameters.osName }}_${{ parameters.pool }}
 
   - task: PublishBuildArtifacts@1
     displayName: Upload Logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,12 +179,12 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
       shell: pwsh
       #timeout-minutes: ${{ env.prTimeout }}
-      run: tools/spinxsk.ps1 -Verbose -Stats -QueueCount ${{ env.queueCount }} -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Minutes ${{ env.prRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }}
+      run: tools/spinxsk.ps1 -Verbose -Stats -QueueCount ${{ env.queueCount }} -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Minutes ${{ env.prRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf
     - name: Run spinxsk (main)
       if: ${{ github.event_name != 'pull_request' }}
       shell: pwsh
       #timeout-minutes: ${{ env.fullTimeout }}
-      run: tools/spinxsk.ps1 -Verbose -Stats -QueueCount ${{ env.queueCount }} -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Minutes ${{ env.fullRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }}
+      run: tools/spinxsk.ps1 -Verbose -Stats -QueueCount ${{ env.queueCount }} -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Minutes ${{ env.fullRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf
     - name: Convert Logs
       if: ${{ always() }}
       shell: pwsh


### PR DESCRIPTION
Now that eBPF stress tests are quite reliable, simplify our test matrix and always enable eBPF.

This still leaves eBPF disabled by default in XDP.