### PR TITLE
Skip Perf When No Secrets are Available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,6 +414,10 @@ jobs:
       shell: pwsh
       run: |
         $url = "https://raw.githubusercontent.com/microsoft/netperf/main/run-workflow.ps1"
+        if ('${{ secrets.NET_PERF_TRIGGER }}' eq '') {
+            Write-Host "Not able to run because no secrets are available!"
+            return
+        }
         iex "& { $(irm $url) } ${{ secrets.NET_PERF_TRIGGER }} xdp ${{ github.sha }} ${{ github.ref }} ${{ github.event.pull_request.number }}"
 
   Complete:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,7 +414,7 @@ jobs:
       shell: pwsh
       run: |
         $url = "https://raw.githubusercontent.com/microsoft/netperf/main/run-workflow.ps1"
-        if ('${{ secrets.NET_PERF_TRIGGER }}' eq '') {
+        if ('${{ secrets.NET_PERF_TRIGGER }}' -eq '') {
             Write-Host "Not able to run because no secrets are available!"
             return
         }


### PR DESCRIPTION
Secrets are not shared with PRs from external forks, so we need to skip the runs that require them.