### PR TITLE
Remove TODO in RSS initialization query

### DIFF
--- a/src/xdplwf/rss.c
+++ b/src/xdplwf/rss.c
@@ -452,10 +452,6 @@ XdpGenericRssInitialize(
     //
     // Attempt to query the indirection table.
     //
-    // TODO: how do we avoid a race with the protocol driver plumbing RSS? The
-    // OID might already be in flight before this LWF has a chance to inspect it
-    // and might still be in flight after we query NDIS.
-    //
 
     Status =
         XdpLwfOidInternalRequest(


### PR DESCRIPTION
I've verified NDIS performs the required serialization across OIDs on our behalf, so remove the TODO.

Resolves #56 