### PR TITLE
Check drivers after prepare-machine

### DIFF
--- a/.azure/templates/spinxsk.yml
+++ b/.azure/templates/spinxsk.yml
@@ -52,16 +52,16 @@ jobs:
   - checkout: self
 
   - task: PowerShell@2
-    displayName: Check Drivers
-    inputs:
-      filePath: tools/check-drivers.ps1
-      arguments: -Verbose
-
-  - task: PowerShell@2
     displayName: Prepare Machine
     inputs:
       filePath: tools/prepare-machine.ps1
       arguments: -ForSpinxskTest -NoReboot -Verbose
+
+  - task: PowerShell@2
+    displayName: Check Drivers
+    inputs:
+      filePath: tools/check-drivers.ps1
+      arguments: -Verbose
 
   - task: DownloadBuildArtifacts@0
     displayName: Download Artifacts

--- a/.azure/templates/tests.yml
+++ b/.azure/templates/tests.yml
@@ -32,16 +32,16 @@ jobs:
   - checkout: self
 
   - task: PowerShell@2
-    displayName: Check Drivers
-    inputs:
-      filePath: tools/check-drivers.ps1
-      arguments: -Verbose
-
-  - task: PowerShell@2
     displayName: Prepare Machine
     inputs:
       filePath: tools/prepare-machine.ps1
       arguments: -ForFunctionalTest -NoReboot -Verbose
+
+  - task: PowerShell@2
+    displayName: Check Drivers
+    inputs:
+      filePath: tools/check-drivers.ps1
+      arguments: -Verbose
 
   - task: DownloadBuildArtifacts@0
     displayName: Download Artifacts


### PR DESCRIPTION
MsQuic machines are borked because jobs got cancelled while eBPF was installed, and the check-drivers script runs before the eBPF installer gets downloaded.

Download the MSI installer (and other stuff) prior to checking for lingering drivers.