### PR TITLE
Fix CodeQL errors in scheduled build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,6 +404,8 @@ jobs:
       fail-fast: false
       matrix:
         configuration: [Release, Debug]
+    permissions:
+      security-events: write  # For CodeQL
     steps:
     - name: Checkout repository
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11


### PR DESCRIPTION
ETW is failing to build CodeQL with a 403 error. We're missing a write permission, I think.