### PR TITLE
Fix direct OID completion

### DIFF
--- a/src/xdp.props
+++ b/src/xdp.props
@@ -7,7 +7,7 @@
     <!-- Project-wide properties -->
     <EbpfPackagePath>$(SolutionDir)packages\eBPF-for-Windows.0.15.1\</EbpfPackagePath>
     <WiXPackagePath>$(SolutionDir)packages\wix.3.14.1\</WiXPackagePath>
-    <FnPackagePath>$(SolutionDir)artifacts\fn\devkit-0.4.3\</FnPackagePath>
+    <FnPackagePath>$(SolutionDir)artifacts\fn\devkit-0.4.4\</FnPackagePath>
   </PropertyGroup>
   <!-- The set of (eventually?) supported configurations -->
   <ItemGroup Label="ProjectConfigurations">

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -7419,10 +7419,8 @@ OidPassthru()
     UINT32 MpInfoBufferLength;
     unique_malloc_ptr<VOID> MpInfoBuffer;
     auto DefaultLwf = LwfOpenDefault(FnMpIf.GetIfIndex());
-    auto ExclusiveMp = MpOpenAdapter(FnMpIf.GetIfIndex());
 
     TEST_NOT_NULL(DefaultLwf.get());
-    TEST_NOT_NULL(ExclusiveMp.get());
 
     //
     // Get.
@@ -7469,6 +7467,9 @@ OidPassthru()
         UINT32 LwfInfoBufferLength = OidParam->BufferSize;
         std::vector<UCHAR> LwfInfoBuffer(LwfInfoBufferLength);
         const UINT32 CompletionSize = LwfInfoBufferLength / 2;
+
+        auto ExclusiveMp = MpOpenAdapter(FnMpIf.GetIfIndex());
+        TEST_NOT_NULL(ExclusiveMp.get());
 
         MpOidFilter(ExclusiveMp, &OidParam->Key, 1);
 

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -7426,7 +7426,7 @@ OidPassthru()
     //
     InitializeOidKey(&OidKeys[0], OID_GEN_CURRENT_PACKET_FILTER, NdisRequestQueryInformation);
 
-    ULONG OriginalPacketFilter;
+    ULONG OriginalPacketFilter = 0;
     LwfInfoBufferLength = sizeof(OriginalPacketFilter);
     TEST_HRESULT(
         LwfOidSubmitRequest(DefaultLwf, OidKeys[0], &LwfInfoBufferLength, &OriginalPacketFilter));
@@ -7439,7 +7439,7 @@ OidPassthru()
     //
     // Verify synchronous OID completion, i.e. without FNMP pending the OID.
     //
-    ULONG BlockSize;
+    ULONG BlockSize = 0;
     LwfInfoBufferLength = sizeof(BlockSize);
     TEST_HRESULT(
         LwfOidSubmitRequest(DefaultLwf, OidKeys[0], &LwfInfoBufferLength, &BlockSize));
@@ -7466,7 +7466,7 @@ OidPassthru()
     //
     // Verify synchronous OID completion, i.e. without FNMP pending the OID.
     //
-    NDIS_QUIC_CONNECTION Connection;
+    NDIS_QUIC_CONNECTION Connection = {0};
     LwfInfoBufferLength = sizeof(Connection);
     TEST_HRESULT(
         LwfOidSubmitRequest(DefaultLwf, OidKeys[2], &LwfInfoBufferLength, &Connection));
@@ -7496,7 +7496,7 @@ OidPassthru()
         MpInfoBuffer = MpOidAllocateAndGetRequest(ExclusiveMp, OidKeys[Index], &MpInfoBufferLength);
         TEST_NOT_NULL(MpInfoBuffer.get());
 
-        TEST_TRUE(MpOidCompleteRequest(
+        TEST_HRESULT(MpOidCompleteRequest(
             ExclusiveMp, OidKeys[Index], STATUS_SUCCESS, &LwfInfoBuffer, CompletionSize));
 
         TEST_EQUAL(OidRequestThread.wait_for(TEST_TIMEOUT_ASYNC), std::future_status::ready);

--- a/test/functional/lib/tests.h
+++ b/test/functional/lib/tests.h
@@ -217,3 +217,6 @@ OffloadQeoRevert(
 VOID
 OffloadQeoOidFailure(
     );
+
+VOID
+OidPassthru();

--- a/test/functional/taef/tests.cpp
+++ b/test/functional/taef/tests.cpp
@@ -506,4 +506,8 @@ public:
     TEST_METHOD_PRERELEASE(OffloadQeoOidFailure) {
         ::OffloadQeoOidFailure();
     }
+
+    TEST_METHOD(OidPassthru) {
+        ::OidPassthru();
+    }
 };

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -144,7 +144,7 @@ function Get-EbpfPackageUrl {
 }
 
 function Get-FnVersion {
-    return "0.4.3"
+    return "0.4.4"
 }
 
 function Get-FnDevKitUrl {


### PR DESCRIPTION
Today, if a direct OID gets completed inline, we accidentally call the regular NDIS completion routine. This is a bug, and we should call the appropriate direct OID variant for direct OID requests.

Also add test coverage for OIDs passing through XDP unscathed.

Resolves #498 (I think).