### PR TITLE
Actions: require all actions succeed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,5 +308,6 @@ jobs:
   Complete:
     name: Complete
     needs: [build, functional_tests, stress_tests, perf_tests, devkit, etw]
+    runs-on: windows-latest
     steps:
     - run: echo "CI succeeded"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,3 +304,7 @@ jobs:
       with:
         name: etw_${{ matrix.configuration }}
         path: artifacts/bin
+
+  etw:
+    name: Complete
+    needs: [build, functional_tests, stress_tests, perf_tests, devkit, etw]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,4 +309,4 @@ jobs:
     name: Complete
     needs: [build, functional_tests, stress_tests, perf_tests, devkit, etw]
     steps:
-      run: echo "CI succeeded"
+    - run: echo "CI succeeded"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,6 @@ jobs:
         name: etw_${{ matrix.configuration }}
         path: artifacts/bin
 
-  etw:
+  Complete:
     name: Complete
     needs: [build, functional_tests, stress_tests, perf_tests, devkit, etw]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,4 +308,5 @@ jobs:
   Complete:
     name: Complete
     needs: [build, functional_tests, stress_tests, perf_tests, devkit, etw]
-    steps: []
+    steps:
+      -run: echo "CI succeeded"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,4 +308,4 @@ jobs:
   Complete:
     name: Complete
     needs: [build, functional_tests, stress_tests, perf_tests, devkit, etw]
-    steps:
+    steps: []

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,3 +308,4 @@ jobs:
   Complete:
     name: Complete
     needs: [build, functional_tests, stress_tests, perf_tests, devkit, etw]
+    steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,4 +309,4 @@ jobs:
     name: Complete
     needs: [build, functional_tests, stress_tests, perf_tests, devkit, etw]
     steps:
-      -run: echo "CI succeeded"
+      run: echo "CI succeeded"


### PR DESCRIPTION
Create a dummy job that depends on all other jobs, so our GitHub branch policies can simply require the dummy final job runs successfully.