### PR TITLE
Use XDP MSI in CI tests

### DIFF
--- a/.azure/templates/build.yml
+++ b/.azure/templates/build.yml
@@ -80,6 +80,24 @@ jobs:
       filePath: tools/sign.ps1
       arguments: -Config ${{ parameters.config }} -Arch ${{ parameters.arch }}
 
+  - task: VSBuild@1
+    displayName: Build Installer (Debug)
+    condition: and(succeeded(), contains('${{ parameters.config }}', 'Debug'))
+    inputs:
+      solution: src\xdpinstaller\xdpinstaller.sln
+      platform: ${{ parameters.arch }}
+      configuration: debug
+      msbuildArgs: -m
+
+  - task: VSBuild@1
+    displayName: Build Installer (Release)
+    condition: and(succeeded(), contains('${{ parameters.config }}', 'Release'))
+    inputs:
+      solution: src\xdpinstaller\xdpinstaller.sln
+      platform: ${{ parameters.arch }}
+      configuration: release
+      msbuildArgs: -m
+
   - task: CopyFiles@2
     displayName: Filter Artifacts
     condition: and(succeeded(), eq('${{ parameters.publish }}', 'true'))

--- a/src/xdpinstaller/xdpinstaller.wixproj
+++ b/src/xdpinstaller/xdpinstaller.wixproj
@@ -5,9 +5,9 @@
     <ProductVersion>3.10</ProductVersion>
     <ProjectGuid>93635a7b-565e-4b41-af67-5b375756b227</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
-    <OutputName>xdpinstaller</OutputName>
+    <OutputName>xdp-for-windows</OutputName>
     <OutputType>Package</OutputType>
-    <OutputPath>$(SolutionDir)..\..\artifacts\bin\$(Platform)_$(Configuration)\msi\</OutputPath>
+    <OutputPath>$(SolutionDir)..\..\artifacts\bin\$(Platform)_$(Configuration)\xdpinstaller\</OutputPath>
     <IntermediateOutputPath>$(SolutionDir)..\..\build\$(Platform)_$(Configuration)\obj\$(OutputName)\</IntermediateOutputPath>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DefineConstants>

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -94,9 +94,14 @@ function Get-VsTestPath {
     return $null
 }
 
+# Returns the XDP installation path
+function Get-XdpInstallPath {
+    return "$($env:SystemDrive)\xdpmsi"
+}
+
 # Returns the eBPF installation path
 function Get-EbpfInstallPath {
-    return "C:\ebpf"
+    return "$($env:SystemDrive)\ebpf"
 }
 
 # Returns the eBPF MSI filename

--- a/tools/sign.ps1
+++ b/tools/sign.ps1
@@ -71,7 +71,6 @@ if (!(Test-Path $CertPath)) { Write-Error "$CertPath does not exist!" }
 
 # All the file paths.
 $XdpDir = Join-Path $ArtifactsDir "xdp"
-$XdpMsiDir = Join-Path $ArtifactsDir "msi"
 $XdpSys = Join-Path $XdpDir "xdp.sys"
 $XdpInf = Join-Path $XdpDir "xdp.inf"
 $XdpCat = Join-Path $XdpDir "xdp.cat"


### PR DESCRIPTION
Install and uninstall XDP using the MSI installer in CI tests. For now, leave the old install/uninstall steps in case we need them.
#307 