### PR TITLE
Further disambiguate downlevel artifact upload name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
       uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6
       if: ${{ always() }}
       with:
-        name: logs_dnlvl_win${{ matrix.windows }}_${{ matrix.configuration }}_${{ matrix.platform }}
+        name: logs_downlevel_${{ matrix.downlevel_release }}_win${{ matrix.windows }}_${{ matrix.configuration }}_${{ matrix.platform }}
         path: artifacts/logs
     - name: Check Drivers
       if: ${{ always() }}


### PR DESCRIPTION
Ensure adding a new downlevel version won't collide with existing artifact paths.