### PR TITLE
Fix fnio filter for multi MDL NB

### DIFF
--- a/test/common/lib/fnio/filter.c
+++ b/test/common/lib/fnio/filter.c
@@ -160,16 +160,12 @@ FnIoGetFilteredFrame(
     }
 
     NetBuffer = NET_BUFFER_LIST_FIRST_NB(Nbl);
-    DataBytes = NET_BUFFER_DATA_LENGTH(NetBuffer);
     BufferCount = 0;
-
     OutputSize = sizeof(*Frame);
-    OutputSize += NET_BUFFER_CURRENT_MDL_OFFSET(NetBuffer);
-    OutputSize += DataBytes;
 
-    for (Mdl = NET_BUFFER_CURRENT_MDL(NetBuffer); DataBytes > 0; Mdl = Mdl->Next) {
+    for (Mdl = NET_BUFFER_CURRENT_MDL(NetBuffer); Mdl != NULL; Mdl = Mdl->Next) {
         OutputSize += sizeof(*Buffer);
-        DataBytes -= min(Mdl->ByteCount, DataBytes);
+        OutputSize += Mdl->ByteCount;
 
         if (!NT_SUCCESS(RtlUInt8Add(BufferCount, 1, &BufferCount))) {
             Status = STATUS_INTEGER_OVERFLOW;

--- a/test/common/lib/fnio/filter.c
+++ b/test/common/lib/fnio/filter.c
@@ -199,6 +199,11 @@ FnIoGetFilteredFrame(
     for (UINT32 BufferIndex = 0; BufferIndex < BufferCount; BufferIndex++) {
         UCHAR *MdlBuffer;
 
+        if (Mdl == NULL) {
+            Status = STATUS_UNSUCCESSFUL;
+            goto Exit;
+        }
+
         MdlBuffer = MmGetSystemAddressForMdlSafe(Mdl, LowPagePriority);
         if (MdlBuffer == NULL) {
             Status = STATUS_INSUFFICIENT_RESOURCES;


### PR DESCRIPTION
When a TX NB containing multiple MDLs is filtered, we would expect the resulting frame to either
1) Contain a single data buffer with all bytes of all MDLs or
2) Contain a data buffer per MDL

In the case of a 2-MDL NB where the first MDL's ByteCount > NB data length, we end up with a single data buffer containing just the bytes of the first MDL.

Fix this so that we consistently end up with option 2 above.