### PR TITLE
Populate `ingress_ifindex` in `xdp_md` struct.

### DIFF
--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -238,7 +238,7 @@ XdpInvokeEbpf(
     XdpMd.Base.data = Va;
     XdpMd.Base.data_end = Va + Buffer->DataLength;
     XdpMd.Base.data_meta = 0;
-    XdpMd.Base.ingress_ifindex = IFI_UNSPECIFIED;
+    XdpMd.Base.ingress_ifindex = InspectionContext->IfIndex;
 
     ebpf_program_batch_invoke_function_t EbpfInvokeProgram =
         EbpfExtensionClientGetProgramDispatch(Client)->ebpf_program_batch_invoke_function;

--- a/src/xdp/program.h
+++ b/src/xdp/program.h
@@ -12,15 +12,10 @@ typedef struct _XDP_RX_QUEUE XDP_RX_QUEUE;
 
 typedef ebpf_execution_context_state_t XDP_INSPECTION_EBPF_CONTEXT;
 
-// typedef struct _XDP_NET_DEVICE {
-//     NET_IFINDEX IfIndex;
-// } XDP_NET_DEVICE;
-
 typedef struct _XDP_INSPECTION_CONTEXT {
     XDP_INSPECTION_EBPF_CONTEXT EbpfContext;
     XDP_REDIRECT_CONTEXT RedirectContext;
     ULONG IfIndex;
-    // XDP_NET_DEVICE NetDevice;
 } XDP_INSPECTION_CONTEXT;
 
 //

--- a/src/xdp/program.h
+++ b/src/xdp/program.h
@@ -12,9 +12,15 @@ typedef struct _XDP_RX_QUEUE XDP_RX_QUEUE;
 
 typedef ebpf_execution_context_state_t XDP_INSPECTION_EBPF_CONTEXT;
 
+// typedef struct _XDP_NET_DEVICE {
+//     NET_IFINDEX IfIndex;
+// } XDP_NET_DEVICE;
+
 typedef struct _XDP_INSPECTION_CONTEXT {
     XDP_INSPECTION_EBPF_CONTEXT EbpfContext;
     XDP_REDIRECT_CONTEXT RedirectContext;
+    ULONG IfIndex;
+    // XDP_NET_DEVICE NetDevice;
 } XDP_INSPECTION_CONTEXT;
 
 //

--- a/src/xdp/rx.c
+++ b/src/xdp/rx.c
@@ -90,6 +90,8 @@ typedef struct _XDP_RX_QUEUE {
     PCW_INSTANCE *PcwInstance;
 
     LIST_ENTRY NotifyClients;
+
+    // XDP_NET_DEVICE DeviceInfo;
 } XDP_RX_QUEUE;
 
 typedef struct _XDP_RX_QUEUE_SWAP_PROGRAM_PARAMS {
@@ -1009,6 +1011,7 @@ XdpRxQueueCreate(
     XdpQueueSyncInitialize(&RxQueue->Sync);
     RxQueue->Binding = Binding;
     RxQueue->Key = Key;
+    RxQueue->InspectionContext.IfIndex = XdpIfGetIfIndex(Binding);
     XdpInitializeQueueInfo(&RxQueue->QueueInfo, XDP_QUEUE_TYPE_DEFAULT_RSS, QueueId);
     XdbgInitializeQueueEc(RxQueue);
 

--- a/src/xdp/rx.c
+++ b/src/xdp/rx.c
@@ -90,8 +90,6 @@ typedef struct _XDP_RX_QUEUE {
     PCW_INSTANCE *PcwInstance;
 
     LIST_ENTRY NotifyClients;
-
-    // XDP_NET_DEVICE DeviceInfo;
 } XDP_RX_QUEUE;
 
 typedef struct _XDP_RX_QUEUE_SWAP_PROGRAM_PARAMS {

--- a/test/bpf/bpf.vcxproj
+++ b/test/bpf/bpf.vcxproj
@@ -34,14 +34,15 @@
   <ItemDefinitionGroup>
     <PreBuildEvent>
       <Command>
-       set PATH=%PATH%;$(EbpfPackagePath)build\native\bin
+        xcopy $(EbpfPackagePath)build\native\bin\EbpfApi.dll $(SolutionDir)artifacts\bin\$(Platform)_$(Configuration) /Y
+        $(EbpfPackagePath)build\native\bin\export_program_info.exe
         $(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\xdp_bpfexport.exe
       </Command>
     </PreBuildEvent>
     <PostBuildEvent>
       <Command>
-        set PATH=%PATH%;$(EbpfPackagePath)build\native\bin
         $(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\xdp_bpfexport.exe --clear
+        $(EbpfPackagePath)build\native\bin\export_program_info.exe --clear
       </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>

--- a/test/bpf/bpf.vcxproj
+++ b/test/bpf/bpf.vcxproj
@@ -66,6 +66,16 @@
         rmdir /s /q $(OutDir)\drop_km
         popd</Command>
     </CustomBuild>
+    <CustomBuild Include="selective_drop.c">
+      <FileType>CppCode</FileType>
+      <Outputs>$(OutDir)selective_drop.sys</Outputs>
+      <Command>
+        clang -g -target bpf -O2 -Werror $(ClangIncludes) -c %(Filename).c -o $(OutDir)%(Filename).o
+        pushd $(OutDir)
+        powershell -NonInteractive -ExecutionPolicy Unrestricted $(EbpfBinPath)\Convert-BpfToNative.ps1 -FileName %(Filename) -IncludeDir $(EbpfIncludePath) -Platform $(Platform) -Configuration $(Configuration) -KernelMode $true
+        rmdir /s /q $(OutDir)\selective_drop_km
+        popd</Command>
+    </CustomBuild>
     <CustomBuild Include="l1fwd.c">
       <FileType>CppCode</FileType>
       <Outputs>$(OutDir)l1fwd.sys</Outputs>

--- a/test/bpf/bpf.vcxproj
+++ b/test/bpf/bpf.vcxproj
@@ -43,6 +43,7 @@
       <Command>
         $(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\xdp_bpfexport.exe --clear
         $(EbpfPackagePath)build\native\bin\export_program_info.exe --clear
+        del $(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\ebpfapi.dll /F
       </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>

--- a/test/bpf/selective_drop.c
+++ b/test/bpf/selective_drop.c
@@ -1,0 +1,45 @@
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+
+#include "bpf_endian.h"
+#include "bpf_helpers.h"
+
+// Map configured by user mode to dictate if packets from a specific interface should be dropped.
+struct
+{
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, uint32_t);
+    __type(value, uint32_t);
+    __uint(max_entries, 1);
+} interface_map SEC(".maps");
+
+struct
+{
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, uint32_t);
+    __type(value, uint64_t);
+    __uint(max_entries, 1);
+} dropped_packet_map SEC(".maps");
+
+SEC("xdp/selective_drop")
+int
+drop(xdp_md_t *ctx)
+{
+    int action = XDP_PASS;
+    uint32_t interface_index = ctx->ingress_ifindex;
+    uint32_t *interface_value = bpf_map_lookup_elem(&interface_map, &interface_index);
+    if (interface_value) {
+        action = XDP_DROP;
+        uint64_t *dropped_packet_count = bpf_map_lookup_elem(&dropped_packet_map, &interface_index);
+        if (dropped_packet_count) {
+            *dropped_packet_count += 1;
+        } else {
+            uint64_t dropped_packet_count = 1;
+            bpf_map_update_elem(&dropped_packet_map, &interface_index, &dropped_packet_count, BPF_ANY);
+        }
+    }
+
+    return action;
+}

--- a/test/bpf/selective_drop.c
+++ b/test/bpf/selective_drop.c
@@ -26,7 +26,7 @@ struct
 
 SEC("xdp/selective_drop")
 int
-drop(xdp_md_t *ctx)
+selective_drop(xdp_md_t *ctx)
 {
     int action = XDP_PASS;
     int zero = 0;

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -4717,7 +4717,7 @@ GenericRxEbpfIfIndex()
     const UCHAR Payload[] = "GenericRxEbpfIfIndex";
     UINT32 Zero = 0;
 
-    unique_bpf_object BpfObject = AttachEbpfXdpProgram(If, "\\bpf\\selective_drop.sys", "drop");
+    unique_bpf_object BpfObject = AttachEbpfXdpProgram(If, "\\bpf\\selective_drop.sys", "selective_drop");
 
     GenericMp = MpOpenGeneric(If.GetIfIndex());
     FnLwf = LwfOpenDefault(If.GetIfIndex());

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -4717,7 +4717,7 @@ GenericRxEbpfIfIndex()
     const UCHAR Payload[] = "GenericRxEbpfIfIndex";
     UINT32 Zero = 0;
 
-    unique_bpf_object BpfObject = AttachEbpfXdpProgram(If, "\\bpf\\selective_drop.sys", "selective_drop");
+    unique_bpf_object BpfObject = AttachEbpfXdpProgram(If, "\\bpf\\selective_drop.sys", "drop");
 
     GenericMp = MpOpenGeneric(If.GetIfIndex());
     FnLwf = LwfOpenDefault(If.GetIfIndex());
@@ -4728,6 +4728,8 @@ GenericRxEbpfIfIndex()
 
     // Update the interface_map with the interface index of the test interface.
     UINT32 IfIndex = If.GetIfIndex();
+    TEST_NOT_EQUAL(IfIndex, IFI_UNSPECIFIED);
+
     TEST_EQUAL(0, bpf_map_update_elem(interface_map_fd, &Zero, &IfIndex, BPF_ANY));
 
     std::vector<UCHAR> Mask(sizeof(Payload), 0xFF);
@@ -4751,7 +4753,7 @@ GenericRxEbpfIfIndex()
     TEST_NOT_EQUAL(dropped_packet_map_fd, ebpf_fd_invalid);
 
     UINT64 DroppedPacketCount = 0;
-    TEST_EQUAL(0, bpf_map_lookup_elem(dropped_packet_map_fd, &IfIndex, &DroppedPacketCount));
+    TEST_EQUAL(0, bpf_map_lookup_elem(dropped_packet_map_fd, &Zero, &DroppedPacketCount));
     TEST_EQUAL(DroppedPacketCount, 1);
 
     // Now set the ifIndex to some other value and verify that the packet is not dropped.

--- a/test/functional/lib/tests.h
+++ b/test/functional/lib/tests.h
@@ -122,6 +122,9 @@ VOID
 ProgTestRunRxEbpfPayload();
 
 VOID
+GenericRxEbpfIfIndex();
+
+VOID
 GenericRxEbpfFragments();
 
 VOID

--- a/test/functional/taef/tests.cpp
+++ b/test/functional/taef/tests.cpp
@@ -424,6 +424,10 @@ public:
         ::ProgTestRunRxEbpfPayload();
     }
 
+    TEST_METHOD(GenericRxEbpfIfIndex) {
+        ::GenericRxEbpfIfIndex();
+    }
+
     TEST_METHOD(GenericRxEbpfFragments) {
         ::GenericRxEbpfFragments();
     }


### PR DESCRIPTION
Fixes #448 

This PR populates `ingress_ifindex` in `xdp_md` struct passed to the eBPF program. Also added test to validate that ifindex is correctly populated.