### PR TITLE
fix new afxdp.h nameless struct warning

### DIFF
--- a/published/external/afxdp.h
+++ b/published/external/afxdp.h
@@ -17,11 +17,13 @@ extern "C" {
 #endif
 
 typedef union _XSK_BUFFER_ADDRESS {
+#pragma warning(push)
+#pragma warning(disable:4201) // nonstandard extension used: nameless struct/union
     struct {
         UINT64 BaseAddress : 48;
         UINT64 Offset : 16;
-#pragma warning(suppress:4201) // nonstandard extension used: nameless struct/union
-    } DUMMYUNIONNAME;
+    } DUMMYSTRUCTNAME;
+#pragma warning(pop)
     UINT64 AddressAndOffset;
 } XSK_BUFFER_ADDRESS;
 


### PR DESCRIPTION
The latest VS2022 toolchains fail to suppress the nameless struct/union warning in C++ mode. I don't know why that is, but work around it by suppressing it a different way.