### PR TITLE
sign driver packages within msbuild

### DIFF
--- a/.azure/templates/build.yml
+++ b/.azure/templates/build.yml
@@ -126,20 +126,6 @@ jobs:
         files_to_sign: '**/*.exe;**/*.dll' # Only supports usermode binaries
         search_root: 'artifacts/bin'
 
-  - task: PowerShell@2
-    displayName: Sign and Package Kernel (Debug)
-    condition: and(succeeded(), contains('${{ parameters.config }}', 'Debug'))
-    inputs:
-      filePath: tools/sign.ps1
-      arguments: -Config Debug -Arch ${{ parameters.arch }}
-
-  - task: PowerShell@2
-    displayName: Sign and Package Kernel (Release)
-    condition: and(succeeded(), contains('${{ parameters.config }}', 'Release'))
-    inputs:
-      filePath: tools/sign.ps1
-      arguments: -Config Release -Arch ${{ parameters.arch }}
-
   - task: VSBuild@1
     displayName: Build Installer (Debug)
     condition: and(succeeded(), contains('${{ parameters.config }}', 'Debug'))

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,10 +72,7 @@ jobs:
     - name: Prepare for compiling eBPF programs
       run: tools/prepare-machine.ps1 -ForEbpfBuild -Verbose
     - name: Build
-      run: msbuild xdp.sln /m /p:configuration=${{ inputs.config }} /p:platform=${{ inputs.arch }}
-    - name: Sign Binaries
-      shell: PowerShell
-      run: tools/sign.ps1 -Config ${{ inputs.config }} -Arch ${{ inputs.arch }}
+      run: msbuild xdp.sln /m /p:configuration=${{ inputs.config }} /p:platform=${{ inputs.arch }} /p:SignMode=TestSign
     - name: Build Installer
       shell: PowerShell
       run: tools/create-installer.ps1 -Config ${{ inputs.config }} -Platform ${{ inputs.arch }}

--- a/src/xdp.cpp.kernel.props
+++ b/src/xdp.cpp.kernel.props
@@ -26,9 +26,6 @@
       <AdditionalOptions>/kernel /NOOPTIDATA /pdbcompress /MERGE:.gfids=GFIDS /MERGE:.orpc=.text /MERGE:_PAGE=PAGE /MERGE:_RDATA=.rdata /MERGE:_TEXT=.text /section:GFIDS,d</AdditionalOptions>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
-    <DriverSign>
-      <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
-    </DriverSign>
   </ItemDefinitionGroup>
   <PropertyGroup>
     <InfVerif_AdditionalOptions>/msft</InfVerif_AdditionalOptions>

--- a/src/xdp.cpp.kernel.props
+++ b/src/xdp.cpp.kernel.props
@@ -26,10 +26,12 @@
       <AdditionalOptions>/kernel /NOOPTIDATA /pdbcompress /MERGE:.gfids=GFIDS /MERGE:.orpc=.text /MERGE:_PAGE=PAGE /MERGE:_RDATA=.rdata /MERGE:_TEXT=.text /section:GFIDS,d</AdditionalOptions>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
+    <DriverSign>
+      <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
+    </DriverSign>
   </ItemDefinitionGroup>
   <PropertyGroup>
     <InfVerif_AdditionalOptions>/msft</InfVerif_AdditionalOptions>
-    <SignMode>Off</SignMode>
-    <EnableInf2cat>false</EnableInf2cat>
+    <EnableInf2cat>true</EnableInf2cat>
   </PropertyGroup>
 </Project>

--- a/src/xdp.cpp.props
+++ b/src/xdp.cpp.props
@@ -46,5 +46,9 @@
     <Link>
       <CETCompat>true</CETCompat>
     </Link>
+    <!-- Driver signing is used by both driver and driver application projects -->
+    <DriverSign>
+      <FileDigestAlgorithm>SHA256</FileDigestAlgorithm>
+    </DriverSign>
   </ItemDefinitionGroup>
 </Project>

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -18,9 +18,6 @@ param (
     [switch]$NoClean = $false,
 
     [Parameter(Mandatory = $false)]
-    [switch]$NoSign = $false,
-
-    [Parameter(Mandatory = $false)]
     [switch]$NoInstaller = $false,
 
     [Parameter(Mandatory = $false)]
@@ -51,7 +48,6 @@ if ([string]::IsNullOrEmpty($Project)) {
         $Clean = ":Rebuild"
     }
     $Tasks += "$Project$Clean"
-    $NoSign = $true
     $NoInstaller = $true
 }
 
@@ -63,7 +59,8 @@ msbuild.exe $RootDir\xdp.sln `
     /p:RestorePackagesConfig=true `
     /p:RestoreConfigFile=src\nuget.config `
     /p:Configuration=$Config `
-    /p:Platform=$Platform
+    /p:Platform=$Platform `
+    /p:SignMode=TestSign
 if (!$?) {
     Write-Error "Restoring NuGet packages failed: $LastExitCode"
 }
@@ -81,10 +78,6 @@ msbuild.exe $RootDir\xdp.sln `
     /maxCpuCount
 if (!$?) {
     Write-Error "Build failed: $LastExitCode"
-}
-
-if (!$NoSign) {
-    & $RootDir\tools\sign.ps1 -Config $Config -Arch $Platform
 }
 
 if (!$NoInstaller) {

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -59,8 +59,7 @@ msbuild.exe $RootDir\xdp.sln `
     /p:RestorePackagesConfig=true `
     /p:RestoreConfigFile=src\nuget.config `
     /p:Configuration=$Config `
-    /p:Platform=$Platform `
-    /p:SignMode=TestSign
+    /p:Platform=$Platform
 if (!$?) {
     Write-Error "Restoring NuGet packages failed: $LastExitCode"
 }
@@ -74,6 +73,7 @@ nuget.exe restore $RootDir\src\xdpinstaller\xdpinstaller.sln `
 msbuild.exe $RootDir\xdp.sln `
     /p:Configuration=$Config `
     /p:Platform=$Platform `
+    /p:SignMode=TestSign `
     /t:$($Tasks -join ",") `
     /maxCpuCount
 if (!$?) {

--- a/tools/create-devkit.ps1
+++ b/tools/create-devkit.ps1
@@ -63,8 +63,6 @@ $VersionString = Get-XdpBuildVersionString
 
 if (!(Is-ReleaseBuild)) {
     $VersionString += "-prerelease+" + (git.exe describe --long --always --dirty --exclude=* --abbrev=8)
-
-    copy "$ArtifactBin\CoreNetSignRoot.cer" $DstPath\bin
 }
 
 Compress-Archive -DestinationPath "$DstPath\$Name-$VersionString.zip" -Path $DstPath\*

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -188,22 +188,6 @@ function Setup-TestSigning {
     }
 }
 
-# Installs the XDP certificates.
-function Install-Certs {
-    $CodeSignCertPath = Get-CoreNetCiArtifactPath -Name "CoreNetSignRoot.cer"
-    if (!(Test-Path $CodeSignCertPath)) {
-        Write-Error "$CodeSignCertPath does not exist!"
-    }
-    CertUtil.exe -f -addstore Root $CodeSignCertPath 2>&1 | Write-Verbose
-    CertUtil.exe -f -addstore trustedpublisher $CodeSignCertPath 2>&1 | Write-Verbose
-}
-
-# Uninstalls the XDP certificates.
-function Uninstall-Certs {
-    try { CertUtil.exe -delstore Root "CoreNetTestSigning" } catch { }
-    try { CertUtil.exe -delstore trustedpublisher "CoreNetTestSigning" } catch { }
-}
-
 function Setup-VcRuntime {
     $Installed = $false
     try { $Installed = Get-ChildItem -Path Registry::HKEY_CLASSES_ROOT\Installer\Dependencies | Where-Object { $_.Name -like "*VC,redist*" } } catch {}
@@ -243,11 +227,11 @@ function Setup-VsTest {
 
 if ($Cleanup) {
     if ($ForTest) {
-        Uninstall-Certs
+        # Tests do not fully clean up.
     }
 } else {
     if ($ForBuild) {
-        Download-CoreNet-Deps
+        # There are currently no build dependencies required.
     }
 
     if ($ForEbpfBuild) {
@@ -329,7 +313,6 @@ if ($Cleanup) {
         Download-CoreNet-Deps
         Download-Ebpf-Msi
         Setup-TestSigning
-        Install-Certs
     }
 
     if ($ForLogging) {

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -70,6 +70,7 @@ $DswDevice = Get-CoreNetCiArtifactPath -Name "dswdevice.exe"
 
 # File paths.
 $XdpInf = "$ArtifactsDir\xdp\xdp.inf"
+$XdpCert = "$ArtifactsDir\xdp.cer"
 $XdpPcwMan = "$ArtifactsDir\xdppcw.man"
 $XdpFileVersion = (Get-Item "$ArtifactsDir\xdp\xdp.sys").VersionInfo.FileVersion
 # Determine the XDP build version string from xdp.sys. The Windows file version
@@ -79,6 +80,7 @@ $XdpMsiFullPath = "$ArtifactsDir\xdpinstaller\xdp-for-windows.$XdpFileVersion.ms
 $FndisSys = "$ArtifactsDir\fndis\fndis.sys"
 $XdpMpSys = "$ArtifactsDir\xdpmp\xdpmp.sys"
 $XdpMpInf = "$ArtifactsDir\xdpmp\xdpmp.inf"
+$XdpMpCert = "$ArtifactsDir\xdpmp.cer"
 $XdpMpComponentId = "ms_xdpmp"
 $XdpMpDeviceId = "xdpmp0"
 $XdpMpServiceName = "XDPMP"
@@ -173,6 +175,13 @@ function Cleanup-Service($Name) {
     }
 }
 
+# Installs the certificates for driver package signing.
+function Install-DriverCertificate($CertFileName) {
+    Write-Verbose "Installing driver signing certificate $CertFileName"
+    Import-Certificate -FilePath $CertFileName -CertStoreLocation 'cert:\localmachine\root' | Write-Verbose
+    Import-Certificate -FilePath $CertFileName -CertStoreLocation 'cert:\localmachine\trustedpublisher' | Write-Verbose
+}
+
 # Helper to wait for an adapter to start.
 function Wait-For-Adapters($IfDesc, $Count=1, $WaitForUp=$true) {
     Write-Verbose "Waiting for $Count `"$IfDesc`" adapter(s) to start"
@@ -231,6 +240,8 @@ function Uninstall-Driver($Inf) {
 
 # Installs the xdp driver.
 function Install-Xdp {
+    Install-DriverCertificate $XdpCert
+
     if ($XdpInstaller -eq "MSI") {
         $XdpPath = Get-XdpInstallPath
 
@@ -346,6 +357,8 @@ function Install-XdpMp {
     if (!(Test-Path $XdpMpSys)) {
         Write-Error "$XdpMpSys does not exist!"
     }
+
+    Install-DriverCertificate $XdpMpCert
 
     Write-Verbose "pnputil.exe /install /add-driver $XdpMpInf"
     pnputil.exe /install /add-driver $XdpMpInf | Write-Verbose


### PR DESCRIPTION
Progress towards #585

This eliminates the dependency on the corenet test signing certificate and signs binaries using msbuild.