### PR TITLE
Fix perf runs with MSI

### DIFF
--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -63,7 +63,6 @@ $DevCon = Get-CoreNetCiArtifactPath -Name "devcon.exe"
 $DswDevice = Get-CoreNetCiArtifactPath -Name "dswdevice.exe"
 
 # File paths.
-$XdpSys = "$ArtifactsDir\xdp\xdp.sys"
 $XdpInf = "$ArtifactsDir\xdp\xdp.inf"
 $XdpMsiFullPath = "$ArtifactsDir\xdpinstaller\xdp-for-windows.msi"
 $FndisSys = "$ArtifactsDir\fndis\fndis.sys"
@@ -81,6 +80,9 @@ $XdpFnMpServiceName = "XDPFNMP"
 $XdpFnLwfSys = "$ArtifactsDir\xdpfnlwf\xdpfnlwf.sys"
 $XdpFnLwfInf = "$ArtifactsDir\xdpfnlwf\xdpfnlwf.inf"
 $XdpFnLwfComponentId = "ms_xdpfnlwf"
+
+# Ensure the output path exists.
+New-Item -ItemType Directory -Force -Path $LogsDir | Out-Null
 
 # Helper to capture failure diagnostics and trigger CI agent reboot
 function Uninstall-Failure {

--- a/tools/xskperf.ps1
+++ b/tools/xskperf.ps1
@@ -95,6 +95,9 @@ param (
     [string]$XperfFile = ""
 )
 
+Set-StrictMode -Version 'Latest'
+$ErrorActionPreference = 'Stop'
+
 function Wait-NetAdapterUpStatus {
     [CmdletBinding()]
     param(

--- a/tools/xskperfsuite.ps1
+++ b/tools/xskperfsuite.ps1
@@ -68,6 +68,10 @@ param (
     [string]$CommitHash = ""
 )
 
+
+Set-StrictMode -Version 'Latest'
+$ErrorActionPreference = 'Stop'
+
 function ExtractKppsStat {
     param(
         $FileName

--- a/tools/xskperfsuite.ps1
+++ b/tools/xskperfsuite.ps1
@@ -68,7 +68,6 @@ param (
     [string]$CommitHash = ""
 )
 
-
 Set-StrictMode -Version 'Latest'
 $ErrorActionPreference = 'Stop'
 


### PR DESCRIPTION
The MSI was failing to install in perf runs because the log directory doesn't exist at the time XDP is installed, so fix that.

Fix the silent failure by making the perf tests stop upon errors.