### PR TITLE
Fix WS2025 netperf Test Execution

### DIFF
--- a/tools/two-machine-perf.ps1
+++ b/tools/two-machine-perf.ps1
@@ -23,7 +23,10 @@ $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
 
 # Set up the connection to the peer over remote powershell.
 Write-Output "Connecting to $PeerName..."
-$Session = New-PSSession -ComputerName $PeerName -ConfigurationName $RemotePSConfiguration
+$Username = (Get-ItemProperty 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon').DefaultUserName
+$Password = (Get-ItemProperty 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon').DefaultPassword | ConvertTo-SecureString -AsPlainText -Force
+$Creds = New-Object System.Management.Automation.PSCredential ($Username, $Password)
+$Session = New-PSSession -ComputerName $PeerName -Credential $Creds -ConfigurationName $RemotePSConfiguration
 if ($null -eq $Session) {
     Write-Error "Failed to create remote session"
 }


### PR DESCRIPTION
For WS2025 machines you are required to pass the credentials explicitly to be able to connect the remote PowerShell session. This copies the code from MsQuic.