### PR TITLE
test sign installer

### DIFF
--- a/src/xdpinstaller/xdpinstaller.vcxproj
+++ b/src/xdpinstaller/xdpinstaller.vcxproj
@@ -27,10 +27,13 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <Target Name="CopyFiles" BeforeTargets="Build">
+  <Target Name="CopyBinaries" BeforeTargets="Build">
       <Copy SourceFiles="xdp-setup.ps1" DestinationFolder="$(OutDir)xdpinstaller\" />
   </Target>
-  <Target Name="SignFiles" DependsOnTargets="CopyFiles" BeforeTargets="Build" Condition="$(SignMode) != 'Off'">
+  <Target Name="SignBinaries" DependsOnTargets="CopyBinaries" BeforeTargets="Build" Condition="$(SignMode) != 'Off'">
       <Exec Command="powershell.exe /c &quot;&amp; '$(WDKBinRoot)\$(Platform)\signtool.exe' sign /sha1 ([system.security.cryptography.x509certificates.x509certificate2]::new([System.IO.File]::ReadAllBytes('$(OutDir)xdp\xdp.sys'))).Thumbprint /fd sha256  $(OutDir)xdpinstaller\xdp-setup.ps1&quot;" />
+  </Target>
+  <Target Name="SignMsi">
+      <Exec Command="powershell.exe /c &quot;&amp; '$(WDKBinRoot)\$(Platform)\signtool.exe' sign /sha1 ([system.security.cryptography.x509certificates.x509certificate2]::new([System.IO.File]::ReadAllBytes('$(OutDir)xdp\xdp.sys'))).Thumbprint /fd sha256  $(OutDir)xdpinstaller\*.msi &quot;" />
   </Target>
 </Project>

--- a/src/xdpinstaller/xdpinstaller.wixproj
+++ b/src/xdpinstaller/xdpinstaller.wixproj
@@ -53,6 +53,9 @@
   </ItemGroup>
   <Import Project="$(WixPackagePath)build\wix.props"/>
   <Import Project="$(WixTargetsPath)" />
+  <Target Name="SignMsi" Condition="'$(BuildStage)' != 'Binary' and '$(SignMode)' != 'Off'" AfterTargets="Link">
+    <MSBuild Projects="$(SolutionDir)src\xdpinstaller\xdpinstaller.vcxproj" Targets="SignMsi"/>
+  </Target>
   <!-- prevents NU1503 -->
   <Target Name="_IsProjectRestoreSupported"
           Returns="@(_ValidProjectsForRestore)">


### PR DESCRIPTION
test sign the MSI with the same cert that signed xdp.sys, so that the MSI's cert can be extracted and installed prior to installing the MSI itself.

```PowerShell
$CertFileName = 'xdp.cer'
Get-AuthenticodeSignature 'xdp.msi' | Select-Object -ExpandProperty SignerCertificate | Export-Certificate -Type CERT -FilePath $CertFileName
Import-Certificate -FilePath $CertFileName -CertStoreLocation 'cert:\localmachine\root'
Import-Certificate -FilePath $CertFileName -CertStoreLocation 'cert:\localmachine\trustedpublisher'
```