### PR TITLE
Fix incomplete TCP test case fix

### DIFF
--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -2082,6 +2082,7 @@ CreateTcpSocket(
             break;
         }
 
+        XskRingConsumerRelease(&Xsk.Rings.Rx, 1);
         SocketProduceRxFill(&Xsk, 1);
         TcpHeaderParsed = NULL;
     } while (!Watchdog.IsExpired());


### PR DESCRIPTION
I forgot to advance the RX completion ring, so we re-retrieve the same frame over and over again until either the test case times out or we receive two (!) frames, which causes an assert failure. Advance past the TCP frames we reject.