### PR TITLE
Use consistent argument types in NDIS request poll helper

### DIFF
--- a/published/external/xdp/ndis6poll.h
+++ b/published/external/xdp/ndis6poll.h
@@ -57,8 +57,7 @@ VOID
 XdpCompleteNdisPoll(
     _In_ NDIS_POLL_HANDLE PollHandle,
     _In_ NDIS_POLL_DATA *Poll,
-    _In_ XDP_POLL_TRANSMIT_DATA *Transmit,
-    _In_ XDP_POLL_RECEIVE_DATA *Receive,
+    _In_ XDP_POLL_DATA *XdpPoll,
     _In_ XDP_NDIS_REQUEST_POLL *RequestPoll
     )
 {
@@ -69,8 +68,8 @@ XdpCompleteNdisPoll(
         return;
     }
 
-    if (Transmit->FramesCompleted > 0 || Transmit->FramesTransmitted > 0 ||
-        Receive->FramesAbsorbed > 0) {
+    if (XdpPoll->Transmit.FramesCompleted > 0 || XdpPoll->Transmit.FramesTransmitted > 0 ||
+        XdpPoll->Receive.FramesAbsorbed > 0) {
         //
         // XDP made forward progress, and this was not observable to NDIS.
         // Explicitly request another poll.

--- a/test/fakendis/inc/fndispoll.h
+++ b/test/fakendis/inc/fndispoll.h
@@ -58,15 +58,14 @@ void
 FNdisCompletePoll(
     _In_ NDIS_HANDLE PollHandle,
     _In_ NDIS_POLL_DATA *Poll,
-    _In_ XDP_POLL_TRANSMIT_DATA *Transmit,
-    _In_ XDP_POLL_RECEIVE_DATA *Receive,
+    _In_ XDP_POLL_DATA *XdpPoll,
     _In_ XDP_NDIS_REQUEST_POLL *RequestPoll
     )
 {
     UNREFERENCED_PARAMETER(PollHandle);
     UNREFERENCED_PARAMETER(RequestPoll);
 
-    Poll->Transmit.Reserved1[TxXdpFramesCompleted] = Transmit->FramesCompleted;
-    Poll->Transmit.Reserved1[TxXdpFramesTransmitted] = Transmit->FramesTransmitted;
-    Poll->Receive.Reserved1[RxXdpFramesAbsorbed] = Receive->FramesAbsorbed;
+    Poll->Transmit.Reserved1[TxXdpFramesCompleted] = XdpPoll->Transmit.FramesCompleted;
+    Poll->Transmit.Reserved1[TxXdpFramesTransmitted] = XdpPoll->Transmit.FramesTransmitted;
+    Poll->Receive.Reserved1[RxXdpFramesAbsorbed] = XdpPoll->Receive.FramesAbsorbed;
 }

--- a/test/xdpmp/rss.c
+++ b/test/xdpmp/rss.c
@@ -11,8 +11,7 @@ VOID
 POLL_COMPLETE_HELPER(
     _In_ NDIS_HANDLE PollHandle,
     _In_ NDIS_POLL_DATA *Poll,
-    _In_ XDP_POLL_TRANSMIT_DATA *Transmit,
-    _In_ XDP_POLL_RECEIVE_DATA *Receive,
+    _In_ XDP_POLL_DATA *XdpData,
     _In_ XDP_NDIS_REQUEST_POLL *RequestPoll
     );
 
@@ -49,8 +48,7 @@ MpPoll(
     }
 
     PollComplete(
-        RssQueue->NdisPollHandle, Poll, &XdpPoll.Transmit, &XdpPoll.Receive,
-        RssQueue->Adapter->PollDispatch.RequestPoll);
+        RssQueue->NdisPollHandle, Poll, &XdpPoll, RssQueue->Adapter->PollDispatch.RequestPoll);
 }
 
 static


### PR DESCRIPTION
As I've been passing through all our headers migrating documentation to markdown, I noticed the NDIS helpers are using a stale data type. Fix that.