### PR TITLE
Add IO work item logging

### DIFF
--- a/src/rtl/xdpregistry.c
+++ b/src/rtl/xdpregistry.c
@@ -63,7 +63,7 @@ XdpRegQueryDwordValue(
 Exit:
 
     TraceInfo(
-        TRACE_CORE,
+        TRACE_RTL,
         "KeyName=%S ValueName=%S Value=%u Status=%!STATUS!",
         KeyName, ValueName, NT_SUCCESS(Status) ? *ValueData : 0, Status);
 

--- a/src/rtl/xdptimer.c
+++ b/src/rtl/xdptimer.c
@@ -4,6 +4,7 @@
 //
 
 #include "precomp.h"
+#include "xdptimer.tmh"
 
 typedef struct _EX_TIMER EX_TIMER;
 typedef struct _IO_WORKITEM IO_WORKITEM;
@@ -339,7 +340,8 @@ XdpTimerWorker(
     KIRQL OldIrql;
     KEVENT *CancelEvent = NULL;
 
-    UNREFERENCED_PARAMETER(IoObject);
+    TraceEnter(TRACE_RTL, "Timer=%p IoObject=%p", Timer, IoObject);
+
     UNREFERENCED_PARAMETER(IoWorkItem);
     ASSERT(Timer);
 
@@ -363,4 +365,6 @@ XdpTimerWorker(
     }
 
     XdpTimerDereference(Timer);
+
+    TraceExitSuccess(TRACE_RTL);
 }

--- a/src/rtl/xdpworkqueue.c
+++ b/src/rtl/xdpworkqueue.c
@@ -4,6 +4,7 @@
 //
 
 #include "precomp.h"
+#include "xdpworkqueue.tmh"
 
 #pragma warning(disable:4701) // OldIrql for XdpWorkQueueReleaseLock is initialized.
 
@@ -239,8 +240,9 @@ XdpIoWorkItemRoutine(
     XDP_WORK_QUEUE *WorkQueue = (XDP_WORK_QUEUE *)Context;
     KIRQL OldIrql;
 
+    TraceEnter(TRACE_RTL, "WorkQueue=%p IoObject=%p", WorkQueue, IoObject);
+
     UNREFERENCED_PARAMETER(IoWorkItem);
-    UNREFERENCED_PARAMETER(IoObject);
     ASSERT(WorkQueue);
 
     //
@@ -287,4 +289,6 @@ XdpIoWorkItemRoutine(
         KeSetEvent(WorkQueue->ShutdownEvent, 0, FALSE);
     }
     XdpDereferenceWorkQueue(WorkQueue);
+
+    TraceExitSuccess(TRACE_RTL);
 }

--- a/src/xdplwf/oid.c
+++ b/src/xdplwf/oid.c
@@ -208,13 +208,16 @@ XdpLwfOidRequestWorker(
     XDP_LWF_FILTER *Filter = Context;
     NDIS_OID_REQUEST *Request;
 
-    UNREFERENCED_PARAMETER(IoObject);
+    TraceEnter(TRACE_LWF, "Filter=%p IoObject=%p", Filter, IoObject);
+
     UNREFERENCED_PARAMETER(IoWorkItem);
     ASSERT(Context != NULL);
 
     Request = InterlockedExchangePointer(&Filter->OidWorkerRequest, NULL);
     FRE_ASSERT(Request != NULL);
     FRE_ASSERT(XdpLwfOidRequest((NDIS_HANDLE)Filter, Request) == NDIS_STATUS_PENDING);
+
+    TraceExitSuccess(TRACE_LWF);
 }
 
 VOID


### PR DESCRIPTION
Add diagnostics for #278: XDP sometimes fails to start in functional tests, even though DriverUnload has exited after the previous stop. It's possible that our IO work items are still referencing the driver, which might explain why the new driver can't be loaded yet.

Add logs to catch XDP in the act, if that's indeed what is happening.
