### PR TITLE
Fix devkit creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,7 @@ jobs:
       with:
         name: release_artifacts_${{ matrix.configuration }}_${{ matrix.platform }}
         path: |
-          artifacts/kits/**/*.zip
+          artifacts/kit/**/*.zip
           artifacts/tests/**/*.zip
 
   etw:


### PR DESCRIPTION
I noticed our new release artifacts zip is missing the devkit and runtime kit, so fix the typo.