### PR TITLE
Fix kit version numbering

### DIFF
--- a/tools/create-devkit.ps1
+++ b/tools/create-devkit.ps1
@@ -59,9 +59,9 @@ copy "artifacts\bin\$($Platform)_$($Config)\xdpnmr.lib" $DstPath\lib
 copy "artifacts\bin\$($Platform)_$($Config)\xdpnmr.pdb" $DstPath\lib
 
 [xml]$XdpVersion = Get-Content $RootDir\src\xdp.props
-$Major = $XdpVersion.Project.PropertyGroup.XdpMajorVersion[0]
-$Minor = $XdpVersion.Project.PropertyGroup.XdpMinorVersion[0]
-$Patch = $XdpVersion.Project.PropertyGroup.XdpPatchVersion[0]
+$Major = $XdpVersion.Project.PropertyGroup.XdpMajorVersion
+$Minor = $XdpVersion.Project.PropertyGroup.XdpMinorVersion
+$Patch = $XdpVersion.Project.PropertyGroup.XdpPatchVersion
 
 $VersionString = "$Major.$Minor.$Patch"
 

--- a/tools/create-runtime-kit.ps1
+++ b/tools/create-runtime-kit.ps1
@@ -44,9 +44,9 @@ copy "artifacts\bin\$($Platform)_$($Config)\xdpapi.pdb" $DstPath\symbols
 copy "artifacts\bin\$($Platform)_$($Config)\xdpcfg.pdb" $DstPath\symbols
 
 [xml]$XdpVersion = Get-Content $RootDir\src\xdp.props
-$Major = $XdpVersion.Project.PropertyGroup.XdpMajorVersion[0]
-$Minor = $XdpVersion.Project.PropertyGroup.XdpMinorVersion[0]
-$Patch = $XdpVersion.Project.PropertyGroup.XdpPatchVersion[0]
+$Major = $XdpVersion.Project.PropertyGroup.XdpMajorVersion
+$Minor = $XdpVersion.Project.PropertyGroup.XdpMinorVersion
+$Patch = $XdpVersion.Project.PropertyGroup.XdpPatchVersion
 
 $VersionString = "$Major.$Minor.$Patch"
 

--- a/tools/create-test-archive.ps1
+++ b/tools/create-test-archive.ps1
@@ -39,9 +39,9 @@ New-Item -Path $DstPath\symbols -ItemType Directory > $null
 copy "artifacts\bin\$($Platform)_$($Config)\xdpfunctionaltests.pdb"   $DstPath\symbols
 
 [xml]$XdpVersion = Get-Content $RootDir\src\xdp.props
-$Major = $XdpVersion.Project.PropertyGroup.XdpMajorVersion[0]
-$Minor = $XdpVersion.Project.PropertyGroup.XdpMinorVersion[0]
-$Patch = $XdpVersion.Project.PropertyGroup.XdpPatchVersion[0]
+$Major = $XdpVersion.Project.PropertyGroup.XdpMajorVersion
+$Minor = $XdpVersion.Project.PropertyGroup.XdpMinorVersion
+$Patch = $XdpVersion.Project.PropertyGroup.XdpPatchVersion
 
 $VersionString = "$Major.$Minor.$Patch"
 


### PR DESCRIPTION
We're creating dev kits, but the version numbers are only the first digit :(

Use the complete version numbers.