### PR TITLE
remove dependency on xdp.cer

### DIFF
--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -179,8 +179,8 @@ function Install-DriverCertificate($CertFileName) {
     $Chain.Build($CertFileName) | Write-Verbose
     $Chain.ChainElements.Certificate | Select-Object -Last 1 | Export-Certificate -Type CERT -FilePath $CertRootFileName | Write-Verbose
 
-    Import-Certificate -FilePath $CertFileName -CertStoreLocation 'cert:\localmachine\root' | Write-Verbose
-    Import-Certificate -FilePath $CertFileName -CertStoreLocation 'cert:\localmachine\trustedpublisher' | Write-Verbose
+    Import-Certificate -FilePath $CertRootFileName -CertStoreLocation 'cert:\localmachine\root' | Write-Verbose
+    Import-Certificate -FilePath $CertRootFileName -CertStoreLocation 'cert:\localmachine\trustedpublisher' | Write-Verbose
 }
 
 function Install-SignedDriverCertificate($SignedFileName) {

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -181,6 +181,12 @@ function Install-DriverCertificate($CertFileName) {
 
     Import-Certificate -FilePath $CertRootFileName -CertStoreLocation 'cert:\localmachine\root' | Write-Verbose
     Import-Certificate -FilePath $CertFileName -CertStoreLocation 'cert:\localmachine\trustedpublisher' | Write-Verbose
+
+    # WS2019 and older also require the root cert be installed to trustedpublisher.
+    $OsVersion = [Environment]::OSVersion.Version
+    if ($OsVersion.Major -lt 10 -or ($OsVersion.Major -eq 10 -and $OsVersion.Build -le 17763)) {
+        Import-Certificate -FilePath $CertRootFileName -CertStoreLocation 'cert:\localmachine\trustedpublisher' | Write-Verbose
+    }
 }
 
 function Install-SignedDriverCertificate($SignedFileName) {

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -188,11 +188,12 @@ function Install-DriverCertificate($CertFileName) {
         $i = 0
 
         foreach ($Certificate in $Chain.ChainElements.Certificate) {
-            $TempFileName = "$CertFileName.tmp.$($i++).cer"
+            $TempFileName = "$CertFileName.tmp.$i.cer"
             $Certificate | Export-Certificate -Type CERT -FilePath $TempFileName | Write-Verbose
             Write-Verbose "Gratuitously importing $($Certificate.Subject) everywhere"
             Import-Certificate -FilePath $TempFileName -CertStoreLocation 'cert:\localmachine\root' | Write-Verbose
             Import-Certificate -FilePath $TempFileName -CertStoreLocation 'cert:\localmachine\trustedpublisher' | Write-Verbose
+            $i++
         }
     }
 }

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -240,10 +240,10 @@ function Uninstall-Driver($Inf) {
 
 # Installs the xdp driver.
 function Install-Xdp {
+    Install-SignedDriverCertificate $XdpSys
+
     if ($XdpInstaller -eq "MSI") {
         $XdpPath = Get-XdpInstallPath
-
-        Install-SignedDriverCertificate $XdpMsiFullPath
 
         Write-Verbose "msiexec.exe /i $XdpMsiFullPath INSTALLFOLDER=$XdpPath /quiet /l*v $LogsDir\xdpinstall.txt"
         msiexec.exe /i $XdpMsiFullPath INSTALLFOLDER=$XdpPath /quiet /l*v $LogsDir\xdpinstall.txt | Write-Verbose
@@ -252,8 +252,6 @@ function Install-Xdp {
             Write-Error "XDP MSI installation failed: $LastExitCode"
         }
     } elseif ($XdpInstaller -eq "INF") {
-        Install-SignedDriverCertificate $XdpSys
-
         Write-Verbose "netcfg.exe -v -l $XdpInf -c s -i ms_xdp"
         netcfg.exe -v -l $XdpInf -c s -i ms_xdp | Write-Verbose
         if ($LastExitCode) {

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -62,6 +62,7 @@ $DevCon = Get-CoreNetCiArtifactPath -Name "devcon.exe"
 $DswDevice = Get-CoreNetCiArtifactPath -Name "dswdevice.exe"
 
 # File paths.
+$XdpCat = "$ArtifactsDir\xdp\xdp.cat"
 $XdpInf = "$ArtifactsDir\xdp\xdp.inf"
 $XdpPcwMan = "$ArtifactsDir\xdppcw.man"
 $XdpSys = "$ArtifactsDir\xdp\xdp.sys"
@@ -240,7 +241,7 @@ function Uninstall-Driver($Inf) {
 
 # Installs the xdp driver.
 function Install-Xdp {
-    Install-SignedDriverCertificate $XdpSys
+    Install-SignedDriverCertificate $XdpCat
 
     if ($XdpInstaller -eq "MSI") {
         $XdpPath = Get-XdpInstallPath

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -180,7 +180,7 @@ function Install-DriverCertificate($CertFileName) {
     $Chain.ChainElements.Certificate | Select-Object -Last 1 | Export-Certificate -Type CERT -FilePath $CertRootFileName | Write-Verbose
 
     Import-Certificate -FilePath $CertRootFileName -CertStoreLocation 'cert:\localmachine\root' | Write-Verbose
-    Import-Certificate -FilePath $CertRootFileName -CertStoreLocation 'cert:\localmachine\trustedpublisher' | Write-Verbose
+    Import-Certificate -FilePath $CertFileName -CertStoreLocation 'cert:\localmachine\trustedpublisher' | Write-Verbose
 }
 
 function Install-SignedDriverCertificate($SignedFileName) {

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -181,21 +181,6 @@ function Install-DriverCertificate($CertFileName) {
 
     Import-Certificate -FilePath $CertRootFileName -CertStoreLocation 'cert:\localmachine\root' | Write-Verbose
     Import-Certificate -FilePath $CertFileName -CertStoreLocation 'cert:\localmachine\trustedpublisher' | Write-Verbose
-
-    # WS2019 and older also require extra certificates.
-    $OsVersion = [Environment]::OSVersion.Version
-    if ($OsVersion.Major -lt 10 -or ($OsVersion.Major -eq 10 -and $OsVersion.Build -le 17763)) {
-        $i = 0
-
-        foreach ($Certificate in $Chain.ChainElements.Certificate) {
-            $TempFileName = "$CertFileName.tmp.$i.cer"
-            $Certificate | Export-Certificate -Type CERT -FilePath $TempFileName | Write-Verbose
-            Write-Verbose "Gratuitously importing $($Certificate.Subject) everywhere"
-            Import-Certificate -FilePath $TempFileName -CertStoreLocation 'cert:\localmachine\root' | Write-Verbose
-            Import-Certificate -FilePath $TempFileName -CertStoreLocation 'cert:\localmachine\trustedpublisher' | Write-Verbose
-            $i++
-        }
-    }
 }
 
 function Install-SignedDriverCertificate($SignedFileName) {


### PR DESCRIPTION
Progress towards #585 

OneBranch doesn't produce an xdp.cer file, so we need to extract the xdp.cat signing certificate.