### PR TITLE
Update setup-msbuild manually

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       with:
         languages: c-cpp
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@ab534842b4bdf384b8aaf93765dc6f721d9f5fab
+      uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce
     - name: Prepare Machine
       shell: PowerShell
       run: tools/prepare-machine.ps1 -ForBuild -Verbose


### PR DESCRIPTION
For some reason dependabot has not picked up newer changes of the setup-msbuild action. This left us with a stale version which is now causing warnings during the CI build. Manually bump the version to resolve the build warnings and hope dependabot starts working.