### PR TITLE
Fix creation of release artifacts and revert version number

### DIFF
--- a/src/xdp.props
+++ b/src/xdp.props
@@ -1,9 +1,11 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- Defines the XDP version numbers -->
   <PropertyGroup>
+    <!-- Defines the XDP version numbers -->
     <XdpMajorVersion>0</XdpMajorVersion>
     <XdpMinorVersion>17</XdpMinorVersion>
     <XdpPatchVersion>0</XdpPatchVersion>
+    <!-- Project-wide properties -->
+    <EbpfPackagePath>$(SolutionDir)packages\eBPF-for-Windows.0.9.0\</EbpfPackagePath>
   </PropertyGroup>
   <!-- The set of (eventually?) supported configurations -->
   <ItemGroup Label="ProjectConfigurations">
@@ -24,8 +26,4 @@
       <Platform>ARM64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
-  <!-- Project-wide properties -->
-  <PropertyGroup>
-    <EbpfPackagePath>$(SolutionDir)packages\eBPF-for-Windows.0.9.0\</EbpfPackagePath>
-  </PropertyGroup>
 </Project>

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -30,6 +30,9 @@ param (
     [switch]$RuntimeKit = $false,
 
     [Parameter(Mandatory = $false)]
+    [switch]$TestArchive = $false,
+
+    [Parameter(Mandatory = $false)]
     [switch]$UpdateDeps = $false
 )
 
@@ -92,4 +95,8 @@ if ($DevKit) {
 
 if ($RuntimeKit) {
     & $RootDir\tools\create-runtime-kit.ps1 -Config $Config
+}
+
+if ($TestArchive) {
+    & $RootDir\tools\create-test-archive.ps1 -Config $Config
 }

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -77,6 +77,10 @@ function Get-BuildBranch {
     }
 }
 
+function Is-ReleaseBuild {
+    return ((Get-BuildBranch) -match '^release/|^tags/')
+}
+
 function Get-VsTestPath {
     # Unfortunately CI doesn't add vstest to PATH. Test existence of vstest
     # install paths instead.

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -62,7 +62,7 @@ function Get-BuildBranch {
     } elseif (![string]::IsNullOrWhiteSpace($env:BUILD_SOURCEBRANCH)) {
         # We are in a (AZP) main build.
         Write-Host "Using BUILD_SOURCEBRANCH=$env:BUILD_SOURCEBRANCH to compute branch"
-        $env:BUILD_SOURCEBRANCH -match 'refs/heads/(.+)' | Out-Null
+        $env:BUILD_SOURCEBRANCH -match 'refs/(?:heads/)?(.+)' | Out-Null
         return $Matches[1]
 
     } elseif (![string]::IsNullOrWhiteSpace($env:GITHUB_REF_NAME)) {

--- a/tools/create-devkit.ps1
+++ b/tools/create-devkit.ps1
@@ -13,6 +13,9 @@ param (
     [string]$Config = "Debug"
 )
 
+Set-StrictMode -Version 'Latest'
+$ErrorActionPreference = 'Stop'
+
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
 
@@ -62,7 +65,7 @@ $Patch = $XdpVersion.Project.PropertyGroup.XdpPatchVersion[0]
 
 $VersionString = "$Major.$Minor.$Patch"
 
-if (!((Get-BuildBranch) -match '^release/|^tags/')) {
+if (!(Is-ReleaseBuild)) {
     $VersionString += "-prerelease+" + (git.exe describe --long --always --dirty --exclude=* --abbrev=8)
 }
 

--- a/tools/create-devkit.ps1
+++ b/tools/create-devkit.ps1
@@ -62,7 +62,7 @@ $Patch = $XdpVersion.Project.PropertyGroup.XdpPatchVersion[0]
 
 $VersionString = "$Major.$Minor.$Patch"
 
-if (!((Get-BuildBranch).StartsWith("release/"))) {
+if (!((Get-BuildBranch) -match '^release/|^tags/')) {
     $VersionString += "-prerelease+" + (git.exe describe --long --always --dirty --exclude=* --abbrev=8)
 }
 

--- a/tools/create-runtime-kit.ps1
+++ b/tools/create-runtime-kit.ps1
@@ -16,6 +16,9 @@ param (
     [string]$Config = "Debug"
 )
 
+Set-StrictMode -Version 'Latest'
+$ErrorActionPreference = 'Stop'
+
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
 
@@ -47,7 +50,7 @@ $Patch = $XdpVersion.Project.PropertyGroup.XdpPatchVersion[0]
 
 $VersionString = "$Major.$Minor.$Patch"
 
-if (!((Get-BuildBranch) -match '^release/|^tags/')) {
+if (!(Is-ReleaseBuild)) {
     $VersionString += "-prerelease+" + (git.exe describe --long --always --dirty --exclude=* --abbrev=8)
 }
 

--- a/tools/create-runtime-kit.ps1
+++ b/tools/create-runtime-kit.ps1
@@ -47,7 +47,7 @@ $Patch = $XdpVersion.Project.PropertyGroup.XdpPatchVersion[0]
 
 $VersionString = "$Major.$Minor.$Patch"
 
-if (!((Get-BuildBranch).StartsWith("release/"))) {
+if (!((Get-BuildBranch) -match '^release/|^tags/')) {
     $VersionString += "-prerelease+" + (git.exe describe --long --always --dirty --exclude=* --abbrev=8)
 }
 

--- a/tools/create-test-archive.ps1
+++ b/tools/create-test-archive.ps1
@@ -42,7 +42,7 @@ $Patch = $XdpVersion.Project.PropertyGroup.XdpPatchVersion[0]
 
 $VersionString = "$Major.$Minor.$Patch"
 
-if (!((Get-BuildBranch).StartsWith("release/"))) {
+if (!((Get-BuildBranch) -match '^release/|^tags/')) {
     $VersionString += "-prerelease+" + (git.exe describe --long --always --dirty --exclude=* --abbrev=8)
 }
 

--- a/tools/create-test-archive.ps1
+++ b/tools/create-test-archive.ps1
@@ -17,6 +17,9 @@ param (
     [string]$Config = "Debug"
 )
 
+Set-StrictMode -Version 'Latest'
+$ErrorActionPreference = 'Stop'
+
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
 
@@ -42,7 +45,7 @@ $Patch = $XdpVersion.Project.PropertyGroup.XdpPatchVersion[0]
 
 $VersionString = "$Major.$Minor.$Patch"
 
-if (!((Get-BuildBranch) -match '^release/|^tags/')) {
+if (!(Is-ReleaseBuild)) {
     $VersionString += "-prerelease+" + (git.exe describe --long --always --dirty --exclude=* --abbrev=8)
 }
 


### PR DESCRIPTION
Attempting to build v0.17.0 from a git tag resulted in a number of errors in AZP. Fix the cascade of errors and revert main's version number to v0.17.0.