### PR TITLE
Remove nonstandard shared umem option

### DIFF
--- a/published/external/afxdp.h
+++ b/published/external/afxdp.h
@@ -474,16 +474,6 @@ typedef enum _XSK_ERROR {
 #define XSK_SOCKOPT_TX_COMPLETION_ERROR   13
 
 //
-// Supports: set
-//
-// Optval type: HANDLE
-// Description: An AF_XDP socket can share a UMEM registered with another AF_XDP
-//              socket by supplying the handle of the socket already registered
-//              with a UMEM.
-//
-#define XSK_SOCKOPT_SHARE_UMEM 14
-
-//
 // XSK_SOCKOPT_TX_FRAME_LAYOUT_EXTENSION
 //
 // Supports: get
@@ -493,7 +483,7 @@ typedef enum _XSK_ERROR {
 //              set, and at least one socket option has enabled the frame layout
 //              extension.
 //
-#define XSK_SOCKOPT_TX_FRAME_LAYOUT_EXTENSION 15
+#define XSK_SOCKOPT_TX_FRAME_LAYOUT_EXTENSION 14
 
 //
 // XSK_SOCKOPT_TX_FRAME_CHECKSUM_EXTENSION
@@ -505,7 +495,7 @@ typedef enum _XSK_ERROR {
 //              is set, and at least one socket option has enabled the frame
 //              layout extension.
 //
-#define XSK_SOCKOPT_TX_FRAME_CHECKSUM_EXTENSION 16
+#define XSK_SOCKOPT_TX_FRAME_CHECKSUM_EXTENSION 15
 
 //
 // XSK_SOCKOPT_OFFLOAD_UDP_CHECKSUM_TX
@@ -517,7 +507,7 @@ typedef enum _XSK_ERROR {
 //              is not set. This option enables the XDP_FRAME_LAYOUT and
 //              XDP_FRAME_CHECKSUM extensions on the TX frame ring.
 //
-#define XSK_SOCKOPT_OFFLOAD_UDP_CHECKSUM_TX 17
+#define XSK_SOCKOPT_OFFLOAD_UDP_CHECKSUM_TX 16
 
 //
 // XSK_SOCKOPT_OFFLOAD_UDP_CHECKSUM_TX_CAPABILITIES
@@ -527,7 +517,7 @@ typedef enum _XSK_ERROR {
 // Description: Returns the UDP checksum transmit offload capabilities. This
 //              option requires the socket is bound.
 //
-#define XSK_SOCKOPT_OFFLOAD_UDP_CHECKSUM_TX_CAPABILITIES 18
+#define XSK_SOCKOPT_OFFLOAD_UDP_CHECKSUM_TX_CAPABILITIES 17
 
 typedef struct _XSK_OFFLOAD_UDP_CHECKSUM_TX_CAPABILITIES {
     BOOLEAN Supported;
@@ -544,7 +534,7 @@ typedef struct _XSK_OFFLOAD_UDP_CHECKSUM_TX_CAPABILITIES {
 //              HRESULT_FROM_WIN32(ERROR_NOT_CAPABLE), when the ideal processor
 //              affinity is unknown or unknowable.
 //
-#define XSK_SOCKOPT_RX_PROCESSOR_AFFINITY 19
+#define XSK_SOCKOPT_RX_PROCESSOR_AFFINITY 18
 
 //
 // XSK_SOCKOPT_TX_PROCESSOR_AFFINITY
@@ -557,7 +547,7 @@ typedef struct _XSK_OFFLOAD_UDP_CHECKSUM_TX_CAPABILITIES {
 //              HRESULT_FROM_WIN32(ERROR_NOT_CAPABLE), when the ideal processor
 //              affinity is unknown or unknowable.
 //
-#define XSK_SOCKOPT_TX_PROCESSOR_AFFINITY 20
+#define XSK_SOCKOPT_TX_PROCESSOR_AFFINITY 19
 
 #ifdef __cplusplus
 } // extern "C"

--- a/published/external/xdpapi.h
+++ b/published/external/xdpapi.h
@@ -351,7 +351,7 @@ typedef struct _XDP_API_TABLE XDP_API_TABLE;
 // The only API version currently supported. Any change to the API is considered
 // a breaking change and support for previous versions will be removed.
 //
-#define XDP_VERSION_PRERELEASE 100005
+#define XDP_VERSION_PRERELEASE 100006
 
 //
 // Opens the API and returns an API function table with the rest of the API's

--- a/test/spinxsk/spinxsk.c
+++ b/test/spinxsk/spinxsk.c
@@ -1286,24 +1286,16 @@ FuzzSocketSharedUmemSetup(
     _In_ HANDLE SharedUmemSock
     )
 {
+    HRESULT res;
+
     if (RandUlong() % 2) {
-        HRESULT res;
-
-        switch (RandUlong() % 4) {
-        case 0:
-            SharedUmemSock = NULL;
-            break;
-        case 1:
-            SharedUmemSock = Sock;
-            break;
-        }
-
         res =
             Queue->xdpApi->XskSetSockopt(
-                Sock, XSK_SOCKOPT_SHARE_UMEM, &SharedUmemSock, sizeof(SharedUmemSock));
+                Sock, XSK_SOCKOPT_UMEM_REG, &Queue->umemReg, sizeof(Queue->umemReg));
         if (SUCCEEDED(res)) {
             TraceVerbose(
-                "q[%u]: umem shared with SharedUmemSock=%p", Queue->queueId, SharedUmemSock);
+                "q[%u]: umem shared with SharedUmemSock=%p Buffer=%p",
+                Queue->queueId, SharedUmemSock, Queue->umemReg.address);
         }
     }
 }


### PR DESCRIPTION
Resolves #294 

This feature is untested, diverged from Linux, and AFAIK unused. Remove it for 1.0.