### PR TITLE
don't run prerelease tests downlevel, part 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
     - name: Run Tests
       shell: PowerShell
       timeout-minutes: 15
-      run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Iterations ${{ env.Iters }} -Timeout ${{ env.Runtime }} -UseJitEbpf
+      run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Iterations ${{ env.Iters }} -NoPrerelease -Timeout ${{ env.Runtime }} -UseJitEbpf
     - name: Convert Logs
       if: ${{ always() }}
       timeout-minutes: 5

--- a/test/functional/taef/tests.cpp
+++ b/test/functional/taef/tests.cpp
@@ -15,10 +15,12 @@
 
 //
 // Define a test method for a feature not yet officially released.
+// Unfortunately, the vstest.console.exe runner seems unable to filter on
+// arbitrary properties, so mark prerelease as priority 1.
 //
 #define TEST_METHOD_PRERELEASE(_Name) \
     BEGIN_TEST_METHOD_ATTRIBUTE(_Name) \
-        TEST_METHOD_ATTRIBUTE(L"Prerelease", L"1") \
+        TEST_PRIORITY(1) \
     END_TEST_METHOD_ATTRIBUTE() \
     TEST_METHOD(_Name)
 

--- a/tools/functional.ps1
+++ b/tools/functional.ps1
@@ -48,7 +48,10 @@ param (
     [string]$TestBinaryPath = "",
 
     [Parameter(Mandatory = $false)]
-    [switch]$UseJitEbpf = $false
+    [switch]$UseJitEbpf = $false,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$NoPrerelease = $false
 )
 
 Set-StrictMode -Version 'Latest'
@@ -116,6 +119,9 @@ for ($i = 1; $i -le $Iterations; $i++) {
         }
         if (![string]::IsNullOrEmpty($TestCaseFilter)) {
             $TestArgs += "/TestCaseFilter:$TestCaseFilter"
+        }
+        if ($NoPrerelease) {
+            $TestArgs += "/TestCaseFilter:Priority!=1"
         }
         if ($ListTestCases) {
             $TestArgs += "/lt"


### PR DESCRIPTION
Amazingly, vstest.console.exe can't filter arbitrary attributes, and it doesn't seem to be able to pull the "supported" TestCategory attribute, either. I can't believe this is the case (I must be doing something wrong) but work around this apparent restriction by setting the priority of "prerelease" test cases to 1.

Resolves #526 