### PR TITLE
lwf: provide tx frame count hint

### DIFF
--- a/src/xdplwf/send.c
+++ b/src/xdplwf/send.c
@@ -796,7 +796,7 @@ XdpGenericTxCreateQueue(
     TxCapabilities.OutOfOrderCompletionEnabled = TRUE;
     TxCapabilities.MaximumBufferSize = MAX_TX_BUFFER_LENGTH;
     TxCapabilities.MaximumFrameSize = Generic->Tx.Mtu;
-    TxCapabilities.TransmitFrameCountHint = TxQueue->FrameCount;
+    TxCapabilities.TransmitFrameCountHint = (UINT16)min(MAXUINT16, TxQueue->FrameCount);
     XdpTxQueueSetCapabilities(Config, &TxCapabilities);
 
     *InterfaceTxQueue = (XDP_INTERFACE_HANDLE)TxQueue;

--- a/src/xdplwf/send.c
+++ b/src/xdplwf/send.c
@@ -796,6 +796,7 @@ XdpGenericTxCreateQueue(
     TxCapabilities.OutOfOrderCompletionEnabled = TRUE;
     TxCapabilities.MaximumBufferSize = MAX_TX_BUFFER_LENGTH;
     TxCapabilities.MaximumFrameSize = Generic->Tx.Mtu;
+    TxCapabilities.TransmitFrameCountHint = TxQueue->FrameCount;
     XdpTxQueueSetCapabilities(Config, &TxCapabilities);
 
     *InterfaceTxQueue = (XDP_INTERFACE_HANDLE)TxQueue;


### PR DESCRIPTION
The LWF has a configurable TX frame limit, but we don't supply the value to XDP, which chooses the effective ring size.