### PR TITLE
fix ebpf struct version validation

### DIFF
--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -1648,7 +1648,7 @@ EbpfProgramOnClientAttach(
         goto Exit;
     }
 
-    if (ClientDispatch == NULL || ClientDispatch->version < 1 || ClientDispatch->count < 4) {
+    if (ClientDispatch == NULL || ClientDispatch->version != 1 || ClientDispatch->count < 4) {
         Status = STATUS_INVALID_PARAMETER;
         goto Exit;
     }

--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -1633,7 +1633,10 @@ EbpfProgramOnClientAttach(
     TraceEnter(
         TRACE_CORE, "AttachingProvider=%p AttachingClient=%p", AttachingProvider, AttachingClient);
 
-    if (ClientData == NULL || ClientData->header.size != sizeof(IfIndex) || ClientData->data == NULL) {
+    if (ClientData == NULL ||
+        ClientData->header.version != 1 ||
+        ClientData->header.size != sizeof(IfIndex) ||
+        ClientData->data == NULL) {
         Status = STATUS_INVALID_PARAMETER;
         goto Exit;
     }

--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -1634,7 +1634,7 @@ EbpfProgramOnClientAttach(
         TRACE_CORE, "AttachingProvider=%p AttachingClient=%p", AttachingProvider, AttachingClient);
 
     if (ClientData == NULL ||
-        ClientData->header.version != 1 ||
+        ClientData->header.version != 0 ||
         ClientData->header.size != sizeof(IfIndex) ||
         ClientData->data == NULL) {
         Status = STATUS_INVALID_PARAMETER;


### PR DESCRIPTION
eBPF extensions must validate the header version. Any change to the header version is a breaking change.

The use of header.size in version ~~1~~ 0 of the extension data is a bug (it should be the size of the extension data _struct_, not the optional data) but XDP must continue relying on this behavior.