### PR TITLE
always retain crash dumps

### DIFF
--- a/.azure/agents/functional.json
+++ b/.azure/agents/functional.json
@@ -23,6 +23,12 @@
             "parameters": {
                "Script": "reg.exe add HKLM`\\System`\\CurrentControlSet`\\Control`\\CrashControl /v CrashDumpEnabled /d 1 /t REG_DWORD /f; <# Enable complete system crash dumps. #>"
              }
+         },
+         {
+            "name": "windows-powershell-invokecommand",
+            "parameters": {
+               "Script": "reg.exe add HKLM`\\System`\\CurrentControlSet`\\Control`\\CrashControl /v AlwaysKeepMemoryDump /d 1 /t REG_DWORD /f; <# Always retain system crash dumps. #>"
+             }
          }
     ]
 }

--- a/.azure/agents/spinxsk.json
+++ b/.azure/agents/spinxsk.json
@@ -35,6 +35,12 @@
             "parameters": {
                "Script": "reg.exe add HKLM`\\System`\\CurrentControlSet`\\Control`\\CrashControl /v CrashDumpEnabled /d 1 /t REG_DWORD /f; <# Enable complete system crash dumps. #>"
              }
+         },
+         {
+            "name": "windows-powershell-invokecommand",
+            "parameters": {
+               "Script": "reg.exe add HKLM`\\System`\\CurrentControlSet`\\Control`\\CrashControl /v AlwaysKeepMemoryDump /d 1 /t REG_DWORD /f; <# Always retain system crash dumps. #>"
+             }
          }
     ]
 }

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -234,6 +234,13 @@ if ($Cleanup) {
             $Reboot = $true
         }
 
+        if ((Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl).AlwaysKeepMemoryDump -ne 1) {
+            # Always retain crash dumps
+            Write-Verbose "reg.exe add HKLM\System\CurrentControlSet\Control\CrashControl /v AlwaysKeepMemoryDump /d 1 /t REG_DWORD /f"
+            reg.exe add HKLM\System\CurrentControlSet\Control\CrashControl /v AlwaysKeepMemoryDump /d 1 /t REG_DWORD /f
+            $Reboot = $true
+        }
+
         Download-Fn-Runtime
         Write-Verbose "$(Get-FnRuntimeDir)/tools/prepare-machine.ps1 -ForTest -NoReboot"
         $FnResult = & "$(Get-FnRuntimeDir)/tools/prepare-machine.ps1" -ForTest -NoReboot
@@ -265,6 +272,13 @@ if ($Cleanup) {
             # Enable complete (kernel + user) system crash dumps
             Write-Verbose "reg.exe add HKLM\System\CurrentControlSet\Control\CrashControl /v CrashDumpEnabled /d 1 /t REG_DWORD /f"
             reg.exe add HKLM\System\CurrentControlSet\Control\CrashControl /v CrashDumpEnabled /d 1 /t REG_DWORD /f
+            $Reboot = $true
+        }
+
+        if ((Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl).AlwaysKeepMemoryDump -ne 1) {
+            # Always retain crash dumps
+            Write-Verbose "reg.exe add HKLM\System\CurrentControlSet\Control\CrashControl /v AlwaysKeepMemoryDump /d 1 /t REG_DWORD /f"
+            reg.exe add HKLM\System\CurrentControlSet\Control\CrashControl /v AlwaysKeepMemoryDump /d 1 /t REG_DWORD /f
             $Reboot = $true
         }
     }


### PR DESCRIPTION
By default, Windows will delete system crash dumps if the system is low on disk space. This seems to happen pretty often on my local machines, at least, and _might_ be contributing to crash dump loss in CI. Set a config knob that forces the crash dump to be retained.