### PR TITLE
Reduce spinxsk success threshold for MsQuic pool

### DIFF
--- a/.azure/azure-pipelines.ci.yml
+++ b/.azure/azure-pipelines.ci.yml
@@ -149,7 +149,7 @@ stages:
       runtimeMinutes: 2
       timeoutMinutes: 7
       jobTimeoutMinutes: 17
-      successThresholdPercent: 50
+      successThresholdPercent: 10
   - template: ./templates/spinxsk.yml
     parameters:
       pool: XDP-CI-1ES-Spinxsk-2
@@ -187,7 +187,7 @@ stages:
       runtimeMinutes: 2
       timeoutMinutes: 7
       jobTimeoutMinutes: 17
-      successThresholdPercent: 50
+      successThresholdPercent: 10
   - template: ./templates/spinxsk.yml
     parameters:
       pool: XDP-CI-1ES-Spinxsk-2


### PR DESCRIPTION
The MsQuic pool only runs spinxsk for 2 minutes, which because of the small sample size of spins, there is a higher chance of outliers. Reduce the minimum success rate to 10% from 50%.