### PR TITLE
clean up pending NBLs in FNMP and FNLWF using RAII

### DIFF
--- a/src/xdp.props
+++ b/src/xdp.props
@@ -7,7 +7,7 @@
     <!-- Project-wide properties -->
     <EbpfPackagePath>$(SolutionDir)packages\eBPF-for-Windows.0.15.1\</EbpfPackagePath>
     <WiXPackagePath>$(SolutionDir)packages\wix.3.14.1\</WiXPackagePath>
-    <FnPackagePath>$(SolutionDir)artifacts\fn\devkit-0.4.1\</FnPackagePath>
+    <FnPackagePath>$(SolutionDir)artifacts\fn\devkit-0.4.2\</FnPackagePath>
   </PropertyGroup>
   <!-- The set of (eventually?) supported configurations -->
   <ItemGroup Label="ProjectConfigurations">

--- a/src/xdp.props
+++ b/src/xdp.props
@@ -7,7 +7,7 @@
     <!-- Project-wide properties -->
     <EbpfPackagePath>$(SolutionDir)packages\eBPF-for-Windows.0.15.1\</EbpfPackagePath>
     <WiXPackagePath>$(SolutionDir)packages\wix.3.14.1\</WiXPackagePath>
-    <FnPackagePath>$(SolutionDir)artifacts\fn\devkit-0.4.2\</FnPackagePath>
+    <FnPackagePath>$(SolutionDir)artifacts\fn\devkit-0.4.3\</FnPackagePath>
   </PropertyGroup>
   <!-- The set of (eventually?) supported configurations -->
   <ItemGroup Label="ProjectConfigurations">

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -116,6 +116,23 @@ static const XDP_HOOK_ID XdpInspectTxL2 =
 C_ASSERT(POLL_INTERVAL_MS * 5 <= TEST_TIMEOUT_ASYNC_MS);
 C_ASSERT(POLL_INTERVAL_MS * 5 <= std::chrono::milliseconds(MP_RESTART_TIMEOUT).count());
 
+static
+VOID
+MpTxFilterReset(
+    _In_ const FNMP_HANDLE Handle
+    )
+{
+    TEST_HRESULT(FnMpTxFilter(Handle, NULL, NULL, 0));
+}
+
+static
+VOID
+LwfRxFilterReset(
+    _In_ const FNLWF_HANDLE Handle
+    )
+{
+    TEST_HRESULT(FnLwfRxFilter(Handle, NULL, NULL, 0));
+}
 
 template <typename T>
 using unique_malloc_ptr = wistd::unique_ptr<T, wil::function_deleter<decltype(&::free), ::free>>;
@@ -123,6 +140,8 @@ using unique_xdp_api = wistd::unique_ptr<const XDP_API_TABLE, wil::function_dele
 using unique_bpf_object = wistd::unique_ptr<bpf_object, wil::function_deleter<decltype(&::bpf_object__close), ::bpf_object__close>>;
 using unique_fnmp_handle = wil::unique_any<FNMP_HANDLE, decltype(::FnMpClose), ::FnMpClose>;
 using unique_fnlwf_handle = wil::unique_any<FNLWF_HANDLE, decltype(::FnLwfClose), ::FnLwfClose>;
+using unique_fnmp_filter_handle = wil::unique_any<FNMP_HANDLE, decltype(::MpTxFilterReset), ::MpTxFilterReset>;
+using unique_fnlwf_filter_handle = wil::unique_any<FNLWF_HANDLE, decltype(::LwfRxFilterReset), ::LwfRxFilterReset>;
 
 static unique_xdp_api XdpApi;
 static FNMP_LOAD_API_CONTEXT FnMpLoadApiContext;
@@ -1582,8 +1601,9 @@ RxInitializeFrame(
     Frame->Frame.Buffers = &Frame->SingleBufferStorage;
 }
 
+[[nodiscard]]
 static
-VOID
+unique_fnmp_filter_handle
 MpTxFilter(
     _In_ const unique_fnmp_handle &Handle,
     _In_ const VOID *Pattern,
@@ -1592,6 +1612,8 @@ MpTxFilter(
     )
 {
     TEST_HRESULT(FnMpTxFilter(Handle.get(), Pattern, Mask, Length));
+
+    return unique_fnmp_filter_handle(Handle.get());
 }
 
 static
@@ -1700,8 +1722,9 @@ LwfTxFlush(
     TEST_HRESULT(Result);
 }
 
+[[nodiscard]]
 static
-VOID
+unique_fnlwf_filter_handle
 LwfRxFilter(
     _In_ const unique_fnlwf_handle &Handle,
     _In_ const VOID *Pattern,
@@ -1710,6 +1733,8 @@ LwfRxFilter(
     )
 {
     TEST_HRESULT(FnLwfRxFilter(Handle.get(), Pattern, Mask, Length));
+
+    return unique_fnlwf_filter_handle(Handle.get());
 }
 
 static
@@ -4016,12 +4041,15 @@ GenericRxFragmentBuffer(
         Ethernet->Destination = Ethernet->Source;
         Ethernet->Source = TempAddress;
 
+        unique_fnlwf_filter_handle LwfFilter;
+        unique_fnmp_filter_handle MpFilter;
+
         if (Params->IsTxInspect) {
-            LwfRxFilter(FnLwf, &L2FwdPacket[0], &Mask[0], (UINT32)L2FwdPacket.size());
+            LwfFilter = LwfRxFilter(FnLwf, &L2FwdPacket[0], &Mask[0], (UINT32)L2FwdPacket.size());
             LwfTxFlush(FnLwf, &RxFlushOptions);
             TxFrame = LwfRxAllocateAndGetFrame(FnLwf, 0);
         } else {
-            MpTxFilter(GenericMp, &L2FwdPacket[0], &Mask[0], (UINT32)L2FwdPacket.size());
+            MpFilter = MpTxFilter(GenericMp, &L2FwdPacket[0], &Mask[0], (UINT32)L2FwdPacket.size());
             MpRxFlush(GenericMp, &RxFlushOptions);
             TxFrame = MpTxAllocateAndGetFrame(GenericMp, 0);
         }
@@ -4553,7 +4581,7 @@ GenericRxEbpfDrop()
     FnLwf = LwfOpenDefault(If.GetIfIndex());
 
     std::vector<UCHAR> Mask(sizeof(Payload), 0xFF);
-    LwfRxFilter(FnLwf, Payload, &Mask[0], sizeof(Payload));
+    auto LwfFilter = LwfRxFilter(FnLwf, Payload, &Mask[0], sizeof(Payload));
 
     RX_FRAME Frame;
     RxInitializeFrame(&Frame, If.GetQueueId(), Payload, sizeof(Payload));
@@ -4582,7 +4610,7 @@ GenericRxEbpfPass()
     FnLwf = LwfOpenDefault(If.GetIfIndex());
 
     std::vector<UCHAR> Mask(sizeof(Payload), 0xFF);
-    LwfRxFilter(FnLwf, Payload, &Mask[0], sizeof(Payload));
+    auto LwfFilter = LwfRxFilter(FnLwf, Payload, &Mask[0], sizeof(Payload));
 
     RX_FRAME Frame;
     RxInitializeFrame(&Frame, If.GetQueueId(), Payload, sizeof(Payload));
@@ -4606,7 +4634,7 @@ GenericRxEbpfTx()
     GenericMp = MpOpenGeneric(If.GetIfIndex());
 
     std::vector<UCHAR> Mask(sizeof(Payload), 0xFF);
-    MpTxFilter(GenericMp, Payload, &Mask[0], sizeof(Payload));
+    auto MpFilter = MpTxFilter(GenericMp, Payload, &Mask[0], sizeof(Payload));
 
     RX_FRAME Frame;
     RxInitializeFrame(&Frame, If.GetQueueId(), Payload, sizeof(Payload));
@@ -4644,7 +4672,7 @@ GenericRxEbpfPayload()
             &RemoteHw, AF_INET6, &LocalIp, &RemoteIp, LocalPort, RemotePort));
 
     std::vector<UCHAR> Mask(UdpFrameLength, 0xFF);
-    LwfRxFilter(FnLwf, UdpFrame + Backfill, &Mask[0], UdpFrameLength);
+    auto LwfFilter = LwfRxFilter(FnLwf, UdpFrame + Backfill, &Mask[0], UdpFrameLength);
 
     RX_FRAME Frame;
     DATA_BUFFER Buffer = {0};
@@ -4747,7 +4775,7 @@ GenericRxEbpfIfIndex()
     TEST_EQUAL(0, bpf_map_update_elem(interface_map_fd, &Zero, &IfIndex, BPF_ANY));
 
     std::vector<UCHAR> Mask(sizeof(Payload), 0xFF);
-    LwfRxFilter(FnLwf, Payload, &Mask[0], sizeof(Payload));
+    auto LwfFilter = LwfRxFilter(FnLwf, Payload, &Mask[0], sizeof(Payload));
 
     RX_FRAME Frame;
     RxInitializeFrame(&Frame, If.GetQueueId(), Payload, sizeof(Payload));
@@ -4815,7 +4843,7 @@ GenericRxEbpfFragments()
     RxInitializeFrame(&Frame, FnMpIf.GetQueueId(), Buffers, RTL_NUMBER_OF(Buffers));
 
     std::vector<UCHAR> Mask(sizeof(Payload) - Backfill - Trailer, 0xFF);
-    LwfRxFilter(FnLwf, Payload + Backfill, &Mask[0], sizeof(Payload) - Backfill - Trailer);
+    auto LwfFilter = LwfRxFilter(FnLwf, Payload + Backfill, &Mask[0], sizeof(Payload) - Backfill - Trailer);
 
     TEST_HRESULT(MpRxEnqueueFrame(GenericMp, &Frame));
     MpRxFlush(GenericMp);
@@ -4907,7 +4935,7 @@ GenericTxSingleFrame()
     UINT64 Pattern = 0xA5CC7729CE99C16Aui64;
     UINT64 Mask = ~0ui64;
 
-    MpTxFilter(GenericMp, &Pattern, &Mask, sizeof(Pattern));
+    auto MpFilter = MpTxFilter(GenericMp, &Pattern, &Mask, sizeof(Pattern));
 
     UINT16 FrameOffset = 13;
     UCHAR Payload[] = "GenericTxSingleFrame";
@@ -4962,7 +4990,7 @@ GenericTxOutOfOrder()
     UINT64 Pattern = 0x2865A18EE4DB02F0ui64;
     UINT64 Mask = ~0ui64;
 
-    MpTxFilter(GenericMp, &Pattern, &Mask, sizeof(Pattern));
+    auto MpFilter = MpTxFilter(GenericMp, &Pattern, &Mask, sizeof(Pattern));
 
     UINT16 FrameOffset = 13;
     UCHAR Payload[] = "GenericTxOutOfOrder";
@@ -5027,7 +5055,7 @@ GenericTxSharing()
         UINT64 Pattern = 0xA5CC7729CE99C16Aui64 + i;
         UINT64 Mask = ~0ui64;
 
-        MpTxFilter(GenericMp, &Pattern, &Mask, sizeof(Pattern));
+        auto MpFilter = MpTxFilter(GenericMp, &Pattern, &Mask, sizeof(Pattern));
 
         UINT16 FrameOffset = 13;
         UCHAR Payload[] = "GenericTxSharing";
@@ -5083,7 +5111,7 @@ GenericTxPoke()
     UINT64 Pattern = 0x4FA3DF603CC44911ui64;
     UINT64 Mask = ~0ui64;
 
-    MpTxFilter(GenericMp, &Pattern, &Mask, sizeof(Pattern));
+    auto MpFilter = MpTxFilter(GenericMp, &Pattern, &Mask, sizeof(Pattern));
 
     UINT16 FrameOffset = 13;
     UCHAR Payload[] = "GenericTxPoke";
@@ -5971,7 +5999,7 @@ VerifyRssDatapath(
     auto DefaultLwf = LwfOpenDefault(If.GetIfIndex());
     UCHAR Pattern = 0x00;
     UCHAR Mask = 0x00;
-    LwfRxFilter(DefaultLwf, &Pattern, &Mask, sizeof(Pattern));
+    auto LwfFilter = LwfRxFilter(DefaultLwf, &Pattern, &Mask, sizeof(Pattern));
 
     IndicateOnAllActiveRssQueues(If, (UINT32)RssProcessors.size());
 

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -144,7 +144,7 @@ function Get-EbpfPackageUrl {
 }
 
 function Get-FnVersion {
-    return "0.4.1"
+    return "0.4.2"
 }
 
 function Get-FnDevKitUrl {

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -144,7 +144,7 @@ function Get-EbpfPackageUrl {
 }
 
 function Get-FnVersion {
-    return "0.4.2"
+    return "0.4.3"
 }
 
 function Get-FnDevKitUrl {


### PR DESCRIPTION
Our functional tests can bugcheck if filtered NBLs are left pending in the FNMP/FNLWF. This happens if the test fails for some reason, causing an exception to be thrown and objects destructed. If the test cases don't have their handles declared extremely carefully, then an object (like an XDP program or XSK handle) might be destructed before the FNMP/FNLWF handle, causing an infinite hang.

Use the new win-net-test API to atomically clear the FNMP/FNLWF filters and return NBLs, and return an RAII object whenever a filter gets set.

Resolves #510 

Also consumes a new bugfix for FNLWF that ensures its data path doesn't pause until all filtered RX frames are returned.