### PR TITLE
Add xdpcfg.exe to MSI

### DIFF
--- a/src/xdpinstaller/Product.wxs
+++ b/src/xdpinstaller/Product.wxs
@@ -70,6 +70,9 @@ SPDX-License-Identifier: MIT
             <Component Id="xdpapi.dll" Guid="{18A0B4FC-9F22-4E15-8AD2-64131E6E238B}">
                 <File Id="xdpapi.dll" Name="xdpapi.dll" Source="$(var.TargetDir)..\xdpapi.dll" KeyPath="yes" />
             </Component>
+            <Component Id="xdpcfg.exe" Guid="{2F099CCD-54DA-495C-9741-3F3EFE357087}">
+                <File Id="xdpcfg.exe" Name="xdpcfg.exe" Source="$(var.TargetDir)..\xdpcfg.exe" KeyPath="yes" />
+            </Component>
             <Component Id="xdp.sys" Guid="{5E1B9729-E58D-4A4D-A845-FB6D2EE0C498}">
                 <File Id="xdp.sys" Name="xdp.sys" Source="$(var.TargetDir)..\xdp\xdp.sys" KeyPath="yes" />
             </Component>


### PR DESCRIPTION
The MSI is missing xdpcfg.exe, which should be installed with XDP to allow custom ACL configuration.