### PR TITLE
Minor updates and cleanup for v1.0.1 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        downlevel_release: [1.0.0]
+        downlevel_release: [1.0.0, 1.0.1]
         windows: [2019, 2022, Prerelease]
         configuration: [Release]
         platform: [x64]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        downlevel_release: [1.0.0, 1.0.1]
+        downlevel_release: [1.0.1]
         windows: [2019, 2022, Prerelease]
         configuration: [Release]
         platform: [x64]

--- a/docs/release.md
+++ b/docs/release.md
@@ -44,13 +44,11 @@ For example, if `v1.0` is released on January 1st, 2024 and then `v2.0` is relea
 
 # Official Releases
 
-> **Note** - There are no official releases of XDP-for-Windows yet! This section is currently a placeholder.
-
 The following are the official releases of XDP-for-Windows.
 
 | Version | Fork Date | Release Date | End of Support |
 |   --    |     --    |       --     |       --       |
-| [v1.0](https://github.com/microsoft/xdp-for-windows/releases/tag/v1.0.0) | Jul 26, 2023 | Aug 7, 2023 | Feb 7, 2025 |
+| [v1.0](https://github.com/microsoft/xdp-for-windows/tree/release/1.0) | Jul 26, 2023 | Aug 7, 2023 | Feb 7, 2025 |
 |   TBD    |     TBD    |       TBD     |       TBD       |
 
 # Release Process
@@ -62,7 +60,7 @@ The following sections are generally for the maintainers of XDP-for-Windows. The
 > **Note** - TODO
 
 * Authorize the new branch in the [OneBranch.Official](https://mscodehub.visualstudio.com/WindowsXDP/_apps/hub/EZStart.management-ux.onebranch-resources#authorizedbranches/xdp/2407) and [OneBranch.PullRequest](https://mscodehub.visualstudio.com/WindowsXDP/_apps/hub/EZStart.management-ux.onebranch-resources#authorizedbranches/xdp/2404) internal pipelines under **OneBranch Resources** -> **Manage Authorized Branches**.
-* Update https://aka.ms/xdp-v1.msi to redirect to the latest V1.x release.
+* Update https://aka.ms/xdp-v1.msi to redirect to the latest V1.0.x release.
 
 ## Servicing a new Release Branch
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -61,6 +61,8 @@ The following sections are generally for the maintainers of XDP-for-Windows. The
 
 * Authorize the new branch in the [OneBranch.Official](https://mscodehub.visualstudio.com/WindowsXDP/_apps/hub/EZStart.management-ux.onebranch-resources#authorizedbranches/xdp/2407) and [OneBranch.PullRequest](https://mscodehub.visualstudio.com/WindowsXDP/_apps/hub/EZStart.management-ux.onebranch-resources#authorizedbranches/xdp/2404) internal pipelines under **OneBranch Resources** -> **Manage Authorized Branches**.
 * Update https://aka.ms/xdp-v1.msi to redirect to the latest V1.0.x release.
+* Add the test artifacts of the new release to the downlevel tests for main and
+  any other active release branches.
 
 ## Servicing a new Release Branch
 

--- a/src/xdpinstaller/Product.wxs
+++ b/src/xdpinstaller/Product.wxs
@@ -67,7 +67,7 @@ SPDX-License-Identifier: MIT
                 <File Id="xdppcw.man" Source="$(var.TargetDir)..\xdppcw.man" KeyPath="yes"/>
             </Component>
             <Component Id="xdpapi.dll" Guid="{18A0B4FC-9F22-4E15-8AD2-64131E6E238B}">
-                <File Id="xdpapi.dll" Name="xdpapi.dll" Source="$(var.TargetDir)..\xdpapi.dll" KeyPath="yes" />
+                <File Id="xdpapi.dll" Name="xdpapi.dll" Source="$(var.TargetDir)..\xdp\xdpapi.dll" KeyPath="yes" />
             </Component>
             <Component Id="xdpcfg.exe" Guid="{2F099CCD-54DA-495C-9741-3F3EFE357087}">
                 <File Id="xdpcfg.exe" Name="xdpcfg.exe" Source="$(var.TargetDir)..\xdpcfg.exe" KeyPath="yes" />


### PR DESCRIPTION
1. Make the installer pick up the xdpapi.dll binary from the `xdp` subdirectory, i.e. the driver package, which is less likely to be miscopied by human error than the version of xdpapi.dll in the bin root.
2. Make the 1.0 release link point to the 1.0 tree, not just the 1.0.0 tag.
3. Add 1.0.1 to the downlevel test list.
4. Remind releasers to update the downlevel tests.