### PR TITLE
Create downlevel test archive

### DIFF
--- a/.azure/templates/devkit.yml
+++ b/.azure/templates/devkit.yml
@@ -1,4 +1,4 @@
-# This template builds the dev kit.
+# This template builds the release artifacts.
 
 parameters:
   arch: 'x64'
@@ -35,9 +35,22 @@ jobs:
       filePath: tools/create-runtime-kit.ps1
       arguments: -Config ${{ parameters.config }} -Platform ${{ parameters.arch }}
 
+  - task: PowerShell@2
+    displayName: Create Test Archive
+    inputs:
+      filePath: tools/create-test-archive.ps1
+      arguments: -Config ${{ parameters.config }} -Platform ${{ parameters.arch }}
+
   - task: PublishBuildArtifacts@1
-    displayName: Upload Artifacts
+    displayName: Upload Kits
     inputs:
       artifactName: artifacts
       pathToPublish: artifacts/kit
+      parallel: true
+
+  - task: PublishBuildArtifacts@1
+    displayName: Upload Test Archive
+    inputs:
+      artifactName: artifacts
+      pathToPublish: artifacts/tests
       parallel: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,8 +282,8 @@ jobs:
       shell: PowerShell
       run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Verbose
 
-  devkit:
-    name: Dev Kit
+  create_artifacts:
+    name: Create Release Artifacts
     needs: build
     strategy:
       fail-fast: false
@@ -305,11 +305,16 @@ jobs:
     - name: Create Runtime Kit
       shell: PowerShell
       run: tools/create-runtime-kit.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
-    - name: Upload Kit
+    - name: Create Test Archive
+      shell: PowerShell
+      run: tools/create-test-archive.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
+    - name: Upload Release Artifacts
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
       with:
-        name: devkit_${{ matrix.configuration }}_${{ matrix.platform }}
-        path: artifacts/kit
+        name: release_artifacts_${{ matrix.configuration }}_${{ matrix.platform }}
+        path: |
+          artifacts/kits/**/*.zip
+          artifacts/tests/**/*.zip
 
   etw:
     name: ETW Plugin
@@ -338,7 +343,7 @@ jobs:
 
   Complete:
     name: Complete
-    needs: [build, functional_tests, stress_tests, pktfuzz_tests, perf_tests, devkit, etw]
+    needs: [build, functional_tests, stress_tests, pktfuzz_tests, perf_tests, create_artifacts, etw]
     runs-on: windows-latest
     steps:
     - run: echo "CI succeeded"

--- a/tools/create-test-archive.ps1
+++ b/tools/create-test-archive.ps1
@@ -1,0 +1,49 @@
+#
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Creates an archive of XDP test artifacts to validate compatibility with newer
+# versions of XDP binaries.
+# Code must be built before running this script.
+#
+
+param (
+    [ValidateSet("x64")]
+    [Parameter(Mandatory=$false)]
+    [string]$Platform = "x64",
+
+    [ValidateSet("Debug", "Release")]
+    [Parameter(Mandatory=$false)]
+    [string]$Config = "Debug"
+)
+
+$RootDir = Split-Path $PSScriptRoot -Parent
+. $RootDir\tools\common.ps1
+
+$Name = "xdp-tests-$Platform"
+if ($Config -eq "Debug") {
+    $Name += "-debug"
+}
+$DstPath = "artifacts\tests\$Name"
+
+Remove-Item $DstPath -Recurse -ErrorAction Ignore
+New-Item -Path $DstPath -ItemType Directory > $null
+
+New-Item -Path $DstPath\bin -ItemType Directory > $null
+copy "artifacts\bin\$($Platform)_$($Config)\xdpfunctionaltests.dll" $DstPath\bin
+
+New-Item -Path $DstPath\symbols -ItemType Directory > $null
+copy "artifacts\bin\$($Platform)_$($Config)\xdpfunctionaltests.pdb"   $DstPath\symbols
+
+[xml]$XdpVersion = Get-Content $RootDir\src\xdp.props
+$Major = $XdpVersion.Project.PropertyGroup.XdpMajorVersion[0]
+$Minor = $XdpVersion.Project.PropertyGroup.XdpMinorVersion[0]
+$Patch = $XdpVersion.Project.PropertyGroup.XdpPatchVersion[0]
+
+$VersionString = "$Major.$Minor.$Patch"
+
+if (!((Get-BuildBranch).StartsWith("release/"))) {
+    $VersionString += "-prerelease+" + (git.exe describe --long --always --dirty --exclude=* --abbrev=8)
+}
+
+Compress-Archive -DestinationPath "$DstPath\$Name-$VersionString.zip" -Path $DstPath\*


### PR DESCRIPTION
Create an archive of tests we intend to use to test backwards compatibility of newer binaries.
Also allow the functional test script to use an alternate test binary. No tests are onboarded to the CI yet since we don't have any backwards compatible releases yet.

Resolves #341 