### PR TITLE
Disable fuzz tests on 2019

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        windows: [2019, 2022] # ASAN is currently buggy on Prerelease
+        windows: [2022] # ASAN is currently buggy on Prerelease and 2019.
         configuration: [Release, Debug]
         platform: [x64]
     runs-on:


### PR DESCRIPTION
Our ASAN user mode fuzz tests stopped working on WS2019. Disable them since they only need to run on one platform, and WS2022 is still working.