### PR TITLE
eBPF uninstall bugchecks aren't being captured, so try again with live dumps

### DIFF
--- a/.azure/templates/tests.yml
+++ b/.azure/templates/tests.yml
@@ -60,6 +60,7 @@ jobs:
   - task: PowerShell@2
     displayName: Convert Logs
     condition: always()
+    timeoutInMinutes: 5
     inputs:
       filePath: tools/log.ps1
       arguments: -Convert -Name xdpfunc* -Verbose -Config ${{ parameters.config }} -Arch ${{ parameters.arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
       run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Iterations ${{ env.fullIters }} -Timeout ${{ env.fullRuntime }}
     - name: Convert Logs
       if: ${{ always() }}
+      timeout-minutes: 5
       shell: PowerShell
       run: tools/log.ps1 -Convert -Name xdpfunc* -Verbose -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }}
     - name: Upload Logs
@@ -184,6 +185,7 @@ jobs:
       run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Minutes ${{ env.fullRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf
     - name: Convert Logs
       if: ${{ always() }}
+      timeout-minutes: 5
       shell: PowerShell
       run: tools/log.ps1 -Convert -Name spinxsk -Verbose -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }}
     - name: Upload Logs

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -547,16 +547,14 @@ function Uninstall-Ebpf {
 
         if (!(Wait-Job -Job $Job -Timeout 60)) {
             Write-Error "eBPF failed to uninstall within 60 seconds" -ErrorAction Continue
-            Write-Warning "The system will bugcheck in 5 seconds..."
-            Start-Sleep -Seconds 5
-            Initiate-Bugcheck
+            Uninstall-Failure
         }
 
         if (($Status = Receive-Job -Job $Job) -ne 0) {
             if ($Status -eq 0x666) {
                 Write-Error "An unexpected version of eBPF could not be uninstalled"
             } else {
-                Write-Error "MSI uninstall failed with status $Status" -ErrorAction:Continue
+                Write-Error "MSI uninstall failed with status $Status" -ErrorAction Continue
                 Uninstall-Failure
             }
         }


### PR DESCRIPTION
Fall back to capturing live dumps when eBPF fails to uninstall. I recall there was a problem with something else in the pipeline stalling before the dumps could be uploaded, so also timebox the log conversion step.

#306 