### PR TITLE
Uninstall eBPF using Uninstall-Package

### DIFF
--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -623,16 +623,15 @@ function Uninstall-Ebpf {
     }
 
     if ($Process.ExitCode -ne 0) {
-        if ($Process.ExitCode -eq 0x666) {
-            Write-Error "An unexpected version of eBPF could not be uninstalled"
-        } else {
-            Write-Error "MSI uninstall failed with status $($Process.ExitCode)" -ErrorAction Continue
-            Uninstall-Failure "ebpf_uninstall.dmp"
-        }
+        Write-Warning "Uninstalling eBPF from $EbpfMsiFullPath failed: $($Process.ExitCode)"
+
+        Write-Verbose "Attempting generic uninstall using Uninstall-Package"
+        Get-Package | Where-Object -Property "Name" -eq "eBPF for Windows" | Uninstall-Package
     }
 
     if (Test-Path $EbpfPath) {
         Write-Error "eBPF could not be uninstalled"
+        Uninstall-Failure "ebpf_uninstall.dmp"
     }
     Refresh-Path
 }

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -566,7 +566,6 @@ function Uninstall-XdpFnLwf {
 function Install-Ebpf {
     $EbpfPath = Get-EbpfInstallPath
     $EbpfMsiFullPath = Get-EbpfMsiFullPath
-    $EbpfMsiFullPath = (Resolve-Path $EbpfMsiFullPath).Path
     $EbpfOptions = ""
 
     Write-Verbose "Installing eBPF for Windows"
@@ -599,7 +598,6 @@ function Install-Ebpf {
 function Uninstall-Ebpf {
     $EbpfPath = Get-EbpfInstallPath
     $EbpfMsiFullPath = Get-EbpfMsiFullPath
-    $EbpfMsiFullPath = (Resolve-Path $EbpfMsiFullPath).Path
     $Timeout = 60
 
     if (!(Test-Path $EbpfPath)) {


### PR DESCRIPTION
To attempt to make eBPF uninstall more resilient to various errors, uninstall using `Uninstall-Package` if the local MSI uninstall failed.