### PR TITLE
spinxsk: ignore success threshold in final short iteration

### DIFF
--- a/tools/spinxsk.ps1
+++ b/tools/spinxsk.ps1
@@ -115,6 +115,11 @@ while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes))
         $TotalRemainingMinutes = [math]::max(1, [math]::ceiling($Minutes - ((Get-Date)-$StartTime).TotalMinutes))
         if ($ThisIterationMinutes -gt $TotalRemainingMinutes) {
             $ThisIterationMinutes = $TotalRemainingMinutes
+
+            if ($ThisIterationMinutes -ne $Minutes) {
+                Write-Verbose "Using SuccessThresholdPercent = 0 for truncated final iteration"
+                $script:SuccessThresholdPercent = 0
+            }
         }
     }
 


### PR DESCRIPTION
#539 introduced a new problem while trying to solve #536: the PR tests are running a final runt iteration of 1 minute, which is so short it is guaranteed to be noisy. Ignore the success threshold for the final iteration if it is just leftover time.