### PR TITLE
Actually require all CI jobs succeed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,7 +398,11 @@ jobs:
 
   Complete:
     name: Complete
+    if: always()
     needs: [build, functional_tests, stress_tests, pktfuzz_tests, perf_tests, downlevel_functional_tests, create_artifacts, etw]
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
-    - run: echo "CI succeeded"
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
+      with:
+        jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Require all stages actually succeed, not just finish running (or fail, skip, cancel, etc.).