### PR TITLE
Use warning level 4 by default

### DIFF
--- a/published/external/xdp/datapath.h
+++ b/published/external/xdp/datapath.h
@@ -11,6 +11,9 @@ DECLARE_HANDLE(XDP_RX_QUEUE_HANDLE);
 DECLARE_HANDLE(XDP_TX_QUEUE_HANDLE);
 DECLARE_HANDLE(XDP_INTERFACE_HANDLE);
 
+#pragma warning(push)
+#pragma warning(disable:4324) // structure was padded due to alignment specifier
+
 typedef struct DECLSPEC_CACHEALIGN _XDP_RING {
     UINT32 ProducerIndex;
     UINT32 ConsumerIndex;
@@ -22,6 +25,8 @@ typedef struct DECLSPEC_CACHEALIGN _XDP_RING {
     // Followed by power-of-two array of ring elements.
     //
 } XDP_RING;
+
+#pragma warning(pop)
 
 C_ASSERT(sizeof(XDP_RING) == SYSTEM_CACHE_ALIGNMENT_SIZE);
 

--- a/src/xdp.cpp.props
+++ b/src/xdp.cpp.props
@@ -33,6 +33,8 @@
         POOL_ZERO_DOWN_LEVEL_SUPPORT=1;
         %(PreprocessorDefinitions)
       </PreprocessorDefinitions>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
       <!-- Disable C26812: The enum type '' is unscoped. Prefer 'enum class' over 'enum' -->
       <DisableSpecificWarnings>26812;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>

--- a/src/xdp/programinspect.h
+++ b/src/xdp/programinspect.h
@@ -5,6 +5,9 @@
 
 #pragma once
 
+#pragma warning(push)
+#pragma warning(disable:4200) // nonstandard extension used: zero-sized array in struct/union
+
 #pragma pack(push)
 #pragma pack(1)
 typedef struct QUIC_HEADER_INVARIANT {
@@ -94,6 +97,9 @@ typedef struct _XDP_PROGRAM_FRAME_CACHE {
     XDP_PROGRAM_PAYLOAD_CACHE TransportPayload;
 } XDP_PROGRAM_FRAME_CACHE;
 
+#pragma warning(push)
+#pragma warning(disable:4324) // structure was padded due to alignment specifier
+
 typedef struct _XDP_PROGRAM {
     //
     // Storage for discontiguous headers.
@@ -104,6 +110,10 @@ typedef struct _XDP_PROGRAM {
     UINT32 RuleCount;
     XDP_RULE Rules[0];
 } XDP_PROGRAM;
+
+#pragma warning(pop)
+
+#pragma warning(pop)
 
 VOID
 XdpProgramDeleteRule(

--- a/src/xdpcfg/xdpcfg.c
+++ b/src/xdpcfg/xdpcfg.c
@@ -70,6 +70,4 @@ wmain(
     } else {
         Usage();
     }
-
-    return EXIT_SUCCESS;
 }

--- a/src/xdpcfg/xdpcfg.c
+++ b/src/xdpcfg/xdpcfg.c
@@ -32,14 +32,21 @@ SetDeviceSddl(
     _In_ WCHAR **ArgV
     )
 {
+    SIZE_T StringLength;
 
     if (ArgC < 3) {
         Usage();
     }
 
+    StringLength = wcslen(ArgV[2]) * sizeof(WCHAR) + sizeof(UNICODE_NULL);
+    if (StringLength > MAXDWORD) {
+        fprintf(stderr, "Integer overflow\n");
+        return EXIT_FAILURE;
+    }
+
     if (!SetupDiSetClassRegistryPropertyW(
-        &XDP_DEVICE_CLASS_GUID, SPCRP_SECURITY_SDS, (BYTE *)ArgV[2],
-        wcslen(ArgV[2]) * sizeof(WCHAR) + sizeof(UNICODE_NULL), NULL, NULL)) {
+            &XDP_DEVICE_CLASS_GUID, SPCRP_SECURITY_SDS, (BYTE *)ArgV[2], (DWORD)StringLength,
+            NULL, NULL)) {
         fprintf(stderr, "SetupDiSetClassRegistryPropertyW failed: 0x%x\n", GetLastError());
         return EXIT_FAILURE;
     }

--- a/test/pktfuzz/pktfuzz.c
+++ b/test/pktfuzz/pktfuzz.c
@@ -94,7 +94,6 @@ LLVMFuzzerTestOneInput(
     XDP_INSPECTION_CONTEXT InspectionContext = {0};
     UINT32 FrameRingIndex;
     UINT32 FragmentRingIndex = 0;
-    UINT16 BufferDataLength;
     XDP_FRAME_WITH_EXTENSIONS *FrameExt = NULL;
     XDP_BUFFER *Buffer;
 

--- a/test/pktfuzz/stubs/program.c
+++ b/test/pktfuzz/stubs/program.c
@@ -22,6 +22,7 @@ XdpProgramCapturePortSet(
     _Inout_ XDP_PORT_SET *KernelPortSet
     )
 {
+    UNREFERENCED_PARAMETER(UserPortSet);
     UNREFERENCED_PARAMETER(RequestorMode);
 
     KernelPortSet->PortSet = DummyPortSet;


### PR DESCRIPTION
Somehow our build isn't configured to use level 4 and treat warnings as errors globally, so fix that.