### PR TITLE
spinxsk: reduce longhaul stress runtime

### DIFF
--- a/.azure/azure-pipelines.longhaul.yml
+++ b/.azure/azure-pipelines.longhaul.yml
@@ -9,9 +9,9 @@ trigger:
 name: 0.$(Date:yyyy).$(Date:MM).$(DayOfMonth).$(Rev:rr).0
 
 variables:
-    spinxskRuntime: 1440
-    spinxskTimeout: 1445
-    spinxskJobTimeout: 1455
+    spinxskRuntime: 1320 # 22 hours
+    spinxskTimeout: 1325 # 22:05 hours
+    spinxskJobTimeout: 1335 # 22:15 hours
 
 stages:
 


### PR DESCRIPTION
Try to avoid internal flags being raised about machines running for a day: set the runtime target to 22 hours.