### PR TITLE
Force eBPF powershell job cleanup

### DIFF
--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -558,7 +558,7 @@ function Uninstall-Ebpf {
             }
         }
     } finally {
-        Remove-Job -Job $Job
+        Remove-Job -Job $Job -Force
     }
 
     if (Test-Path $EbpfPath) {


### PR DESCRIPTION
If the job fails to complete in time, we throw an exception and leak the job because we didn't force deletion. Force deletion and continue with regular (non-exception) error handling.