### PR TITLE
specify config and arch during check-drivers.ps1

### DIFF
--- a/.azure/templates/spinxsk.yml
+++ b/.azure/templates/spinxsk.yml
@@ -61,7 +61,7 @@ jobs:
     displayName: Check Drivers
     inputs:
       filePath: tools/check-drivers.ps1
-      arguments: -Verbose
+      arguments: -Verbose -Config ${{ parameters.config }} -Arch ${{ parameters.arch }}
 
   - task: DownloadBuildArtifacts@0
     displayName: Download Artifacts
@@ -124,4 +124,4 @@ jobs:
     condition: always()
     inputs:
       filePath: tools/check-drivers.ps1
-      arguments: -Verbose
+      arguments: -Verbose -Config ${{ parameters.config }} -Arch ${{ parameters.arch }}

--- a/.azure/templates/tests.yml
+++ b/.azure/templates/tests.yml
@@ -41,7 +41,7 @@ jobs:
     displayName: Check Drivers
     inputs:
       filePath: tools/check-drivers.ps1
-      arguments: -Verbose
+      arguments: -Verbose -Config ${{ parameters.config }} -Arch ${{ parameters.arch }}
 
   - task: DownloadBuildArtifacts@0
     displayName: Download Artifacts
@@ -102,4 +102,4 @@ jobs:
     condition: always()
     inputs:
       filePath: tools/check-drivers.ps1
-      arguments: -Verbose
+      arguments: -Verbose -Config ${{ parameters.config }} -Arch ${{ parameters.arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
     - name: Check Drivers
       shell: PowerShell
-      run: tools/check-drivers.ps1 -Verbose
+      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Verbose
     - name: Prepare Machine
       shell: PowerShell
       run: tools/prepare-machine.ps1 -ForFunctionalTest -NoReboot -Verbose
@@ -135,7 +135,7 @@ jobs:
     - name: Check Drivers
       if: ${{ always() }}
       shell: PowerShell
-      run: tools/check-drivers.ps1 -Verbose
+      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Verbose
 
   stress_tests:
     name: Stress Tests
@@ -163,7 +163,7 @@ jobs:
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
     - name: Check Drivers
       shell: PowerShell
-      run: tools/check-drivers.ps1 -Verbose
+      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Verbose
     - name: Prepare Machine
       shell: PowerShell
       run: tools/prepare-machine.ps1 -ForSpinxskTest -NoReboot -Verbose
@@ -196,7 +196,7 @@ jobs:
     - name: Check Drivers
       if: ${{ always() }}
       shell: PowerShell
-      run: tools/check-drivers.ps1 -Verbose
+      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Verbose
 
   pktfuzz_tests:
     name: Fuzz Packet Parsing
@@ -248,7 +248,7 @@ jobs:
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
     - name: Check Drivers
       shell: PowerShell
-      run: tools/check-drivers.ps1 -Verbose
+      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Verbose
     - name: Prepare Machine
       shell: PowerShell
       run: tools/prepare-machine.ps1 -ForPerfTest -NoReboot -Verbose
@@ -280,7 +280,7 @@ jobs:
     - name: Check Drivers
       if: ${{ always() }}
       shell: PowerShell
-      run: tools/check-drivers.ps1 -Verbose
+      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Verbose
 
   devkit:
     name: Dev Kit

--- a/tools/check-drivers.ps1
+++ b/tools/check-drivers.ps1
@@ -6,6 +6,14 @@ This checks for the presence of any XDP drivers currently loaded.
 #>
 
 [cmdletbinding()]Param(
+    [ValidateSet("Debug", "Release")]
+    [Parameter(Mandatory=$false)]
+    [string]$Config = "Debug",
+
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("x64", "arm64")]
+    [string]$Arch = "x64",
+
     [Parameter(Mandatory = $false)]
     [switch]$IgnoreEbpf = $false
 )
@@ -32,7 +40,7 @@ function Check-Driver($Driver) {
 function Check-And-Remove-Driver($Driver, $Component) {
     if (Check-Driver $Driver) {
         Write-Host "Detected $Driver is loaded. Uninstalling $Component..."
-        & $RootDir\tools\setup.ps1 -Uninstall $Component
+        & $RootDir\tools\setup.ps1 -Uninstall $Component -Config $Config -Arch $Arch
 
         # Update cached driverquery output.
         $AllDrivers = driverquery /v /fo list


### PR DESCRIPTION
The check-drivers script should use the same config and architecture as the tests.