### PR TITLE
allow dev nuget to be built in independent build stage

### DIFF
--- a/src/nuget/nuget.vcxproj
+++ b/src/nuget/nuget.vcxproj
@@ -20,7 +20,7 @@
   <PropertyGroup>
     <TargetName>nuget</TargetName>
   </PropertyGroup>
-  <ItemGroup>
+ <ItemGroup Condition="'$(DevNugetProjectReferences)' != 'false'">
     <ProjectReference Include="$(SolutionDir)src\bpfexport\bpfexport.vcxproj">
       <Project>{8f8830ff-1648-4772-87ed-f5da091fc931}</Project>
       <Private>false</Private>
@@ -34,7 +34,7 @@
       <Private>false</Private>
     </ProjectReference>
   </ItemGroup>
-  <ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(NoDevNuget)' != 'true'">
     <PostBuildEvent>
       <Command>
         powershell -NonInteractive -ExecutionPolicy Unrestricted ..\..\tools\update-nuspec.ps1 -InputFile xdp-for-windows.nuspec.in -OutputFile $(IntDir)xdp-for-windows.nuspec -Arch $(Platform) -Config $(Configuration)

--- a/src/xdpinstaller/xdpinstaller.wixproj
+++ b/src/xdpinstaller/xdpinstaller.wixproj
@@ -56,7 +56,7 @@
   <Target Name="Build" />
   <Target Name="Clean" />
   <Target Name="Rebuild" />
-  <Import Project="$(WixTargetsPath)" Condition="'$(SignMode)' != 'Off'" />
+  <Import Project="$(WixTargetsPath)" Condition="'$(NoInstaller)' != 'true'" />
   <!-- prevents NU1503 -->
   <Target Name="_IsProjectRestoreSupported"
           Returns="@(_ValidProjectsForRestore)">

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -21,7 +21,16 @@ param (
     [switch]$NoSign = $false,
 
     [Parameter(Mandatory = $false)]
+    [switch]$NoInstaller = $false,
+
+    [Parameter(Mandatory = $false)]
     [switch]$NoInstallerProjectReferences = $false,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$NoDevNuget = $false,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$NoDevNugetProjectReferences = $false,
 
     [Parameter(Mandatory = $false)]
     [switch]$TestArchive = $false,
@@ -89,6 +98,9 @@ msbuild.exe $Sln `
     /p:Configuration=$Config `
     /p:Platform=$Platform `
     /p:InstallerProjectReferences=$(!$NoInstallerProjectReferences) `
+    /p:NoInstaller=$NoInstaller `
+    /p:DevNugetProjectReferences=$(!$NoDevNugetProjectReferences) `
+    /p:NoDevNuget=$NoDevNuget `
     /p:IsAdmin=$IsAdmin `
     /p:SignMode=$SignMode `
     /t:$($Tasks -join ",") `


### PR DESCRIPTION
OneBranch needs to do binary signing outside msbuild before packaging a nuget, so allow the nuget project to be built independently.