### PR TITLE
Enable developer builds of just one project

### DIFF
--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -41,15 +41,18 @@ $RootDir = Split-Path $PSScriptRoot -Parent
 $Tasks = @()
 if ([string]::IsNullOrEmpty($Project)) {
     $Tasks += "Build"
+
+    if (!$NoClean) {
+        $Tasks = @("Clean") + $Tasks
+    }
 } else {
-    $Tasks += "$($Project):Rebuild"
-    $NoClean = $true
+    $Clean = ""
+    if (!$NoClean) {
+        $Clean = ":Rebuild"
+    }
+    $Tasks += "$Project$Clean"
     $NoSign = $true
     $NoInstaller = $true
-}
-
-if (!$NoClean) {
-    $Tasks = @("Clean") + $Tasks
 }
 
 & $RootDir\tools\prepare-machine.ps1 -ForBuild -Force:$UpdateDeps

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -11,6 +11,9 @@ param (
     [Parameter(Mandatory=$false)]
     [string]$Config = "Debug",
 
+    [Parameter(Mandatory=$false)]
+    [string]$Project = "",
+
     [Parameter(Mandatory = $false)]
     [switch]$NoClean = $false,
 
@@ -35,7 +38,16 @@ $ErrorActionPreference = 'Stop'
 
 $RootDir = Split-Path $PSScriptRoot -Parent
 
-$Tasks = @("Build")
+$Tasks = @()
+if ([string]::IsNullOrEmpty($Project)) {
+    $Tasks += "Build"
+} else {
+    $Tasks += "$($Project):Rebuild"
+    $NoClean = $true
+    $NoSign = $true
+    $NoInstaller = $true
+}
+
 if (!$NoClean) {
     $Tasks = @("Clean") + $Tasks
 }


### PR DESCRIPTION
Now that XDP has many submodules, a full build takes ~30 seconds. Speed up the developer inner loop by allowing builds of one project, optionally by clean-building the project and all its dependencies.