### PR TITLE
Improve SAL for RSS APIs

### DIFF
--- a/published/external/xdpapi_experimental.h
+++ b/published/external/xdpapi_experimental.h
@@ -101,7 +101,7 @@ typedef
 HRESULT
 XDP_RSS_GET_CAPABILITIES_FN(
     _In_ HANDLE InterfaceHandle,
-    _Out_opt_ XDP_RSS_CAPABILITIES *RssCapabilities,
+    _Out_writes_bytes_opt_(*RssCapabilitiesSize) XDP_RSS_CAPABILITIES *RssCapabilities,
     _Inout_ UINT32 *RssCapabilitiesSize
     );
 
@@ -213,7 +213,7 @@ typedef
 HRESULT
 XDP_RSS_GET_FN(
     _In_ HANDLE InterfaceHandle,
-    _Out_opt_ XDP_RSS_CONFIGURATION *RssConfiguration,
+    _Out_writes_bytes_opt_(*RssConfigurationSize) XDP_RSS_CONFIGURATION *RssConfiguration,
     _Inout_ UINT32 *RssConfigurationSize
     );
 

--- a/src/xdpapi/xdpapi.c
+++ b/src/xdpapi/xdpapi.c
@@ -172,7 +172,7 @@ XdpInterfaceOpen(
 HRESULT
 XdpRssGetCapabilities(
     _In_ HANDLE InterfaceHandle,
-    _Out_opt_ XDP_RSS_CAPABILITIES *RssCapabilities,
+    _Out_writes_bytes_opt_(*RssCapabilitiesSize) XDP_RSS_CAPABILITIES *RssCapabilities,
     _Inout_ UINT32 *RssCapabilitiesSize
     )
 {
@@ -210,7 +210,7 @@ XdpRssSet(
 HRESULT
 XdpRssGet(
     _In_ HANDLE InterfaceHandle,
-    _Out_opt_ XDP_RSS_CONFIGURATION *RssConfiguration,
+    _Out_writes_bytes_opt_(*RssConfigurationSize) XDP_RSS_CONFIGURATION *RssConfiguration,
     _Inout_ UINT32 *RssConfigurationSize
     )
 {

--- a/test/rssconfig/rssconfig.c
+++ b/test/rssconfig/rssconfig.c
@@ -202,7 +202,7 @@ ProcessCommandGet(
 
     RssConfigSize = 0;
     Result = XdpRssGet(InterfaceHandle, RssConfig, &RssConfigSize);
-    if (SUCCEEDED(Result) || RssConfigSize < sizeof(*RssConfig)) {
+    if (SUCCEEDED(Result)) {
         printf(
             "Error: Failed to get RSS configuration size on IfIndex=%u Result=%d RssConfigSize=%d\n",
             IfIndex, Result, RssConfigSize);
@@ -215,7 +215,6 @@ ProcessCommandGet(
         goto Exit;
     }
 
-    _Analysis_assume_(RssConfigSize >= sizeof(*RssConfig));
     Result = XdpRssGet(InterfaceHandle, RssConfig, &RssConfigSize);
     if (FAILED(Result)) {
         printf("Error: Failed to get RSS configuration on IfIndex=%u Result=%d\n", IfIndex, Result);


### PR DESCRIPTION
Resolves the following static analysis issues for a typical app that queries the required length for capabilities/configuration, allocates a buffer of that length, and gets the capabilities/configuration using that buffer.

```
error C6386: Buffer overrun while writing to 'RssCapabilities':  the writable size is 'RssCapabilitiesSize' bytes, but '28' bytes might be written.
error C6386: Buffer overrun while writing to 'RssConfig':  the writable size is 'RssConfigSize' bytes, but '24' bytes might be written.
```