### PR TITLE
Improve eBPF uninstall diagnostics

### DIFF
--- a/.azure/templates/spinxsk.yml
+++ b/.azure/templates/spinxsk.yml
@@ -83,6 +83,7 @@ jobs:
 
   - task: PowerShell@2
     displayName: Convert logs
+    timeoutInMinutes: 5
     condition: always()
     inputs:
       filePath: tools/log.ps1

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -586,6 +586,10 @@ function Uninstall-Ebpf {
         if (!(Wait-Job -Job $Job -Timeout 60)) {
             Write-Error "eBPF failed to uninstall within 60 seconds" -ErrorAction Continue
             Uninstall-Failure
+
+            # Abandon (leak) the job since the MSI process may be impossible to
+            # terminate in certain hang scenarios.
+            $Job = $null
         }
 
         if (($Status = Receive-Job -Job $Job) -ne 0) {
@@ -597,7 +601,11 @@ function Uninstall-Ebpf {
             }
         }
     } finally {
-        Remove-Job -Job $Job -Force
+        if ($Job) {
+            Write-Verbose "Cleaning up MSI job..."
+            Remove-Job -Job $Job -Force
+            Write-Verbose "Cleaned up MSI job."
+        }
     }
 
     if (Test-Path $EbpfPath) {


### PR DESCRIPTION
We _still_ can't retrieve a dump from the CI when eBPF fails to uninstall: full bugchecks have failed to upload to AzWatson, and our  live dumps fail to upload because PowerShell hangs forever after the MSI breaks.

Try to unblock Powershell and fix a missing timeout in Azure jobs.