### PR TITLE
Improve TCP test reliability

### DIFF
--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -292,6 +292,12 @@ public:
         return T((ElapsedQpc * T::period::den) / T::period::num / _FrequencyQpc.QuadPart);
     }
 
+    T
+    Remaining()
+    {
+        return std::max(T(0), _TimeoutInterval - Elapsed());
+    }
+
     bool
     IsExpired()
     {
@@ -1987,7 +1993,7 @@ CreateTcpSocket(
     //
     WaitForWfpQuarantine(*If);
 
-    wil::unique_socket Socket(socket(Af, SOCK_STREAM,IPPROTO_TCP));
+    wil::unique_socket Socket(socket(Af, SOCK_STREAM, IPPROTO_TCP));
     TEST_NOT_NULL(Socket.get());
 
     SOCKADDR_INET Address = {0};
@@ -2056,15 +2062,32 @@ CreateTcpSocket(
     TEST_HRESULT(MpRxIndicateFrame(GenericMp, &Frame));
 
     //
-    // Verify the SYN+ACK has been redirected to XSK.
+    // Verify the SYN+ACK has been redirected to XSK, filtering out other
+    // TCP connections using the same remote port.
     //
-    UINT32 ConsumerIndex = SocketConsumerReserve(&Xsk.Rings.Rx, 1, std::chrono::milliseconds(5000));
-    TEST_EQUAL(1, XskRingConsumerReserve(&Xsk.Rings.Rx, MAXUINT32, &ConsumerIndex));
-    auto RxDesc = SocketGetAndFreeRxDesc(&Xsk, ConsumerIndex++);
+
     TCP_HDR *TcpHeaderParsed = NULL;
-    TEST_TRUE(PktParseTcpFrame(
-        Xsk.Umem.Buffer.get() + XskDescriptorGetAddress(RxDesc->address) + XskDescriptorGetOffset(RxDesc->address),
-        RxDesc->length, &TcpHeaderParsed, NULL, 0));
+    Stopwatch<std::chrono::seconds> Watchdog(std::chrono::seconds(5));
+    do {
+        UINT32 ConsumerIndex = SocketConsumerReserve(&Xsk.Rings.Rx, 1, Watchdog.Remaining());
+        TEST_EQUAL(1, XskRingConsumerReserve(&Xsk.Rings.Rx, MAXUINT32, &ConsumerIndex));
+        auto RxDesc = SocketGetAndFreeRxDesc(&Xsk, ConsumerIndex++);
+
+        TEST_TRUE(PktParseTcpFrame(
+            Xsk.Umem.Buffer.get() +
+                XskDescriptorGetAddress(RxDesc->address) + XskDescriptorGetOffset(RxDesc->address),
+            RxDesc->length, &TcpHeaderParsed, NULL, 0));
+
+        if (*LocalPort == TcpHeaderParsed->th_sport) {
+            break;
+        }
+
+        TcpHeaderParsed = NULL;
+    } while (!Watchdog.IsExpired());
+
+    TEST_NOT_NULL(TcpHeaderParsed);
+    TEST_EQUAL(*LocalPort, TcpHeaderParsed->th_sport);
+
     //
     // Construct and inject the ACK for SYN+ACK.
     //


### PR DESCRIPTION
Our functional tests were sometimes stalling. With the new functional test watchdog and TCPIP logs, the root cause is the `accept()` waiting forever, which in turn happens because the test responds with the wrong TCP connection's ACK number.

Ensure we respond to the correct ACK and add a watchdog on the `accept()` request since the receive timeout socket option doesn't apply to TCP accept.

Resolves #265 

Log snippets:

```
[1]0004.00F4::‎2023‎-‎06‎-‎11 22:27:23.398 [xdplwf] XdpGenericRxCreateQueue:1295 ---> IfIndex=26 QueueId=0 Hook={XDP_HOOK_L2, XDP_HOOK_TX, XDP_HOOK_INSPECT}
[1]0004.00F4::‎2023‎-‎06‎-‎11 22:27:23.398 [Microsoft-XDP][  ec][0xFFFF918200020F08] state change NewState=0x0 
[1]0004.00F4::‎2023‎-‎06‎-‎11 22:27:23.398 [xdplwf] XdpGenericAttachDatapath:403 IfIndex=26 Requesting datapath attach RX=1 TX=1
[1]0004.00F4::‎2023‎-‎06‎-‎11 22:27:23.398 [xdplwf] XdpGenericRequestRestart:517 IfIndex=26 Requesting datapath restart
[0]0004.00F8::‎2023‎-‎06‎-‎11 22:27:23.398 [rtl] XdpLifetimeWorker:72 Entry=FFFF9182000F2FE8 completed


[0]0004.00F4::‎2023‎-‎06‎-‎11 22:27:23.403 [xdplwf] XdpGenericRxCreateQueue:1424 <--- STATUS_SUCCESS

[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.405 [xdpfnmp] GenericIrpRxFlush:166 ---> Adapter=FFFF9181FFDDAEE0
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.405 [xdpfnmp] TraceNbls:15 Nbl=FFFF918201502DB0
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.405 [Microsoft-XDP][gxrf][0xFFFF9181F5572E28] inspect RX batch 
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.405 [Microsoft-XDP][gxrf][0xFFFF9181F5572E28] inspect RX batch complete 
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.405 [xdpfnlwf] FilterReceiveNetBufferLists:322 ---> Filter=FFFF918201358F90
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.405 [xdpfnlwf] TraceNbls:15 Nbl=FFFF918201502DB0
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.405 [Microsoft-Windows-TCPIP]Nbl 0xFFFF918201502DB0 OOB info (Receive ): TcpIpChecksumNetBufferListInfo 0x0, TcpLargeSendNetBufferListInfo 0x0, Ieee8021QNetBufferListInfo 0x0, NetBufferListHashValue 0x80000000, NetBufferListHashInfo 0x101, VirtualSubnetInfo 0x0, TcpRecvSegCoalesceInfo 0x0, NrtNameResolutionId 0x0 
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.405 [Microsoft-Windows-TCPIP]TCPIP: NBL 0xFFFF918201502DB0 fell off the receive fast path, Reason: IP checksum offload not computed . Protocol = Unknown , Family = IPV4 , Number of NBLs = 1. SourceAddress = 0.0.0.0    . DestAddress = 0.0.0.0    . 
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.405 [Microsoft-Windows-TCPIP]INETINSPECT: Owner = 0xFFFF9181FF3FA250, InspectHandle = 0xFFFFBA0B5BDCD2A8, InspectType = CreateEndpoint , Action = Allow , Status = STATUS_SUCCESS 
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.405 [Microsoft-Windows-TCPIP]INETINSPECT: Owner = 0xFFFF9181FF3FA250, InspectHandle = 0xFFFF9181F9CA5960, InspectType = ReceiveTcpDatagram , Action = Allow , Status = STATUS_SUCCESS 
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.406 [Microsoft-Windows-TCPIP]INETINSPECT: Owner = 0xFFFF9181FF3FA250, InspectHandle = 0xFFFF9181F9CA5960, InspectType = Accept , Action = Allow , Status = STATUS_SUCCESS 
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.406 [Microsoft-Windows-TCPIP]TCP: Connection 0xFFFF9181F018A8A0 template changed. New template=TcpTemplateTypeAutomatic . Context=Initializing Template Accept TCB. 
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.406 [Microsoft-Windows-TCPIP]IP: Setting source constraint for route lookup - Compartment: 1 DstAddr: 192.168.201.2 ConstrainSrcAddr: 192.168.201.1 ConstrainIfIndex: 26 ConstraintFlags: 0x1 
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.406 [Microsoft-Windows-TCPIP]IP: RouteLookup - API: IppFindNextHopAtDpcHelper DstAddr: 192.168.201.2 ConstrainSrcAddr: 192.168.201.1 ConstrainIfIndex: 26 ConstraintOveridden: 0 ReturnConstrained: 0 OutgoingIfIndex: 26 NextHopAddr: 192.168.201.2 Status: STATUS_SUCCESS 
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.406 [Microsoft-Windows-TCPIP]IP: SourceAddrLookup - DstAddr: 192.168.201.2 ConstrainSrcAddr: 192.168.201.1 ConstrainIfIndex: 26 OutgoingIfIndex: 26 ReturnConstrained: 2048 SelectedSrcAddr: 192.168.201.1 
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.406 [Microsoft-Windows-TCPIP]TCP: connection 0xFFFF9181F018A8A0 transition from ListenState  to SynRcvdState , SndNxt = 0. 
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.406 [Microsoft-Windows-TCPIP]TCP  timer rescheduled by processor 1 for processor 2 at Tick = 545047 to Tick = 545057, OldScheduledExpiration = 5459801108 NewScheduledExpiration = 5450280204 DueTime = -100000 Aperiodic = TRUE . 
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.406 [Microsoft-Windows-TCPIP]TCP: connection 0xFFFF9181F018A8A0: TCP send event, SeqNo = 547339576, BytesSent = 1, CWnd = 5360, SndWnd = 65535, SRtt = 3072000, RttVar = 0, RTO = 3000, RcvWnd = 65392. 
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.406 [Microsoft-Windows-TCPIP]TCP: Connection 0xFFFF9181F018A8A0 RetransmitTimer  timer started. Scheduled to expire in 3000 ms. Processor 1: LastInterruptTime 5450180204 100-ns ticks; LastMicrosecondCount 545047896 msec; CachedKQPCValue 5450478963 ticks; CachedFrequencyValue 10000000. 
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.406 [Microsoft-Windows-TCPIP]TCPIP: Framing layer Send  (AddressFamily=IPV4 ) dropped 1 packet(s) on interface=26, Reason=Packet provider reference failure , Data=0x0. 
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.406 [Microsoft-Windows-TCPIP]Nbl 0xFFFF9181FFA6EC60 OOB info (Send ): TcpIpChecksumNetBufferListInfo 0x0, TcpLargeSendNetBufferListInfo 0x0, Ieee8021QNetBufferListInfo 0x0, NetBufferListHashValue 0x8CB2186E, NetBufferListHashInfo 0x0, VirtualSubnetInfo 0x0, TcpRecvSegCoalesceInfo 0x0, NrtNameResolutionId 0x0 
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.406 [xdpfnlwf] FilterReturnNetBufferLists:299 ---> Filter=FFFF918201358F90
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.406 [xdpfnlwf] TraceNbls:15 Nbl=FFFF918201502DB0
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.406 [xdpfnlwf] FilterReturnNetBufferLists:305 <--- STATUS_SUCCESS
[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:23.406 [xdpfnmp] MpReturnNetBufferLists:139 ---> Adapter=FFFF9181FFDDAEE0


[3]0004.01A4::‎2023‎-‎06‎-‎11 22:27:23.437 [Microsoft-Windows-TCPIP]Framing: NDIS restart event. Interface = 26, Compartment = 1. 

[1]0004.01A4::‎2023‎-‎06‎-‎11 22:27:23.443 [Microsoft-Windows-TCPIP]Framing: NDIS restart event. Interface = 26, Compartment = 1. 

[1]1A90.04B4::‎2023‎-‎06‎-‎11 22:27:24.428 [Microsoft-Windows-TCPIP]TCPIP: Transport (Protocol TCP , AddressFamily = IPV4 ) dropped 1 packet(s) with Local = 192.168.201.1:52262, Remote = 192.168.201.2:1234. Reason = ACK Invalid (subreason 0) (invalid ACK in SYN_SENT state) . 

```