### PR TITLE
CI: try to start XDP 10x more times

### DIFF
--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -97,9 +97,9 @@ function Uninstall-Failure {
 function Start-Service-With-Retry($Name) {
     Write-Verbose "Start-Service $Name"
     $StartSuccess = $false
-    for ($i=0; $i -lt 10; $i++) {
+    for ($i=0; $i -lt 100; $i++) {
         try {
-            Start-Sleep -Milliseconds 100
+            Start-Sleep -Milliseconds 10
             Start-Service $Name
             $StartSuccess = $true
             break


### PR DESCRIPTION
We're seeing occasional failures in spinxsk where XDP simply fails to start. Since we're only trying 10 times and various fault injections are enabled, try restarting more aggressively to rule out intentional failures to start.