### PR TITLE
don't publish symbols in github builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,13 +37,6 @@ on:
         required: false
         default: true
         type: boolean
-      publish_symbols:
-        required: false
-        default: false
-        type: boolean
-    secrets:
-      publish_symbols_pat:
-        required: false
 
 jobs:
   build:
@@ -96,13 +89,6 @@ jobs:
           !artifacts/bin/**/*.ilk
           !artifacts/bin/**/*.exp
           !artifacts/bin/**/*.lastcodeanalysissucceeded
-    - name: Publish Symbols
-      uses: microsoft/action-publish-symbols@719c40b80e38bca806f3e01e1e3dd3a67554cd68
-      if: inputs.publish_symbols
-      with:
-        accountName: mscodehub
-        symbolServiceUrl: 'https://artifacts.dev.azure.com'
-        personalAccessToken: ${{ secrets.publish_symbols_pat }}
     - name: Perform CodeQL Analysis
       if: inputs.codeql
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,6 @@ jobs:
       arch: ${{ matrix.arch }}
       codeql: ${{ github.event_name == 'schedule' }}
       upload_artifacts: ${{ matrix.os == 2022 }}
-      publish_symbols: ${{ github.event_name != 'pull_request' && matrix.os == 2022 }}
-    secrets:
-      publish_symbols_pat: ${{ secrets.AZDO_PAT }}
 
   functional_tests:
     name: Functional Tests


### PR DESCRIPTION
This is the last remaining usage of the ADO PAT, which has become an increasing maintenance burden.

The symbols are barely used, so just stop publishing them for now.