### PR TITLE
fix / work around pktfuzz ASAN dependency change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        windows: [2019, 2022, Prerelease]
+        windows: [2019, 2022] # ASAN is currently buggy on Prerelease
         configuration: [Release, Debug]
         platform: [x64]
     runs-on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        windows: [Prerelease]
+        windows: [2019, 2022, Prerelease]
         configuration: [Release, Debug]
         platform: [x64]
     runs-on:

--- a/test/pktfuzz/pktfuzz.vcxproj
+++ b/test/pktfuzz/pktfuzz.vcxproj
@@ -63,6 +63,12 @@
       <AdditionalDependencies>onecore.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
+  <!-- The ASAN runtime cannot be statically linked into the executable, so provide it along with the binary. -->
+  <ItemGroup>
+    <Content Include="$(VCToolsInstallDir)\bin\Hostx64\x64\clang_rt.asan_dynamic-x86_64.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <!-- The following lines configure the targets necessary for sourcelink -->
   <ItemGroup>


### PR DESCRIPTION
The CI and my dev box stopped being able to build and run pktfuzz.exe, so include the ASAN runtime dependency along with the fuzzer binary.

Resolves #412 