### PR TITLE
Wait for work items before unloading XDP

### DIFF
--- a/src/rtl/inc/xdprtl.h
+++ b/src/rtl/inc/xdprtl.h
@@ -92,6 +92,16 @@ RtlReleasePushLockShared(
     _Inout_ EX_PUSH_LOCK *Lock
     );
 
+NTSTATUS
+XdpRtlStart(
+    VOID
+    );
+
+VOID
+XdpRtlStop(
+    VOID
+    );
+
 __forceinline
 VOID
 RtlCopyVolatileMemory(

--- a/src/rtl/precomp.h
+++ b/src/rtl/precomp.h
@@ -48,3 +48,5 @@ ZwNotifyChangeKey(
 #define XDP_POOLTAG_REGISTRY    'RcdX' // XdcR
 #define XDP_POOLTAG_TIMER       'TcdX' // XdcT
 #define XDP_POOLTAG_WORKQUEUE   'WcdX' // XdcW
+
+extern EX_RUNDOWN_REF XdpRtlRundown;

--- a/src/rtl/xdprtl.c
+++ b/src/rtl/xdprtl.c
@@ -5,6 +5,10 @@
 
 #include "precomp.h"
 
+EX_RUNDOWN_REF XdpRtlRundown = {
+    .Count = EX_RUNDOWN_ACTIVE
+};
+
 NTSTATUS
 RtlUInt32RoundUpToPowerOfTwo(
     _In_ UINT32 Value,
@@ -131,4 +135,22 @@ RtlRandomNumberInRange(
     Number += Min;
 
     return Number;
+}
+
+NTSTATUS
+XdpRtlStart(
+    VOID
+    )
+{
+    ExReInitializeRundownProtection(&XdpRtlRundown);
+
+    return STATUS_SUCCESS;
+}
+
+VOID
+XdpRtlStop(
+    VOID
+    )
+{
+    ExWaitForRundownProtectionRelease(&XdpRtlRundown);
 }

--- a/src/rtl/xdptimer.c
+++ b/src/rtl/xdptimer.c
@@ -57,6 +57,8 @@ XdpTimerDereference(
         if (CleanupEvent != NULL) {
             KeSetEvent(CleanupEvent, 0, FALSE);
         }
+
+        ExReleaseRundownProtection(&XdpRtlRundown);
     }
 }
 
@@ -76,6 +78,10 @@ XdpTimerCreate(
 
     ASSERT((DriverObject != NULL) || (DeviceObject != NULL));
     IoObject = (DriverObject != NULL) ? (VOID *)DriverObject : DeviceObject;
+
+    if (!ExAcquireRundownProtection(&XdpRtlRundown)) {
+        return NULL;
+    }
 
     Timer =
         ExAllocatePoolZero(NonPagedPoolNx, sizeof(*Timer) + IoSizeofWorkItem(), XDP_POOLTAG_TIMER);
@@ -106,6 +112,8 @@ Exit:
             XdpTimerDereference(Timer);
             Timer = NULL;
         }
+
+        ExReleaseRundownProtection(&XdpRtlRundown);
     }
 
     return Timer;
@@ -364,7 +372,7 @@ XdpTimerWorker(
         Timer->TimerRoutine(Timer->TimerContext);
     }
 
-    XdpTimerDereference(Timer);
-
     TraceExitSuccess(TRACE_RTL);
+
+    XdpTimerDereference(Timer);
 }

--- a/src/rtl/xdptimer.c
+++ b/src/rtl/xdptimer.c
@@ -372,6 +372,10 @@ XdpTimerWorker(
         Timer->TimerRoutine(Timer->TimerContext);
     }
 
+    //
+    // The work queue holds an indirect reference on the ETW tracing provider,
+    // so trace exit prematurely to ensure the log isn't dropped.
+    //
     TraceExitSuccess(TRACE_RTL);
 
     XdpTimerDereference(Timer);

--- a/src/rtl/xdpworkqueue.c
+++ b/src/rtl/xdpworkqueue.c
@@ -296,6 +296,10 @@ XdpIoWorkItemRoutine(
         KeSetEvent(WorkQueue->ShutdownEvent, 0, FALSE);
     }
 
+    //
+    // The work queue holds an indirect reference on the ETW tracing provider,
+    // so trace exit prematurely to ensure the log isn't dropped.
+    //
     TraceExitSuccess(TRACE_RTL);
 
     XdpDereferenceWorkQueue(WorkQueue);

--- a/src/xdp/dispatch.c
+++ b/src/xdp/dispatch.c
@@ -538,7 +538,7 @@ DriverEntry(
     }
 
     Status = XdpRtlStart();
-      if (!NT_SUCCESS(Status)) {
+    if (!NT_SUCCESS(Status)) {
         goto Exit;
     }
 

--- a/src/xdp/dispatch.c
+++ b/src/xdp/dispatch.c
@@ -537,6 +537,11 @@ DriverEntry(
         goto Exit;
     }
 
+    Status = XdpRtlStart();
+      if (!NT_SUCCESS(Status)) {
+        goto Exit;
+    }
+
     Status = XdpStart();
     if (!NT_SUCCESS(Status)) {
         goto Exit;
@@ -570,6 +575,7 @@ DriverUnload(
 
     XdpLwfStop();
     XdpStop();
+    XdpRtlStop();
 
     TraceExitStatus(TRACE_CORE);
 


### PR DESCRIPTION
Attempt to mitigate an issue seen during an XDP restart test: XDP's DriverUnload has returned while some IO work items are still being processed on other threads. This is an entirely legal scenario (this is why an IO work item takes a driver object as a parameter: to ensure the driver image stays loaded as long as the work items are running) but the user experience will be best if we close the inevitable unload/worker race condition to as small a window as possible.

On that front, wait for all IO work items in the RTL to run to completion before returning from DriverUnload. This does not guarantee the caller of the work item callbacks (i.e. the kernel / IO manager) has dereferenced the driver object at the time we return from DriverUnload, but it's the best we can do.

Resolves #278 