### PR TITLE
release/1.0: fix / work around pktfuzz ASAN dependency change (#413)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        windows: [Prerelease]
+        windows: [2019, 2022] # ASAN is currently buggy on Prerelease
         configuration: [Release, Debug]
         platform: [x64]
     runs-on:

--- a/test/pktfuzz/pktfuzz.vcxproj
+++ b/test/pktfuzz/pktfuzz.vcxproj
@@ -63,6 +63,12 @@
       <AdditionalDependencies>onecore.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
+  <!-- The ASAN runtime cannot be statically linked into the executable, so provide it along with the binary. -->
+  <ItemGroup>
+    <Content Include="$(VCToolsInstallDir)\bin\Hostx64\x64\clang_rt.asan_dynamic-x86_64.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <!-- The following lines configure the targets necessary for sourcelink -->
   <ItemGroup>


### PR DESCRIPTION
Port #413 to release/1.0 to close #479.

I still don't understand why fuzzing doesn't work properly on prerelease builds.