### PR TITLE
Add new -ForPerfTest profile to prepare-machine.ps1

### DIFF
--- a/.azure/templates/spinxsk.yml
+++ b/.azure/templates/spinxsk.yml
@@ -61,7 +61,7 @@ jobs:
     displayName: Prepare Machine
     inputs:
       filePath: tools/prepare-machine.ps1
-      arguments: -ForTest -NoReboot -Verbose
+      arguments: -ForSpinxskTest -NoReboot -Verbose
 
   - task: DownloadBuildArtifacts@0
     displayName: Download Artifacts

--- a/.azure/templates/tests.yml
+++ b/.azure/templates/tests.yml
@@ -41,7 +41,7 @@ jobs:
     displayName: Prepare Machine
     inputs:
       filePath: tools/prepare-machine.ps1
-      arguments: -ForTest -NoReboot -Verbose
+      arguments: -ForFunctionalTest -NoReboot -Verbose
 
   - task: DownloadBuildArtifacts@0
     displayName: Download Artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
       run: tools/check-drivers.ps1 -Verbose
     - name: Prepare Machine
       shell: PowerShell
-      run: tools/prepare-machine.ps1 -ForTest -NoReboot -Verbose
+      run: tools/prepare-machine.ps1 -ForPerfTest -NoReboot -Verbose
     - name: Download Artifacts
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       run: tools/check-drivers.ps1 -Verbose
     - name: Prepare Machine
       shell: PowerShell
-      run: tools/prepare-machine.ps1 -ForTest -NoReboot -Verbose
+      run: tools/prepare-machine.ps1 -ForFunctionalTest -NoReboot -Verbose
     - name: Download Artifacts
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
       with:
@@ -169,7 +169,7 @@ jobs:
       run: tools/check-drivers.ps1 -Verbose
     - name: Prepare Machine
       shell: PowerShell
-      run: tools/prepare-machine.ps1 -ForTest -NoReboot -Verbose
+      run: tools/prepare-machine.ps1 -ForSpinxskTest -NoReboot -Verbose
     - name: Download Artifacts
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
       with:

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -299,6 +299,12 @@ if ($Cleanup) {
     if ($ForPerfTest) {
         $ForTest = $true
 
+        Write-Verbose "verifier.exe /reset"
+        verifier.exe /reset | Write-Verbose
+        if (!$?) {
+            $Reboot = $true
+        }
+
         Install-AzStorageModule
     }
 

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -266,6 +266,7 @@ if ($Cleanup) {
             $Reboot = $true
         }
 
+        Setup-VcRuntime
         Setup-VsTest
     }
 
@@ -313,7 +314,6 @@ if ($Cleanup) {
         Download-CoreNet-Deps
         Download-Ebpf-Msi
         Install-Certs
-        Setup-VcRuntime
     }
 
     if ($ForLogging) {

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -48,6 +48,9 @@ param (
     [switch]$ForSpinxskTest = $false,
 
     [Parameter(Mandatory = $false)]
+    [switch]$ForPerfTest = $false,
+
+    [Parameter(Mandatory = $false)]
     [switch]$ForLogging = $false,
 
     [Parameter(Mandatory = $false)]
@@ -66,8 +69,8 @@ $ErrorActionPreference = 'Stop'
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
 
-if (!$ForBuild -and !$ForEbpfBuild -and !$ForTest -and !$ForFunctionalTest -and !$ForSpinxskTest -and !$ForLogging) {
-    Write-Error 'Must one of -ForBuild, -ForTest, -ForFunctionalTest, -ForSpinxskTest, or -ForLogging'
+if (!$ForBuild -and !$ForEbpfBuild -and !$ForTest -and !$ForFunctionalTest -and !$ForSpinxskTest -and !$ForPerfTest -and !$ForLogging) {
+    Write-Error 'Must one of -ForBuild, -ForTest, -ForFunctionalTest, -ForSpinxskTest, -ForPerfTest, or -ForLogging'
 }
 
 $EbpfNugetVersion = "eBPF-for-Windows.0.9.0"
@@ -262,6 +265,8 @@ if ($Cleanup) {
             reg.exe add HKLM\System\CurrentControlSet\Control\CrashControl /v CrashDumpEnabled /d 1 /t REG_DWORD /f
             $Reboot = $true
         }
+
+        Setup-VsTest
     }
 
     if ($ForSpinxskTest) {
@@ -291,14 +296,18 @@ if ($Cleanup) {
         }
     }
 
+    if ($ForPerfTest) {
+        $ForTest = $true
+
+        Install-AzStorageModule
+    }
+
     if ($ForTest) {
         Setup-TestSigning
         Download-CoreNet-Deps
         Download-Ebpf-Msi
         Install-Certs
         Setup-VcRuntime
-        Setup-VsTest
-        Install-AzStorageModule
     }
 
     if ($ForLogging) {


### PR DESCRIPTION
Add new perf test profile to avoid needlessly installing and uninstalling Azure modules, which is pretty slow. Same with the C++ test framework.