### PR TITLE
Use Windows Artifact Format

### DIFF
--- a/samples/rxfilter/rxfilter.vcxproj
+++ b/samples/rxfilter/rxfilter.vcxproj
@@ -37,7 +37,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>rxfilter</TargetName>
-    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/samples/xskfwd/xskfwd.vcxproj
+++ b/samples/xskfwd/xskfwd.vcxproj
@@ -37,7 +37,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>xskfwd</TargetName>
-    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/src/bpfexport/bpfexport.vcxproj
+++ b/src/bpfexport/bpfexport.vcxproj
@@ -28,7 +28,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>xdp_bpfexport</TargetName>
-    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemGroup>
     <ResourceCompile Include="bpfexport.rc">

--- a/src/nmr/nmr.vcxproj
+++ b/src/nmr/nmr.vcxproj
@@ -40,7 +40,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>xdpnmr</TargetName>
-    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/src/pollshim/pollshim.vcxproj
+++ b/src/pollshim/pollshim.vcxproj
@@ -37,7 +37,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>pollshim</TargetName>
-    <OutDir>$(SolutionDir)build\$(Platform)_$(Configuration)\bin\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/src/rtl/rtl.vcxproj
+++ b/src/rtl/rtl.vcxproj
@@ -41,7 +41,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>xdprtl</TargetName>
-    <OutDir>$(SolutionDir)build\$(Platform)_$(Configuration)\bin\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/src/xdp.cpp.props
+++ b/src/xdp.cpp.props
@@ -13,7 +13,8 @@
   </PropertyGroup>
   <!-- Use the 'build' directory for intermediate files -->
   <PropertyGroup>
-    <IntDir>$(SolutionDir)build\$(Platform)_$(Configuration)\obj\$(ProjectName)\</IntDir>
+    <IntDir>$(SolutionDir)build\obj\$(WinPlat)$(WinConfig)\$(ProjectName)\</IntDir>
+    <OutDir>$(SolutionDir)artifacts\bin\$(WinPlat)$(WinConfig)\</OutDir>
   </PropertyGroup>
   <!-- OneBranch goop -->
   <PropertyGroup>

--- a/src/xdp.props
+++ b/src/xdp.props
@@ -28,4 +28,15 @@
       <Platform>ARM64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <!-- Configuration properties to match Windows -->
+  <PropertyGroup>
+    <WinConfig Condition="'$(Configuration)' == 'Release'">fre</WinConfig>
+    <WinConfig Condition="'$(Configuration)' == 'Debug'">chk</WinConfig>
+  </PropertyGroup>
+  <PropertyGroup>
+    <WinPlat Condition="'$(Platform)' == 'Win32'">x86</WinPlat>
+    <WinPlat Condition="'$(Platform)' == 'x64'">amd64</WinPlat>
+    <WinPlat Condition="'$(Platform)' == 'ARM64'">arm64</WinPlat>
+    <WinPlat Condition="'$(Platform)' == 'ARM64EC'">arm64ec</WinPlat>
+  </PropertyGroup>
 </Project>

--- a/src/xdp/xdp.vcxproj
+++ b/src/xdp/xdp.vcxproj
@@ -119,7 +119,6 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/src/xdpapi/xdpapi.vcxproj
+++ b/src/xdpapi/xdpapi.vcxproj
@@ -80,7 +80,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>xdpapi</TargetName>
-    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/src/xdpcfg/xdpcfg.vcxproj
+++ b/src/xdpcfg/xdpcfg.vcxproj
@@ -31,7 +31,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>xdpcfg</TargetName>
-    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/src/xdplwf/xdplwf.vcxproj
+++ b/src/xdplwf/xdplwf.vcxproj
@@ -56,7 +56,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>xdplwf</TargetName>
-    <OutDir>$(SolutionDir)build\$(Platform)_$(Configuration)\bin\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/test/bpf/bpf.vcxproj
+++ b/test/bpf/bpf.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{5de7385c-80b3-40cd-97d0-7c24dec2f95c}</ProjectGuid>
     <RootNamespace>bpf</RootNamespace>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(SolutionDir)src\xdp.cpp.default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Utility</ConfigurationType>
@@ -29,7 +29,7 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>bpf</TargetName>
-    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\bpf\</OutDir>
+    <OutDir>$(SolutionDir)artifacts\bin\$(WinPlat)$(WinConfig)\bpf\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <PreBuildEvent>

--- a/test/build_headers/ddk/c/cddkheaders.vcxproj
+++ b/test/build_headers/ddk/c/cddkheaders.vcxproj
@@ -34,7 +34,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>cddkheaders</TargetName>
-    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/test/build_headers/ddk/cpp/cppddkheaders.vcxproj
+++ b/test/build_headers/ddk/cpp/cppddkheaders.vcxproj
@@ -34,7 +34,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>cppddkheaders</TargetName>
-    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/test/build_headers/sdk/c/csdkheaders.vcxproj
+++ b/test/build_headers/sdk/c/csdkheaders.vcxproj
@@ -37,7 +37,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>csdkheaders</TargetName>
-    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/test/build_headers/sdk/cpp/cppsdkheaders.vcxproj
+++ b/test/build_headers/sdk/cpp/cppsdkheaders.vcxproj
@@ -37,7 +37,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>cppsdkheaders</TargetName>
-    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/test/common/lib/util/util.vcxproj
+++ b/test/common/lib/util/util.vcxproj
@@ -32,7 +32,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>util</TargetName>
-    <OutDir>$(SolutionDir)build\$(Platform)_$(Configuration)\bin\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/test/fakendis/fndis.vcxproj
+++ b/test/fakendis/fndis.vcxproj
@@ -47,7 +47,6 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/test/functional/lib/xdptests.vcxproj
+++ b/test/functional/lib/xdptests.vcxproj
@@ -33,7 +33,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>xdptests</TargetName>
-    <OutDir>$(SolutionDir)build\$(Platform)_$(Configuration)\bin\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <PreBuildEvent>

--- a/test/functional/taef/xdpfunctionaltests.vcxproj
+++ b/test/functional/taef/xdpfunctionaltests.vcxproj
@@ -55,7 +55,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>xdpfunctionaltests</TargetName>
-    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <PreBuildEvent>

--- a/test/pktcmd/pktcmd.vcxproj
+++ b/test/pktcmd/pktcmd.vcxproj
@@ -32,7 +32,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>pktcmd</TargetName>
-    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/test/pktfuzz/pktfuzz.vcxproj
+++ b/test/pktfuzz/pktfuzz.vcxproj
@@ -42,7 +42,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>pktfuzz</TargetName>
-    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/test/rssconfig/rssconfig.vcxproj
+++ b/test/rssconfig/rssconfig.vcxproj
@@ -32,7 +32,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>rssconfig</TargetName>
-    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/test/spinxsk/spinxsk.vcxproj
+++ b/test/spinxsk/spinxsk.vcxproj
@@ -40,7 +40,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>spinxsk</TargetName>
-    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <PreBuildEvent>

--- a/test/xdpmp/xdpmp.vcxproj
+++ b/test/xdpmp/xdpmp.vcxproj
@@ -59,7 +59,6 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <PreBuildEvent>

--- a/test/xskbench/xskbench.vcxproj
+++ b/test/xskbench/xskbench.vcxproj
@@ -40,7 +40,6 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>xskbench</TargetName>
-    <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -181,6 +181,27 @@ function Get-CoreNetCiArtifactPath {
     return "$RootDir\artifacts\corenet-ci-$Commit\vm-setup\$Name"
 }
 
+function Get-ArtifactBinPathBase {
+    param (
+        [Parameter()]
+        [string]$Config,
+        [Parameter()]
+        [string]$Arch
+    )
+
+    # Convert to Windows format
+    if (($Arch -eq "x64")) {
+        $Arch = "amd64"
+    }
+    if ($Config -eq "Debug") {
+        $Config = "chk"
+    } else {
+        $Config = "fre"
+    }
+
+    return "artifacts\bin\$($Arch)_$($Config)"
+}
+
 function Get-ArtifactBinPath {
     param (
         [Parameter()]
@@ -190,7 +211,7 @@ function Get-ArtifactBinPath {
     )
 
     $RootDir = Split-Path $PSScriptRoot -Parent
-    return "$RootDir\artifacts\bin\$($Arch)_$($Config)"
+    return "$RootDir\$(Get-ArtifactBinPathBase -Config $Config -Arch $Arch)"
 }
 
 function Get-XdpBuildVersion {

--- a/tools/create-devkit.ps1
+++ b/tools/create-devkit.ps1
@@ -18,6 +18,7 @@ $ErrorActionPreference = 'Stop'
 
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
+$ArtifactBin = Get-ArtifactBinPath -Config $Config -Arch $Platform
 
 $Name = "xdp-devkit-$Platform"
 if ($Config -eq "Debug") {
@@ -31,39 +32,39 @@ New-Item -Path $DstPath -ItemType Directory > $null
 copy docs\usage.md $DstPath
 
 New-Item -Path $DstPath\bin -ItemType Directory > $null
-copy "artifacts\bin\$($Platform)_$($Config)\pktcmd.exe" $DstPath\bin
-copy "artifacts\bin\$($Platform)_$($Config)\rxfilter.exe" $DstPath\bin
-copy "artifacts\bin\$($Platform)_$($Config)\xdpcfg.exe" $DstPath\bin
-copy "artifacts\bin\$($Platform)_$($Config)\xskbench.exe" $DstPath\bin
-copy "artifacts\bin\$($Platform)_$($Config)\xskfwd.exe" $DstPath\bin
-copy "artifacts\bin\$($Platform)_$($Config)\xdp_bpfexport.exe" $DstPath\bin
+copy "$ArtifactBin\pktcmd.exe" $DstPath\bin
+copy "$ArtifactBin\rxfilter.exe" $DstPath\bin
+copy "$ArtifactBin\xdpcfg.exe" $DstPath\bin
+copy "$ArtifactBin\xskbench.exe" $DstPath\bin
+copy "$ArtifactBin\xskfwd.exe" $DstPath\bin
+copy "$ArtifactBin\xdp_bpfexport.exe" $DstPath\bin
 
 New-Item -Path $DstPath\symbols -ItemType Directory > $null
-copy "artifacts\bin\$($Platform)_$($Config)\xdp.pdb"   $DstPath\symbols
-copy "artifacts\bin\$($Platform)_$($Config)\xdpapi.pdb" $DstPath\symbols
-copy "artifacts\bin\$($Platform)_$($Config)\pktcmd.pdb" $DstPath\symbols
-copy "artifacts\bin\$($Platform)_$($Config)\rxfilter.pdb" $DstPath\symbols
-copy "artifacts\bin\$($Platform)_$($Config)\xdpcfg.pdb" $DstPath\symbols
-copy "artifacts\bin\$($Platform)_$($Config)\xskbench.pdb" $DstPath\symbols
-copy "artifacts\bin\$($Platform)_$($Config)\xskfwd.pdb" $DstPath\symbols
-copy "artifacts\bin\$($Platform)_$($Config)\xdp_bpfexport.pdb" $DstPath\symbols
+copy "$ArtifactBin\xdp.pdb"   $DstPath\symbols
+copy "$ArtifactBin\xdpapi.pdb" $DstPath\symbols
+copy "$ArtifactBin\pktcmd.pdb" $DstPath\symbols
+copy "$ArtifactBin\rxfilter.pdb" $DstPath\symbols
+copy "$ArtifactBin\xdpcfg.pdb" $DstPath\symbols
+copy "$ArtifactBin\xskbench.pdb" $DstPath\symbols
+copy "$ArtifactBin\xskfwd.pdb" $DstPath\symbols
+copy "$ArtifactBin\xdp_bpfexport.pdb" $DstPath\symbols
 
 New-Item -Path $DstPath\include -ItemType Directory > $null
 copy -Recurse published\external\* $DstPath\include
 
 New-Item -Path $DstPath\lib -ItemType Directory > $null
-copy "artifacts\bin\$($Platform)_$($Config)\xdpapi.lib" $DstPath\lib
-copy "artifacts\bin\$($Platform)_$($Config)\xdpnmr.lib" $DstPath\lib
+copy "$ArtifactBin\xdpapi.lib" $DstPath\lib
+copy "$ArtifactBin\xdpnmr.lib" $DstPath\lib
 # Package the NMR symbols alongside its static library: consuming projects will
 # throw build exceptions if symbols are missing for statically linked code.
-copy "artifacts\bin\$($Platform)_$($Config)\xdpnmr.pdb" $DstPath\lib
+copy "$ArtifactBin\xdpnmr.pdb" $DstPath\lib
 
 $VersionString = Get-XdpBuildVersionString
 
 if (!(Is-ReleaseBuild)) {
     $VersionString += "-prerelease+" + (git.exe describe --long --always --dirty --exclude=* --abbrev=8)
 
-    copy "artifacts\bin\$($Platform)_$($Config)\CoreNetSignRoot.cer" $DstPath\bin
+    copy "$ArtifactBin\CoreNetSignRoot.cer" $DstPath\bin
 }
 
 Compress-Archive -DestinationPath "$DstPath\$Name-$VersionString.zip" -Path $DstPath\*

--- a/tools/create-runtime-kit.ps1
+++ b/tools/create-runtime-kit.ps1
@@ -21,6 +21,7 @@ $ErrorActionPreference = 'Stop'
 
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
+$ArtifactBin = Get-ArtifactBinPath -Config $Config -Arch $Platform
 
 $Name = "xdp-runtime-$Platform"
 if ($Config -eq "Debug") {
@@ -34,13 +35,13 @@ New-Item -Path $DstPath -ItemType Directory > $null
 copy docs\usage.md $DstPath
 
 New-Item -Path $DstPath\bin -ItemType Directory > $null
-copy "artifacts\bin\$($Platform)_$($Config)\CoreNetSignRoot.cer" $DstPath\bin
-copy "artifacts\bin\$($Platform)_$($Config)\xdpinstaller\xdp-for-windows.msi" $DstPath\bin
+copy "$ArtifactBin\CoreNetSignRoot.cer" $DstPath\bin
+copy "$ArtifactBin\xdpinstaller\xdp-for-windows.msi" $DstPath\bin
 
 New-Item -Path $DstPath\symbols -ItemType Directory > $null
-copy "artifacts\bin\$($Platform)_$($Config)\xdp.pdb"   $DstPath\symbols
-copy "artifacts\bin\$($Platform)_$($Config)\xdpapi.pdb" $DstPath\symbols
-copy "artifacts\bin\$($Platform)_$($Config)\xdpcfg.pdb" $DstPath\symbols
+copy "$ArtifactBin\xdp.pdb" $DstPath\symbols
+copy "$ArtifactBin\xdpapi.pdb" $DstPath\symbols
+copy "$ArtifactBin\xdpcfg.pdb" $DstPath\symbols
 
 [xml]$XdpVersion = Get-Content $RootDir\src\xdp.props
 $Major = $XdpVersion.Project.PropertyGroup.XdpMajorVersion

--- a/tools/create-test-archive.ps1
+++ b/tools/create-test-archive.ps1
@@ -22,6 +22,7 @@ $ErrorActionPreference = 'Stop'
 
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
+$ArtifactBin = Get-ArtifactBinPath -Config $Config -Arch $Platform
 
 $Name = "xdp-tests-$Platform"
 if ($Config -eq "Debug") {
@@ -33,10 +34,10 @@ Remove-Item $DstPath -Recurse -ErrorAction Ignore
 New-Item -Path $DstPath -ItemType Directory > $null
 
 New-Item -Path $DstPath\bin -ItemType Directory > $null
-copy "artifacts\bin\$($Platform)_$($Config)\xdpfunctionaltests.dll" $DstPath\bin
+copy "$ArtifactBin\xdpfunctionaltests.dll" $DstPath\bin
 
 New-Item -Path $DstPath\symbols -ItemType Directory > $null
-copy "artifacts\bin\$($Platform)_$($Config)\xdpfunctionaltests.pdb"   $DstPath\symbols
+copy "$ArtifactBin\xdpfunctionaltests.pdb" $DstPath\symbols
 
 $VersionString = Get-XdpBuildVersionString
 

--- a/tools/functional.ps1
+++ b/tools/functional.ps1
@@ -59,7 +59,8 @@ $ErrorActionPreference = 'Stop'
 
 # Important paths.
 $RootDir = Split-Path $PSScriptRoot -Parent
-$ArtifactsDir = "$RootDir\artifacts\bin\$($Arch)_$($Config)"
+. $RootDir\tools\common.ps1
+$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Arch $Arch
 $LogsDir = "$RootDir\artifacts\logs"
 $IterationFailureCount = 0
 $IterationTimeout = 0

--- a/tools/log.ps1
+++ b/tools/log.ps1
@@ -77,7 +77,7 @@ $ErrorActionPreference = 'Stop'
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
 
-$ArtifactsDir = "$RootDir\artifacts\bin\$($Arch)_$($Config)"
+$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Arch $Arch
 $TracePdb = Get-CoreNetCiArtifactPath -Name "tracepdb.exe"
 $WprpFile = "$RootDir\tools\xdptrace.wprp"
 $TmfPath = "$ArtifactsDir\tmfs"

--- a/tools/pktfuzz.ps1
+++ b/tools/pktfuzz.ps1
@@ -19,7 +19,8 @@ $ErrorActionPreference = 'Stop'
 
 # Important paths.
 $RootDir = Split-Path $PSScriptRoot -Parent
-$ArtifactsDir = "$RootDir\artifacts\bin\$($Arch)_$($Config)"
+. $RootDir\tools\common.ps1
+$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Arch $Arch
 $LogsDir = "$RootDir\artifacts\logs"
 
 # Ensure the output path exists.

--- a/tools/rxfilter.ps1
+++ b/tools/rxfilter.ps1
@@ -26,7 +26,8 @@ $ErrorActionPreference = 'Stop'
 
 # Important paths.
 $RootDir = Split-Path $PSScriptRoot -Parent
-$ArtifactsDir = "$RootDir\artifacts\bin\$($Arch)_$($Config)"
+. $RootDir\tools\common.ps1
+$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Arch $Arch
 
 . $RootDir\tools\common.ps1
 

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -63,7 +63,7 @@ $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
 
 # Important paths.
-$ArtifactsDir = "$RootDir\artifacts\bin\$($Arch)_$($Config)"
+$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Arch $Arch
 $LogsDir = "$RootDir\artifacts\logs"
 $DevCon = Get-CoreNetCiArtifactPath -Name "devcon.exe"
 $DswDevice = Get-CoreNetCiArtifactPath -Name "dswdevice.exe"

--- a/tools/sign.ps1
+++ b/tools/sign.ps1
@@ -61,7 +61,7 @@ if (!(Test-Path $Inf2CatToolPath)) { Write-Error "$Inf2CatToolPath does not exis
 
 # Artifact paths.
 $RootDir = (Split-Path $PSScriptRoot -Parent)
-$ArtifactsDir = Join-Path $RootDir "artifacts\bin\$($Arch)_$($Config)"
+$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Arch $Arch
 
 # Certificate paths.
 $CodeSignCertPath = Get-CoreNetCiArtifactPath -Name "CoreNetSignRoot.cer"

--- a/tools/spinxsk.ps1
+++ b/tools/spinxsk.ps1
@@ -92,7 +92,7 @@ $ErrorActionPreference = 'Stop'
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
 
-$ArtifactsDir = "$RootDir\artifacts\bin\$($Arch)_$($Config)"
+$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Arch $Arch
 $LogsDir = "$RootDir\artifacts\logs"
 $SpinXsk = "$ArtifactsDir\spinxsk.exe"
 $LiveKD = Get-CoreNetCiArtifactPath -Name "livekd64.exe"

--- a/tools/two-machine-perf.ps1
+++ b/tools/two-machine-perf.ps1
@@ -34,6 +34,7 @@ if ($null -eq $Session) {
 $RootDir = $pwd
 . $RootDir\tools\common.ps1
 $ArtifactBin = Get-ArtifactBinPath -Config $Config -Arch $Arch
+$ArtifactBinBase = Get-ArtifactBinPatBase -Config $Config -Arch $Arch
 
 # Find all the local and remote IP and MAC addresses.
 $RemoteAddress = [System.Net.Dns]::GetHostAddresses($Session.ComputerName)[0].IPAddressToString
@@ -72,9 +73,6 @@ $out = Invoke-Command -Session $Session -ScriptBlock {
 $RemoteInterface = $out[0]
 $RemoteMacAddress = $out[1]
 Write-Output "Remote interface: $RemoteInterface, $RemoteMacAddress"
-
-# Generate payload to send to the peer.
-$PktCmd = "artifacts\bin\$($Arch)_$($Config)\pktcmd.exe"
 
 Write-Output "`n====================SET UP====================`n"
 
@@ -162,24 +160,23 @@ Start-Sleep -Seconds 5
 # Run xskbench latency mode and forward traffic on the peer.
 Write-Output "Starting L2FWD on peer (forwarding on UDP 9999)..."
 $Job = Invoke-Command -Session $Session -ScriptBlock {
-    param ($Config, $Arch, $RemoteDir, $LocalInterface)
-    $RxFilter = "$RemoteDir\artifacts\bin\$($Arch)_$($Config)\rxfilter.exe"
+    param ($RemoteDir, $LocalInterface)
+    $RxFilter = "$RemoteDir\$using:ArtifactBinBase\rxfilter.exe"
     $RxFilterJob = & $RxFilter -IfIndex $LocalInterface -QueueId * -MatchType UdpDstPort -UdpDstPort 9999 -Action L2Fwd &
     Write-Output "Forwarding for 60 seconds"
     Start-Sleep -Seconds 60
     Stop-Job $RxFilterJob
     Receive-Job -Job $RxFilterJob -ErrorAction 'Continue'
-} -ArgumentList $Config, $Arch, $RemoteDir, $RemoteInterface -AsJob
+} -ArgumentList $RemoteDir, $RemoteInterface -AsJob
 
-$TxBytes = & $PktCmd udp $LocalMacAddress $RemoteMacAddress $LocalAddress $RemoteAddress 9999 9999 8
+$TxBytes = & $ArtifactBin\pktcmd.exe udp $LocalMacAddress $RemoteMacAddress $LocalAddress $RemoteAddress 9999 9999 8
 Write-Verbose "TX Payload: $TxBytes"
 
 for ($i = 0; $i -lt 5; $i++) {
     Start-Sleep -Seconds 1
 
     Write-Output "Run $($i+1): Running xskbench locally (sending to and receiving on UDP 9999)..."
-    $XskBench = "artifacts\bin\$($Arch)_$($Config)\xskbench.exe"
-    & $XskBench lat -i $LowestInterface -d 10 -p 9999 -t -group 1 -ca 0x1 -q -id 0 -tx_pattern $TxBytes -ring_size 1
+    & $ArtifactBin\xskbench.exe lat -i $LowestInterface -d 10 -p 9999 -t -group 1 -ca 0x1 -q -id 0 -tx_pattern $TxBytes -ring_size 1
 }
 
 Write-Output "Waiting for remote RxFilter..."
@@ -198,8 +195,7 @@ $Job = Invoke-Command -Session $Session -ScriptBlock {
 for ($i = 0; $i -lt 5; $i++) {
     Start-Sleep -Seconds 1
     Write-Output "Run $($i+1): Running xskbench locally (receiving from UDP 9999) on 1 queue..."
-    $XskBench = "artifacts\bin\$($Arch)_$($Config)\xskbench.exe"
-    & $XskBench rx -i $LowestInterface -d 10 -p 9999 -t -group 1 -ca 0x1 -q -id 0 $XskQueueParams
+    & $ArtifactBin\xskbench.exe rx -i $LowestInterface -d 10 -p 9999 -t -group 1 -ca 0x1 -q -id 0 $XskQueueParams
 }
 
 Write-Output "Configuring 8 RSS queues"
@@ -212,8 +208,7 @@ if ($LocalVfAdapter) {
 for ($i = 0; $i -lt 5; $i++) {
     Start-Sleep -Seconds 1
     Write-Output "Run $($i+1): Running xskbench locally (receiving from UDP 9999) on 8 queues..."
-    $XskBench = "artifacts\bin\$($Arch)_$($Config)\xskbench.exe"
-    & $XskBench rx -i $LowestInterface -d 10 -p 9999 -t -group 1 -ca 0x1 -q -id 0 $XskQueueParams -q -id 1 $XskQueueParams -q -id 2 $XskQueueParams -q -id 3 $XskQueueParams -q -id 4 $XskQueueParams -q -id 5 $XskQueueParams -q -id 6 $XskQueueParams -q -id 7 $XskQueueParams
+    & $ArtifactBin\xskbench.exe rx -i $LowestInterface -d 10 -p 9999 -t -group 1 -ca 0x1 -q -id 0 $XskQueueParams -q -id 1 $XskQueueParams -q -id 2 $XskQueueParams -q -id 3 $XskQueueParams -q -id 4 $XskQueueParams -q -id 5 $XskQueueParams -q -id 6 $XskQueueParams -q -id 7 $XskQueueParams
 }
 
 Write-Output "Waiting for remote wsario..."

--- a/tools/xskperf.ps1
+++ b/tools/xskperf.ps1
@@ -132,7 +132,7 @@ function Wait-NetAdapterUpStatus {
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
 
-$ArtifactsDir = "$RootDir\artifacts\bin\$($Arch)_$($Config)"
+$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Arch $Arch
 $WsaRio = Get-CoreNetCiArtifactPath -Name "wsario.exe"
 $Mode = $Mode.ToUpper()
 $Adapter = Get-NetAdapter $AdapterName


### PR DESCRIPTION
This updated XDP to use the Windows artifact directory format (i.e., arm64chk or amd64fre), which is needed for internal build alignment.

Future changes may further refactor the project files to use https://github.com/microsoft/undocked instead of manually doing parts of this.