### PR TITLE
Use regular, kernel-only crash dumps in CI

### DIFF
--- a/.azure/scripts/agent-functionaltest/Setup.ps1
+++ b/.azure/scripts/agent-functionaltest/Setup.ps1
@@ -16,5 +16,5 @@ bcdedit.exe /set testsigning on
 Write-Host "Enable driver verifier"
 verifier.exe /standard /driver xdp.sys xdpfnmp.sys xdpfnlwf.sys ndis.sys ebpfcore.sys
 
-Write-Host "Enable complete system crash dumps"
-reg.exe add HKLM\System\CurrentControlSet\Control\CrashControl /v CrashDumpEnabled /d 1 /t REG_DWORD /f
+#Write-Host "Enable complete system crash dumps"
+#reg.exe add HKLM\System\CurrentControlSet\Control\CrashControl /v CrashDumpEnabled /d 1 /t REG_DWORD /f

--- a/.azure/scripts/agent-spinxsktest/Setup.ps1
+++ b/.azure/scripts/agent-spinxsktest/Setup.ps1
@@ -51,5 +51,5 @@ if ($Depends -contains "tdx") {
     Set-ItemProperty -Path HKLM:System\CurrentControlSet\Services\dhcp -Name DependOnService -Value $Depends
 }
 
-Write-Host "Enable complete system crash dumps"
-reg.exe add HKLM\System\CurrentControlSet\Control\CrashControl /v CrashDumpEnabled /d 1 /t REG_DWORD /f
+#Write-Host "Enable complete system crash dumps"
+#reg.exe add HKLM\System\CurrentControlSet\Control\CrashControl /v CrashDumpEnabled /d 1 /t REG_DWORD /f


### PR DESCRIPTION
We're seeing less crash dumps uploaded to AzWatson lately; the only change I can think of on our side is collecting much larger complete dumps (on behalf of eBPF) rather than kernel-only dumps.

Sacrifice full info for eBPF in exchange for some idea of what is going wrong in the kernel.