### PR TITLE
Reduce spinxsk variance

### DIFF
--- a/tools/spinxsk.ps1
+++ b/tools/spinxsk.ps1
@@ -110,7 +110,7 @@ $StartTime = Get-Date
 
 while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes)) {
 
-    $ThisIterationMinutes = 5
+    $ThisIterationMinutes = 10
     if ($Minutes -ne 0) {
         $TotalRemainingMinutes = [math]::max(1, [math]::ceiling($Minutes - ((Get-Date)-$StartTime).TotalMinutes))
         if ($ThisIterationMinutes -gt $TotalRemainingMinutes) {


### PR DESCRIPTION
The spinxsk tests run for 10 minutes in PRs and 60 minutes in main, and every once in a while we hit a "bad" run where the success rate is less than 1%. Other times the success rate can be as high as 15%.

Try running each iteration for twice as long (10 minutes) to let the randomized test converge to the mean.

Resolves #536 