### PR TITLE
perf test: continue past errors during cleanup

### DIFF
--- a/tools/two-machine-perf.ps1
+++ b/tools/two-machine-perf.ps1
@@ -289,7 +289,7 @@ Write-Output "Test Complete!"
     Invoke-Command -Session $Session -ScriptBlock {
         param ($Config, $Arch, $RemoteDir)
         & $RemoteDir\tools\log.ps1 -Stop -Name xskcpu -Config $Config -Arch $Arch -EtlPath $RemoteDir\artifacts\logs\xskbench-peer.etl -ErrorAction 'Continue' | Out-Null
-    } -ArgumentList $Config, $Arch, $RemoteDir
+    } -ArgumentList $Config, $Arch, $RemoteDir -ErrorAction 'Continue'
     Write-Output "Stopping local logs..."
     tools\log.ps1 -Stop -Name xskcpu -Config $Config -Arch $Arch -EtlPath artifacts\logs\xskbench-local.etl -ErrorAction 'Continue' | Out-Null
     Write-Output "Copying remote logs..."
@@ -303,7 +303,7 @@ Write-Output "Test Complete!"
     Invoke-Command -Session $Session -ScriptBlock {
         param ($Config, $Arch, $RemoteDir)
         & $RemoteDir\tools\setup.ps1 -Uninstall xdp -Config $Config -Arch $Arch -ErrorAction 'Continue'
-    } -ArgumentList $Config, $Arch, $RemoteDir
+    } -ArgumentList $Config, $Arch, $RemoteDir -ErrorAction 'Continue'
     # Clean up eBPF
     Write-Output "Removing eBPF locally..."
     tools\setup.ps1 -Uninstall ebpf -Config $Config -Arch $Arch -ErrorAction 'Continue'
@@ -311,5 +311,5 @@ Write-Output "Test Complete!"
     Invoke-Command -Session $Session -ScriptBlock {
         param ($Config, $Arch, $RemoteDir)
         & $RemoteDir\tools\setup.ps1 -Uninstall ebpf -Config $Config -Arch $Arch -ErrorAction 'Continue'
-    } -ArgumentList $Config, $Arch, $RemoteDir
+    } -ArgumentList $Config, $Arch, $RemoteDir -ErrorAction 'Continue'
 }


### PR DESCRIPTION
The new two-machine perf tests specify `-ErrorAction 'Continue'` for each command within the remote script block, but, curiously, PowerShell treats errors in local and remote script blocks differently. Without digging into why exactly there is such a difference, simply specify each invocation of the remote script block is to have its errors continued.

Avoids situations like the following:

```
====================CLEAN UP====================

Stopping remote logs...
##vso[task.setvariable variable=NeedsReboot]true
Write-Error: C:\actions-runner\_work\netperf\netperf\tools\two-machine-perf.ps1:289
Line |
 289 |      Invoke-Command -Session $Session -ScriptBlock {
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | wpr.exe failed: -9840762[88](https://github.com/microsoft/netperf/actions/runs/9367353340/job/25787006193#step:4:89)
Error: Process completed with exit code 1.
```