### PR TITLE
remove xdpnmr.pdb from nuget

### DIFF
--- a/src/nuget/xdp-for-windows.nuspec.in
+++ b/src/nuget/xdp-for-windows.nuspec.in
@@ -19,6 +19,5 @@
         <file src="{binpath}\xdpbpfexport.exe" target="build\native\bin"/>
         <file src="{binpath}\xdpapi.lib" target="build\native\lib"/>
         <file src="{binpath}\xdpnmr.lib" target="build\native\lib"/>
-        <file src="{binpath}\xdpnmr.pdb" target="build\native\symbols"/>
     </files>
 </package>


### PR DESCRIPTION
OneBranch doesn't produce xdpnmr.pdb for some reason. We don't strictly require this PDB in our nuget since Native XDP is not officially supported. Our long term plan is to replace the NMR static lib with a header-only library, so the long term path was removal anyways.