### PR TITLE
Redirect Error Output from certutil.exe

### DIFF
--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -197,9 +197,9 @@ function Install-Certs {
         Write-Error "$CodeSignCertPath does not exist!"
     }
     Write-Host "CertUtil.exe -f -addstore Root $CodeSignCertPath"
-    CertUtil.exe -f -addstore Root $CodeSignCertPath | Write-Verbose
+    CertUtil.exe -f -addstore Root $CodeSignCertPath 2>&1 | Write-Verbose
     Write-Host "CertUtil.exe -f -addstore trustedpublisher $CodeSignCertPath"
-    CertUtil.exe -f -addstore trustedpublisher $CodeSignCertPath | Write-Host
+    CertUtil.exe -f -addstore trustedpublisher $CodeSignCertPath 2>&1 | Write-Verbose
 }
 
 # Uninstalls the XDP certificates.

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -196,8 +196,9 @@ function Install-Certs {
     if (!(Test-Path $CodeSignCertPath)) {
         Write-Error "$CodeSignCertPath does not exist!"
     }
+    Write-Host "CertUtil.exe -f -addstore Root $CodeSignCertPath"
     CertUtil.exe -f -addstore Root $CodeSignCertPath | Write-Verbose
-    Write-Host "Installing Code Signing Certificate"
+    Write-Host "CertUtil.exe -f -addstore trustedpublisher $CodeSignCertPath"
     CertUtil.exe -f -addstore trustedpublisher $CodeSignCertPath | Write-Host
 }
 
@@ -345,11 +346,17 @@ if ($Cleanup) {
     }
 
     if ($ForNetPerfTest) {
+        Write-Host "Setup-VcRuntime"
         Setup-VcRuntime
+        Write-Host "Download-CoreNet-Deps"
         Download-CoreNet-Deps
+        Write-Host "Download-Ebpf-Msi"
         Download-Ebpf-Msi
+        Write-Host "Setup-TestSigning"
         Setup-TestSigning
+        Write-Host "Install-Certs"
         Install-Certs
+        Write-Host "Done"
     }
 
     if ($ForTest) {

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -98,6 +98,7 @@ $EbpfNugetRestoreDir = "$RootDir/packages/$EbpfNugetVersion"
 $Reboot = $false
 
 function Download-CoreNet-Deps {
+    Write-Host "Downloading CoreNet dependencies"
     $CoreNetCiCommit = Get-CoreNetCiCommit
 
     # Download and extract https://github.com/microsoft/corenet-ci.
@@ -114,6 +115,7 @@ function Download-CoreNet-Deps {
 }
 
 function Download-eBpf-Nuget {
+    Write-Host "Downloading eBPF Nuget package"
     # Download and extract private eBPF Nuget package.
     $NugetDir = "$ArtifactsDir/nuget"
     if ($Force -and (Test-Path $NugetDir)) {
@@ -151,6 +153,7 @@ function Extract-Ebpf-Msi {
 }
 
 function Download-Ebpf-Msi {
+    Write-Host "Downloading eBPF installer"
     # Download and extract private eBPF installer MSI package.
     $EbpfPackageUrl = Get-EbpfPackageUrl
     $EbpfMsiFullPath = Get-EbpfMsiFullPath
@@ -173,6 +176,7 @@ function Download-Ebpf-Msi {
 }
 
 function Setup-TestSigning {
+    Write-Host "Checking for test signing"
     # Check to see if test signing is enabled.
     $HasTestSigning = $false
     try { $HasTestSigning = ("$(bcdedit)" | Select-String -Pattern "testsigning\s+Yes").Matches.Success } catch { }
@@ -196,7 +200,9 @@ function Install-Certs {
     if (!(Test-Path $CodeSignCertPath)) {
         Write-Error "$CodeSignCertPath does not exist!"
     }
+    Write-Host "Installing Root certificate"
     CertUtil.exe -f -addstore Root $CodeSignCertPath | Write-Verbose
+    Write-Host "Installing TrustedPublisher certificate"
     CertUtil.exe -f -addstore trustedpublisher $CodeSignCertPath | Write-Verbose
 }
 
@@ -207,6 +213,7 @@ function Uninstall-Certs {
 }
 
 function Setup-VcRuntime {
+    Write-Host "Checking for VC++ runtime"
     $Installed = $false
     try { $Installed = Get-ChildItem -Path Registry::HKEY_CLASSES_ROOT\Installer\Dependencies | Where-Object { $_.Name -like "*VC,redist*" } } catch {}
 

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -196,9 +196,7 @@ function Install-Certs {
     if (!(Test-Path $CodeSignCertPath)) {
         Write-Error "$CodeSignCertPath does not exist!"
     }
-    Write-Host "CertUtil.exe -f -addstore Root $CodeSignCertPath"
     CertUtil.exe -f -addstore Root $CodeSignCertPath 2>&1 | Write-Verbose
-    Write-Host "CertUtil.exe -f -addstore trustedpublisher $CodeSignCertPath"
     CertUtil.exe -f -addstore trustedpublisher $CodeSignCertPath 2>&1 | Write-Verbose
 }
 
@@ -346,17 +344,11 @@ if ($Cleanup) {
     }
 
     if ($ForNetPerfTest) {
-        Write-Host "Setup-VcRuntime"
         Setup-VcRuntime
-        Write-Host "Download-CoreNet-Deps"
         Download-CoreNet-Deps
-        Write-Host "Download-Ebpf-Msi"
         Download-Ebpf-Msi
-        Write-Host "Setup-TestSigning"
         Setup-TestSigning
-        Write-Host "Install-Certs"
         Install-Certs
-        Write-Host "Done"
     }
 
     if ($ForTest) {

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -98,7 +98,6 @@ $EbpfNugetRestoreDir = "$RootDir/packages/$EbpfNugetVersion"
 $Reboot = $false
 
 function Download-CoreNet-Deps {
-    Write-Host "Downloading CoreNet dependencies"
     $CoreNetCiCommit = Get-CoreNetCiCommit
 
     # Download and extract https://github.com/microsoft/corenet-ci.
@@ -115,7 +114,6 @@ function Download-CoreNet-Deps {
 }
 
 function Download-eBpf-Nuget {
-    Write-Host "Downloading eBPF Nuget package"
     # Download and extract private eBPF Nuget package.
     $NugetDir = "$ArtifactsDir/nuget"
     if ($Force -and (Test-Path $NugetDir)) {
@@ -153,7 +151,6 @@ function Extract-Ebpf-Msi {
 }
 
 function Download-Ebpf-Msi {
-    Write-Host "Downloading eBPF installer"
     # Download and extract private eBPF installer MSI package.
     $EbpfPackageUrl = Get-EbpfPackageUrl
     $EbpfMsiFullPath = Get-EbpfMsiFullPath
@@ -176,7 +173,6 @@ function Download-Ebpf-Msi {
 }
 
 function Setup-TestSigning {
-    Write-Host "Checking for test signing"
     # Check to see if test signing is enabled.
     $HasTestSigning = $false
     try { $HasTestSigning = ("$(bcdedit)" | Select-String -Pattern "testsigning\s+Yes").Matches.Success } catch { }
@@ -200,10 +196,9 @@ function Install-Certs {
     if (!(Test-Path $CodeSignCertPath)) {
         Write-Error "$CodeSignCertPath does not exist!"
     }
-    Write-Host "Installing Root certificate"
     CertUtil.exe -f -addstore Root $CodeSignCertPath | Write-Verbose
-    Write-Host "Installing TrustedPublisher certificate"
-    CertUtil.exe -f -addstore trustedpublisher $CodeSignCertPath | Write-Verbose
+    Write-Host "Installing Code Signing Certificate"
+    CertUtil.exe -f -addstore trustedpublisher $CodeSignCertPath | Write-Host
 }
 
 # Uninstalls the XDP certificates.
@@ -213,7 +208,6 @@ function Uninstall-Certs {
 }
 
 function Setup-VcRuntime {
-    Write-Host "Checking for VC++ runtime"
     $Installed = $false
     try { $Installed = Get-ChildItem -Path Registry::HKEY_CLASSES_ROOT\Installer\Dependencies | Where-Object { $_.Name -like "*VC,redist*" } } catch {}
 


### PR DESCRIPTION
When running the perf tests on some new machines, certutil seemed to be succeeding but still writing some wierd error output. Ignoring it seems safe, so we are just redirecting the output. The perf run then passed.