### PR TITLE
consistently use xdp.cpp.default.props

### DIFF
--- a/samples/rxfilter/rxfilter.vcxproj
+++ b/samples/rxfilter/rxfilter.vcxproj
@@ -21,6 +21,7 @@
     <RootNamespace>rxfilter</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>

--- a/src/nmr/nmr.vcxproj
+++ b/src/nmr/nmr.vcxproj
@@ -23,6 +23,7 @@
     <DriverType>KMDF</DriverType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>

--- a/src/pollshim/pollshim.vcxproj
+++ b/src/pollshim/pollshim.vcxproj
@@ -20,6 +20,7 @@
     <DriverType>KMDF</DriverType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>

--- a/src/rtl/rtl.vcxproj
+++ b/src/rtl/rtl.vcxproj
@@ -24,6 +24,7 @@
     <DriverType>KMDF</DriverType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>

--- a/src/xdp/xdp.vcxproj
+++ b/src/xdp/xdp.vcxproj
@@ -97,6 +97,7 @@
     <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>

--- a/src/xdpapi/xdpapi.vcxproj
+++ b/src/xdpapi/xdpapi.vcxproj
@@ -64,6 +64,7 @@
     <RootNamespace>xdpapi</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>

--- a/src/xdpetw/xdpetw.vcxproj
+++ b/src/xdpetw/xdpetw.vcxproj
@@ -5,6 +5,7 @@
     <ProjectGuid>{a87d995b-384f-4853-abdb-3ec024be18e3}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>

--- a/src/xdplwf/xdplwf.vcxproj
+++ b/src/xdplwf/xdplwf.vcxproj
@@ -36,6 +36,7 @@
     <DriverType>KMDF</DriverType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>

--- a/test/build_headers/ddk/c/cddkheaders.vcxproj
+++ b/test/build_headers/ddk/c/cddkheaders.vcxproj
@@ -17,6 +17,7 @@
     <DriverType>KMDF</DriverType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>

--- a/test/build_headers/ddk/cpp/cppddkheaders.vcxproj
+++ b/test/build_headers/ddk/cpp/cppddkheaders.vcxproj
@@ -17,6 +17,7 @@
     <DriverType>KMDF</DriverType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>

--- a/test/build_headers/sdk/c/csdkheaders.vcxproj
+++ b/test/build_headers/sdk/c/csdkheaders.vcxproj
@@ -24,6 +24,7 @@
     <RootNamespace>csdkheaders</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>

--- a/test/build_headers/sdk/cpp/cppsdkheaders.vcxproj
+++ b/test/build_headers/sdk/cpp/cppsdkheaders.vcxproj
@@ -24,6 +24,7 @@
     <RootNamespace>cppsdkheaders</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>

--- a/test/common/lib/bounce/bounce.vcxproj
+++ b/test/common/lib/bounce/bounce.vcxproj
@@ -17,6 +17,7 @@
     <DriverType>KMDF</DriverType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>

--- a/test/common/lib/fnio/fnio.vcxproj
+++ b/test/common/lib/fnio/fnio.vcxproj
@@ -19,6 +19,7 @@
     <DriverType>KMDF</DriverType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>

--- a/test/common/lib/util/util.vcxproj
+++ b/test/common/lib/util/util.vcxproj
@@ -16,6 +16,7 @@
     <RootNamespace>util</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>

--- a/test/fakendis/fndis.vcxproj
+++ b/test/fakendis/fndis.vcxproj
@@ -30,6 +30,7 @@
     <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>

--- a/test/functional/lib/xdptests.vcxproj
+++ b/test/functional/lib/xdptests.vcxproj
@@ -17,6 +17,7 @@
     <RootNamespace>xdptests</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>

--- a/test/functional/lwf/lib/xdpfnlwfapi.vcxproj
+++ b/test/functional/lwf/lib/xdpfnlwfapi.vcxproj
@@ -17,6 +17,7 @@
     <RootNamespace>xdpfnlwfapi</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>

--- a/test/functional/lwf/sys/xdpfnlwf.vcxproj
+++ b/test/functional/lwf/sys/xdpfnlwf.vcxproj
@@ -45,6 +45,7 @@
     <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>

--- a/test/functional/mp/lib/xdpfnmpapi.vcxproj
+++ b/test/functional/mp/lib/xdpfnmpapi.vcxproj
@@ -17,6 +17,7 @@
     <RootNamespace>xdpfnmpapi</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>

--- a/test/functional/mp/sys/generic/xdpfnmpgeneric.vcxproj
+++ b/test/functional/mp/sys/generic/xdpfnmpgeneric.vcxproj
@@ -22,6 +22,7 @@
     <DriverType>KMDF</DriverType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>

--- a/test/functional/mp/sys/native/xdpfnmpnative.vcxproj
+++ b/test/functional/mp/sys/native/xdpfnmpnative.vcxproj
@@ -22,6 +22,7 @@
     <DriverType>KMDF</DriverType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>

--- a/test/functional/mp/sys/xdpfnmp.vcxproj
+++ b/test/functional/mp/sys/xdpfnmp.vcxproj
@@ -52,6 +52,7 @@
     <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>

--- a/test/functional/taef/xdpfunctionaltests.vcxproj
+++ b/test/functional/taef/xdpfunctionaltests.vcxproj
@@ -37,6 +37,7 @@
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <ConfigurationType>DynamicLibrary</ConfigurationType>

--- a/test/pktcmd/pktcmd.vcxproj
+++ b/test/pktcmd/pktcmd.vcxproj
@@ -21,6 +21,7 @@
     <RootNamespace>pktcmd</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>

--- a/test/pkthlp/km/pkthlp_km.vcxproj
+++ b/test/pkthlp/km/pkthlp_km.vcxproj
@@ -17,6 +17,7 @@
     <DriverType>KMDF</DriverType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>

--- a/test/pkthlp/um/pkthlp_um.vcxproj
+++ b/test/pkthlp/um/pkthlp_um.vcxproj
@@ -16,6 +16,7 @@
     <RootNamespace>pkthlp_um</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>

--- a/test/rssconfig/rssconfig.vcxproj
+++ b/test/rssconfig/rssconfig.vcxproj
@@ -16,6 +16,7 @@
     <RootNamespace>rssconfig</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>

--- a/test/xdpmp/xdpmp.vcxproj
+++ b/test/xdpmp/xdpmp.vcxproj
@@ -42,6 +42,7 @@
     <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>

--- a/test/xskbench/xskbench.vcxproj
+++ b/test/xskbench/xskbench.vcxproj
@@ -24,6 +24,7 @@
     <RootNamespace>xskbench</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(SolutionDir)xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
     <PlatformToolset>WindowsApplicationForDrivers10.0</PlatformToolset>

--- a/xdp.cpp.props
+++ b/xdp.cpp.props
@@ -29,8 +29,6 @@
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
       <PreprocessorDefinitions>
-        NTDDI_VERSION=NTDDI_WIN10_VB;
-        _WIN32_WINNT=_WIN32_WINNT_WIN10;
         POOL_NX_OPTIN_AUTO=1;
         POOL_ZERO_DOWN_LEVEL_SUPPORT=1;
         %(PreprocessorDefinitions)

--- a/xdp.cpp.props
+++ b/xdp.cpp.props
@@ -28,7 +28,13 @@
         $(SolutionDir)published\external;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>POOL_NX_OPTIN_AUTO=1;POOL_ZERO_DOWN_LEVEL_SUPPORT=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>
+        NTDDI_VERSION=NTDDI_WIN10_VB;
+        _WIN32_WINNT=_WIN32_WINNT_WIN10;
+        POOL_NX_OPTIN_AUTO=1;
+        POOL_ZERO_DOWN_LEVEL_SUPPORT=1;
+        %(PreprocessorDefinitions)
+      </PreprocessorDefinitions>
       <!-- Disable C26812: The enum type '' is unscoped. Prefer 'enum class' over 'enum' -->
       <DisableSpecificWarnings>26812;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>


### PR DESCRIPTION
To provide a single point of maintenance, consistently import xdp.cpp.default.props in each project file.