### PR TITLE
Remove OID_GEN_DRIVER_VERSION from test miniports

### DIFF
--- a/test/functional/mp/sys/oid.c
+++ b/test/functional/mp/sys/oid.c
@@ -22,7 +22,6 @@ CONST NDIS_OID MpSupportedOidArray[] =
     OID_GEN_VENDOR_DESCRIPTION,
     OID_GEN_CURRENT_PACKET_FILTER,
     OID_GEN_CURRENT_LOOKAHEAD,
-    OID_GEN_DRIVER_VERSION,
     OID_GEN_MAXIMUM_TOTAL_SIZE,
     OID_GEN_MAC_OPTIONS,
     OID_GEN_MEDIA_CONNECT_STATUS,
@@ -208,11 +207,6 @@ MpProcessQueryOid(
 
         case OID_GEN_CURRENT_PACKET_FILTER:
             Data = &Adapter->CurrentPacketFilter;
-            break;
-
-        case OID_GEN_DRIVER_VERSION:
-            DataLength = sizeof(USHORT);
-            LocalData = 0x650;
             break;
 
         case OID_GEN_MAC_OPTIONS:

--- a/test/xdpmp/miniport.c
+++ b/test/xdpmp/miniport.c
@@ -82,7 +82,6 @@ NDIS_OID MpSupportedOidArray[] =
     OID_GEN_VENDOR_DESCRIPTION,
     OID_GEN_CURRENT_PACKET_FILTER,
     OID_GEN_CURRENT_LOOKAHEAD,
-    OID_GEN_DRIVER_VERSION,
     OID_GEN_MAXIMUM_TOTAL_SIZE,
     OID_GEN_MAC_OPTIONS,
     OID_GEN_MEDIA_CONNECT_STATUS,
@@ -1196,11 +1195,6 @@ MpQueryInformationHandler(
 
         case OID_GEN_CURRENT_PACKET_FILTER:
             DataPointer = &Adapter->CurrentPacketFilter;
-            break;
-
-        case OID_GEN_DRIVER_VERSION:
-            DataLength = sizeof(USHORT);
-            Data = 0x650;
             break;
 
         case OID_GEN_MAC_OPTIONS:


### PR DESCRIPTION
NDIS implements this on our behalf, and we're returning the wrong answer anyways.