### PR TITLE
Use UndockedOfficial Parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,11 +69,11 @@ jobs:
     - name: Nuget Restore
       run: nuget.exe restore xdp.sln -ConfigFile src/nuget.config
     - name: Build Binary
-      run: msbuild xdp.sln /m  /t:onebranch /p:configuration=${{ matrix.config }} /p:platform=${{ matrix.arch }} /p:SignMode=Off /p:IsAdmin=true /p:BuildStage=Binary
+      run: msbuild xdp.sln /m  /t:onebranch /p:configuration=${{ matrix.config }} /p:platform=${{ matrix.arch }} /p:UndockedOfficial=true /p:BuildStage=Binary
     - name: Build Catalog
-      run: msbuild xdp.sln /m  /t:onebranch /p:configuration=${{ matrix.config }} /p:platform=${{ matrix.arch }} /p:SignMode=Off /p:IsAdmin=true /p:BuildStage=Catalog
+      run: msbuild xdp.sln /m  /t:onebranch /p:configuration=${{ matrix.config }} /p:platform=${{ matrix.arch }} /p:UndockedOfficial=true /p:BuildStage=Catalog
     - name: Build Package
-      run: msbuild xdp.sln /m  /t:onebranch /p:configuration=${{ matrix.config }} /p:platform=${{ matrix.arch }} /p:SignMode=Off /p:IsAdmin=true /p:BuildStage=Package
+      run: msbuild xdp.sln /m  /t:onebranch /p:configuration=${{ matrix.config }} /p:platform=${{ matrix.arch }} /p:UndockedOfficial=true /p:BuildStage=Package
     - name: Upload Artifacts
       uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b
       with:

--- a/src/xdp.cpp.kernel.props
+++ b/src/xdp.cpp.kernel.props
@@ -30,10 +30,10 @@
   <PropertyGroup>
     <InfVerif_AdditionalOptions>/msft</InfVerif_AdditionalOptions>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(SignMode)' != 'Off'">
+  <PropertyGroup Condition="'$(SignMode)' != 'Off' AND '$(UndockedOfficial)' != 'true'">
       <EnableInf2cat>true</EnableInf2cat>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(SignMode)' == 'Off'">
+  <PropertyGroup Condition="'$(SignMode)' == 'Off' OR '$(UndockedOfficial)' == 'true'">
       <EnableInf2cat>false</EnableInf2cat>
   </PropertyGroup>
 </Project>

--- a/src/xdpinstaller/xdpinstaller.vcxproj
+++ b/src/xdpinstaller/xdpinstaller.vcxproj
@@ -30,7 +30,7 @@
   <Target Name="CopyBinaries" BeforeTargets="Build">
       <Copy SourceFiles="xdp-setup.ps1" DestinationFolder="$(OutDir)xdpinstaller\" />
   </Target>
-  <Target Name="SignBinaries" DependsOnTargets="CopyBinaries" BeforeTargets="Build" Condition="$(SignMode) != 'Off'">
+  <Target Name="SignBinaries" DependsOnTargets="CopyBinaries" BeforeTargets="Build" Condition="$(SignMode) != 'Off' AND '$(UndockedOfficial)' != 'true'">
       <Exec Command="powershell.exe /c &quot;&amp; '$(WDKBinRoot)\$(Platform)\signtool.exe' sign /sha1 ([system.security.cryptography.x509certificates.x509certificate2]::new([System.IO.File]::ReadAllBytes('$(OutDir)xdp\xdp.sys'))).Thumbprint /fd sha256  $(OutDir)xdpinstaller\xdp-setup.ps1&quot;" />
   </Target>
   <Target Name="SignMsi">

--- a/src/xdpinstaller/xdpinstaller.wixproj
+++ b/src/xdpinstaller/xdpinstaller.wixproj
@@ -34,7 +34,7 @@
       <Project>{921ea48b-3d7b-4e5c-892b-6f72f0852714}</Project>
     </ProjectReference>
   </ItemGroup>
-  <PropertyGroup Condition=" '$(IsAdmin)' == 'False' ">
+  <PropertyGroup Condition=" '$(IsAdmin)' == 'False' OR '$(UndockedOfficial)' == 'true' ">
     <SuppressValidation>true</SuppressValidation>
   </PropertyGroup>
   <ItemGroup Condition="'$(BuildStage)' != 'Binary'">

--- a/src/xdpinstaller/xdpinstaller.wixproj
+++ b/src/xdpinstaller/xdpinstaller.wixproj
@@ -53,7 +53,7 @@
   </ItemGroup>
   <Import Project="$(WixPackagePath)build\wix.props"/>
   <Import Project="$(WixTargetsPath)" />
-  <Target Name="SignMsi" Condition="'$(BuildStage)' != 'Binary' and '$(SignMode)' != 'Off'" AfterTargets="Link">
+  <Target Name="SignMsi" Condition="'$(BuildStage)' != 'Binary' and '$(SignMode)' != 'Off' and '$(UndockedOfficial)' != 'true'" AfterTargets="Link">
     <MSBuild Projects="$(SolutionDir)src\xdpinstaller\xdpinstaller.vcxproj" Targets="SignMsi"/>
   </Target>
   <!-- prevents NU1503 -->


### PR DESCRIPTION
Official builds in OneBranch already pass `-p:UndockedOfficial=true`, so to simplify/eliminate any custom msbuild args that need to be passed for the builds there, we update the project files to key off this to do what is necessary for the `SignMode` and `IsAdmin` parameters.