### PR TITLE
run stress tests on Windows prerelease

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        windows: [2019, 2022]
+        windows: [2019, 2022, Prerelease]
         configuration: [Release, Debug]
         platform: [x64]
     timeout-minutes: 75 # Ideally this would be only 25 min for PR runs, but GitHub Actions don't support that.


### PR DESCRIPTION
I just noticed we're not running stress tests on prerelease Windows builds - this seems to be a day-zero bug in our GitHub actions.