### PR TITLE
Use enum for XdpCreateProgram flags

### DIFF
--- a/published/external/xdpapi.h
+++ b/published/external/xdpapi.h
@@ -26,21 +26,28 @@ extern "C" {
 // N.B. The current implementation supports only L2 RX inspect programs.
 //
 
-//
-// Attach to the interface using the generic XDP provider.
-//
-#define XDP_CREATE_PROGRAM_FLAG_GENERIC 0x1
+typedef enum _XDP_CREATE_PROGRAM_FLAGS {
+    XDP_CREATE_PROGRAM_FLAG_NONE = 0x0,
 
-//
-// Attach to the interface using the native XDP provider. If the interface does
-// not support native XDP, the attach will fail.
-//
-#define XDP_CREATE_PROGRAM_FLAG_NATIVE  0x2
+    //
+    // Attach to the interface using the generic XDP provider.
+    //
+    XDP_CREATE_PROGRAM_FLAG_GENERIC = 0x1,
 
-//
-// Attach to all XDP queues on the interface.
-//
-#define XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES  0x4
+    //
+    // Attach to the interface using the native XDP provider. If the interface does
+    // not support native XDP, the attach will fail.
+    //
+    XDP_CREATE_PROGRAM_FLAG_NATIVE = 0x2,
+
+    //
+    // Attach to all XDP queues on the interface.
+    //
+    XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES = 0x4,
+} XDP_CREATE_PROGRAM_FLAGS;
+
+DEFINE_ENUM_FLAG_OPERATORS(XDP_CREATE_PROGRAM_FLAGS);
+C_ASSERT(sizeof(XDP_CREATE_PROGRAM_FLAGS) == sizeof(UINT32));
 
 typedef
 HRESULT
@@ -48,7 +55,7 @@ XDP_CREATE_PROGRAM_FN(
     _In_ UINT32 InterfaceIndex,
     _In_ CONST XDP_HOOK_ID *HookId,
     _In_ UINT32 QueueId,
-    _In_ UINT32 Flags,
+    _In_ XDP_CREATE_PROGRAM_FLAGS Flags,
     _In_reads_(RuleCount) CONST XDP_RULE *Rules,
     _In_ UINT32 RuleCount,
     _Out_ HANDLE *Program

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -1018,7 +1018,7 @@ TryCreateXdpProg(
     _In_ XDP_MODE XdpMode,
     _In_ XDP_RULE *Rules,
     _In_ UINT32 RuleCount,
-    _In_ UINT32 Flags = 0
+    _In_ XDP_CREATE_PROGRAM_FLAGS Flags = XDP_CREATE_PROGRAM_FLAG_NONE
     )
 {
     ASSERT(Flags & (XDP_CREATE_PROGRAM_FLAG_GENERIC | XDP_CREATE_PROGRAM_FLAG_NATIVE) == 0);
@@ -1042,7 +1042,7 @@ CreateXdpProg(
     _In_ XDP_MODE XdpMode,
     _In_ XDP_RULE *Rules,
     _In_ UINT32 RuleCount,
-    _In_ UINT32 Flags = 0
+    _In_ XDP_CREATE_PROGRAM_FLAGS Flags = XDP_CREATE_PROGRAM_FLAG_NONE
     )
 {
     wil::unique_handle ProgramHandle;


### PR DESCRIPTION
Avoid using `UINT32` types for flags.