### PR TITLE
Stamp the XDP version number onto the MSI file name

### DIFF
--- a/.azure/templates/create-release-artifacts.yml
+++ b/.azure/templates/create-release-artifacts.yml
@@ -30,12 +30,6 @@ jobs:
       arguments: -Config ${{ parameters.config }} -Platform ${{ parameters.arch }}
 
   - task: PowerShell@2
-    displayName: Create Runtime Kit
-    inputs:
-      filePath: tools/create-runtime-kit.ps1
-      arguments: -Config ${{ parameters.config }} -Platform ${{ parameters.arch }}
-
-  - task: PowerShell@2
     displayName: Create Test Archive
     inputs:
       filePath: tools/create-test-archive.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,9 +302,6 @@ jobs:
     - name: Create Dev Kit
       shell: PowerShell
       run: tools/create-devkit.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
-    - name: Create Runtime Kit
-      shell: PowerShell
-      run: tools/create-runtime-kit.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
     - name: Create Test Archive
       shell: PowerShell
       run: tools/create-test-archive.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}

--- a/src/xdpinstaller/xdpinstaller.wixproj
+++ b/src/xdpinstaller/xdpinstaller.wixproj
@@ -5,7 +5,7 @@
     <ProductVersion>3.10</ProductVersion>
     <ProjectGuid>93635a7b-565e-4b41-af67-5b375756b227</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
-    <OutputName>xdp-for-windows</OutputName>
+    <OutputName>xdp-for-windows.$(XdpMajorVersion).$(XdpMinorVersion).$(XdpPatchVersion)</OutputName>
     <OutputType>Package</OutputType>
     <OutputPath>$(SolutionDir)..\..\artifacts\bin\$(Platform)_$(Configuration)\xdpinstaller\</OutputPath>
     <IntermediateOutputPath>$(SolutionDir)..\..\build\$(Platform)_$(Configuration)\obj\$(OutputName)\</IntermediateOutputPath>

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -27,9 +27,6 @@ param (
     [switch]$DevKit = $false,
 
     [Parameter(Mandatory = $false)]
-    [switch]$RuntimeKit = $false,
-
-    [Parameter(Mandatory = $false)]
     [switch]$TestArchive = $false,
 
     [Parameter(Mandatory = $false)]
@@ -91,10 +88,6 @@ if (!$NoInstaller) {
 
 if ($DevKit) {
     & $RootDir\tools\create-devkit.ps1 -Config $Config
-}
-
-if ($RuntimeKit) {
-    & $RootDir\tools\create-runtime-kit.ps1 -Config $Config
 }
 
 if ($TestArchive) {

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -123,7 +123,7 @@ function Get-EbpfMsiFullPath {
 # Returns the eBPF MSI download URL
 function Get-EbpfMsiUrl {
     $EbpfMsiFilename = Get-EbpfMsiFilename
-    return "https://github.com/microsoft/ebpf-for-windows/releases/download/v0.9.1/$EbpfMsiFilename"
+    return "https://github.com/microsoft/xdp-for-windows/releases/download/main-prerelease/$EbpfMsiFilename"
 }
 
 function Get-CoreNetCiCommit {

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -123,7 +123,7 @@ function Get-EbpfMsiFullPath {
 # Returns the eBPF MSI download URL
 function Get-EbpfMsiUrl {
     $EbpfMsiFilename = Get-EbpfMsiFilename
-    return "https://github.com/microsoft/xdp-for-windows/releases/download/main-prerelease/$EbpfMsiFilename"
+    return "https://github.com/microsoft/ebpf-for-windows/releases/download/v0.9.1/$EbpfMsiFilename"
 }
 
 function Get-CoreNetCiCommit {
@@ -140,6 +140,21 @@ function Get-CoreNetCiArtifactPath {
     $Commit = Get-CoreNetCiCommit
 
     return "$RootDir\artifacts\corenet-ci-$Commit\vm-setup\$Name"
+}
+
+function Get-XdpBuildVersion {
+    $RootDir = Split-Path $PSScriptRoot -Parent
+    $XdpBuildVersion = @{}
+    [xml]$XdpVersion = Get-Content $RootDir\src\xdp.props
+    $XdpBuildVersion.Major = $XdpVersion.Project.PropertyGroup.XdpMajorVersion
+    $XdpBuildVersion.Minor = $XdpVersion.Project.PropertyGroup.XdpMinorVersion
+    $XdpBuildVersion.Patch = $XdpVersion.Project.PropertyGroup.XdpPatchVersion
+    return $XdpBuildVersion;
+}
+
+function Get-XdpBuildVersionString {
+    $XdpVersion = Get-XdpBuildVersion
+    return "$($XdpVersion.Major).$($XdpVersion.Minor).$($XdpVersion.Patch)"
 }
 
 # Returns whether the script is running as a built-in administrator.

--- a/tools/create-devkit.ps1
+++ b/tools/create-devkit.ps1
@@ -32,7 +32,7 @@ copy docs\usage.md $DstPath
 
 New-Item -Path $DstPath\bin -ItemType Directory > $null
 copy "artifacts\bin\$($Platform)_$($Config)\CoreNetSignRoot.cer" $DstPath\bin
-copy "artifacts\bin\$($Platform)_$($Config)\xdpinstaller\xdp-for-windows.msi" $DstPath\bin
+copy "artifacts\bin\$($Platform)_$($Config)\xdpinstaller\xdp-for-windows.$(Get-XdpBuildVersionString).msi" $DstPath\bin
 copy "artifacts\bin\$($Platform)_$($Config)\pktcmd.exe" $DstPath\bin
 copy "artifacts\bin\$($Platform)_$($Config)\rxfilter.exe" $DstPath\bin
 copy "artifacts\bin\$($Platform)_$($Config)\xdpcfg.exe" $DstPath\bin

--- a/tools/create-devkit.ps1
+++ b/tools/create-devkit.ps1
@@ -58,12 +58,7 @@ copy "artifacts\bin\$($Platform)_$($Config)\xdpnmr.lib" $DstPath\lib
 # throw build exceptions if symbols are missing for statically linked code.
 copy "artifacts\bin\$($Platform)_$($Config)\xdpnmr.pdb" $DstPath\lib
 
-[xml]$XdpVersion = Get-Content $RootDir\src\xdp.props
-$Major = $XdpVersion.Project.PropertyGroup.XdpMajorVersion
-$Minor = $XdpVersion.Project.PropertyGroup.XdpMinorVersion
-$Patch = $XdpVersion.Project.PropertyGroup.XdpPatchVersion
-
-$VersionString = "$Major.$Minor.$Patch"
+$VersionString = Get-XdpBuildVersionString
 
 if (!(Is-ReleaseBuild)) {
     $VersionString += "-prerelease+" + (git.exe describe --long --always --dirty --exclude=* --abbrev=8)

--- a/tools/create-runtime-kit.ps1
+++ b/tools/create-runtime-kit.ps1
@@ -36,7 +36,6 @@ copy docs\usage.md $DstPath
 New-Item -Path $DstPath\bin -ItemType Directory > $null
 copy "artifacts\bin\$($Platform)_$($Config)\CoreNetSignRoot.cer" $DstPath\bin
 copy "artifacts\bin\$($Platform)_$($Config)\xdpinstaller\xdp-for-windows.msi" $DstPath\bin
-copy "artifacts\bin\$($Platform)_$($Config)\xdpcfg.exe" $DstPath\bin
 
 New-Item -Path $DstPath\symbols -ItemType Directory > $null
 copy "artifacts\bin\$($Platform)_$($Config)\xdp.pdb"   $DstPath\symbols

--- a/tools/create-test-archive.ps1
+++ b/tools/create-test-archive.ps1
@@ -38,12 +38,7 @@ copy "artifacts\bin\$($Platform)_$($Config)\xdpfunctionaltests.dll" $DstPath\bin
 New-Item -Path $DstPath\symbols -ItemType Directory > $null
 copy "artifacts\bin\$($Platform)_$($Config)\xdpfunctionaltests.pdb"   $DstPath\symbols
 
-[xml]$XdpVersion = Get-Content $RootDir\src\xdp.props
-$Major = $XdpVersion.Project.PropertyGroup.XdpMajorVersion
-$Minor = $XdpVersion.Project.PropertyGroup.XdpMinorVersion
-$Patch = $XdpVersion.Project.PropertyGroup.XdpPatchVersion
-
-$VersionString = "$Major.$Minor.$Patch"
+$VersionString = Get-XdpBuildVersionString
 
 if (!(Is-ReleaseBuild)) {
     $VersionString += "-prerelease+" + (git.exe describe --long --always --dirty --exclude=* --abbrev=8)

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -65,7 +65,7 @@ $DswDevice = Get-CoreNetCiArtifactPath -Name "dswdevice.exe"
 # File paths.
 $XdpInf = "$ArtifactsDir\xdp\xdp.inf"
 $XdpPcwMan = "$ArtifactsDir\xdppcw.man"
-$XdpMsiFullPath = "$ArtifactsDir\xdpinstaller\xdp-for-windows.msi"
+$XdpMsiFullPath = "$ArtifactsDir\xdpinstaller\xdp-for-windows.$(Get-XdpBuildVersionString).msi"
 $FndisSys = "$ArtifactsDir\fndis\fndis.sys"
 $XdpMpSys = "$ArtifactsDir\xdpmp\xdpmp.sys"
 $XdpMpInf = "$ArtifactsDir\xdpmp\xdpmp.inf"


### PR DESCRIPTION
I noticed we're building a runtime kit, which is now obsolete, so remove that.
We're also not stamping the version number onto the MSI, so fix that.