### PR TITLE
Fix PAT for publishing symbols

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,10 @@ on:
         required: false
         default: false
         type: boolean
+      publish_symbols_pat:
+        required: false
+        type: string
+        default: ''
 
 jobs:
   build:
@@ -99,7 +103,7 @@ jobs:
       with:
         accountName: mscodehub
         symbolServiceUrl: 'https://artifacts.dev.azure.com'
-        personalAccessToken: ${{ secrets.AZDO_PAT }}
+        personalAccessToken: ${{ inputs.publish_symbols_pat }}
     - name: Perform CodeQL Analysis
       if: inputs.codeql
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,10 +41,9 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
       publish_symbols_pat:
         required: false
-        type: string
-        default: ''
 
 jobs:
   build:
@@ -103,7 +102,7 @@ jobs:
       with:
         accountName: mscodehub
         symbolServiceUrl: 'https://artifacts.dev.azure.com'
-        personalAccessToken: ${{ inputs.publish_symbols_pat }}
+        personalAccessToken: ${{ secrets.publish_symbols_pat }}
     - name: Perform CodeQL Analysis
       if: inputs.codeql
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
       codeql: ${{ github.event_name == 'schedule' }}
       upload_artifacts: ${{ matrix.os == 2022 }}
       publish_symbols: ${{ github.event_name != 'pull_request' && matrix.os == 2022 }}
+      publish_symbols_pat: ${{ secrets.AZDO_PAT }}
 
   functional_tests:
     name: Functional Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
       codeql: ${{ github.event_name == 'schedule' }}
       upload_artifacts: ${{ matrix.os == 2022 }}
       publish_symbols: ${{ github.event_name != 'pull_request' && matrix.os == 2022 }}
+    secrets:
       publish_symbols_pat: ${{ secrets.AZDO_PAT }}
 
   functional_tests:


### PR DESCRIPTION
The refactored build script broke in main: the secret PAT doesn't automatically propagate to the reusable workflow.