### PR TITLE
consume win-net-test 1.0.0 in release/1.0

### DIFF
--- a/src/xdp.props
+++ b/src/xdp.props
@@ -7,7 +7,7 @@
     <!-- Project-wide properties -->
     <EbpfPackagePath>$(SolutionDir)packages\eBPF-for-Windows.0.9.0\</EbpfPackagePath>
     <WiXPackagePath>$(SolutionDir)packages\wix.3.14.1\</WiXPackagePath>
-    <FnPackagePath>$(SolutionDir)artifacts\fn\devkit-0.4.1\</FnPackagePath>
+    <FnPackagePath>$(SolutionDir)packages\win-net-test.1.0.0\</FnPackagePath>
   </PropertyGroup>
   <!-- The set of (eventually?) supported configurations -->
   <ItemGroup Label="ProjectConfigurations">

--- a/src/xdp/packages.config
+++ b/src/xdp/packages.config
@@ -5,4 +5,5 @@
   <package id="Microsoft.SourceLink.Common" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="eBPF-for-Windows" version="0.9.0" targetFramework="native" developmentDependency="true" />
+  <package id="win-net-test" version="1.0.0" targetFramework="native" developmentDependency="true" />
 </packages>

--- a/test/functional/lib/xdptests.vcxproj
+++ b/test/functional/lib/xdptests.vcxproj
@@ -7,6 +7,7 @@
   <Import Project="$(SolutionDir)packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props" Condition="Exists('$(SolutionDir)packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props')" />
   <Import Project="$(SolutionDir)packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props')" />
   <Import Project="$(EbpfPackagePath)build\native\ebpf-for-windows.props" Condition="Exists('$(EbpfPackagePath)build\native\ebpf-for-windows.props')" />
+  <Import Project="$(FnPackagePath)build\native\win-net-test.props" Condition="Exists('$(FnPackagePath)build\native\win-net-test.props')" />
   <ItemGroup>
     <ClCompile Include="tests.cpp" />
   </ItemGroup>
@@ -49,7 +50,6 @@
         $(SolutionDir)test\functional\mp\inc;
         $(SolutionDir)submodules\net-offloads\include;
         $(SolutionDir)submodules\wil\include;
-        $(FnPackagePath)include;
         $(IntDir);
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>

--- a/test/pktcmd/pktcmd.vcxproj
+++ b/test/pktcmd/pktcmd.vcxproj
@@ -6,6 +6,7 @@
   <Import Project="$(SolutionDir)packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props" Condition="Exists('$(SolutionDir)packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props')" />
   <Import Project="$(SolutionDir)packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props" Condition="Exists('$(SolutionDir)packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props')" />
   <Import Project="$(SolutionDir)packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props')" />
+  <Import Project="$(FnPackagePath)build\native\win-net-test.props" Condition="Exists('$(FnPackagePath)build\native\win-net-test.props')" />
   <ItemGroup>
     <ClCompile Include="pktcmd.c" />
   </ItemGroup>
@@ -35,12 +36,6 @@
     <OutDir>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
-    <ClCompile>
-      <AdditionalIncludeDirectories>
-        $(FnPackagePath)include;
-        %(AdditionalIncludeDirectories)
-      </AdditionalIncludeDirectories>
-    </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <AdditionalDependencies>onecore.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/test/pktfuzz/pktfuzz.vcxproj
+++ b/test/pktfuzz/pktfuzz.vcxproj
@@ -6,6 +6,7 @@
   <Import Project="$(SolutionDir)packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props" Condition="Exists('$(SolutionDir)packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props')" />
   <Import Project="$(SolutionDir)packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props" Condition="Exists('$(SolutionDir)packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props')" />
   <Import Project="$(SolutionDir)packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props')" />
+  <Import Project="$(FnPackagePath)build\native\win-net-test.props" Condition="Exists('$(FnPackagePath)build\native\win-net-test.props')" />
   <ItemGroup>
     <ClCompile Include="$(SolutionDir)src\xdp\programinspect.c" />
     <ClCompile Include="pktfuzz.c" />
@@ -54,7 +55,6 @@
         $(SolutionDir)src\xdp;
         $(SolutionDir)src\xdppcw\inc;
         $(SolutionDir)build\$(Platform)_$(Configuration)\obj\xdppcw\;
-        $(FnPackagePath)include;
         %(AdditionalIncludeDirectories);
       </AdditionalIncludeDirectories>
     </ClCompile>

--- a/test/xdpmp/xdpmp.vcxproj
+++ b/test/xdpmp/xdpmp.vcxproj
@@ -6,6 +6,7 @@
   <Import Project="$(SolutionDir)packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props" Condition="Exists('$(SolutionDir)packages\Microsoft.SourceLink.GitHub.1.0.0\build\Microsoft.SourceLink.GitHub.props')" />
   <Import Project="$(SolutionDir)packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props" Condition="Exists('$(SolutionDir)packages\Microsoft.SourceLink.Common.1.0.0\build\Microsoft.SourceLink.Common.props')" />
   <Import Project="$(SolutionDir)packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Build.Tasks.Git.1.0.0\build\Microsoft.Build.Tasks.Git.props')" />
+  <Import Project="$(FnPackagePath)build\native\win-net-test.props" Condition="Exists('$(FnPackagePath)build\native\win-net-test.props')" />
   <ItemGroup>
     <ClCompile Include="hwring.c" />
     <ClCompile Include="miniport.c" />
@@ -72,7 +73,6 @@ wmimofck.exe -h$(IntDir)xdpmpwmi.h $(IntDir)xdpmp.bmf</Command>
         $(SolutionDir)src\rtl\inc;
         $(SolutionDir)test\fakendis\inc;
         $(IntDir);
-        $(FnPackagePath)include;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
       <PreprocessorDefinitions>

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -127,16 +127,7 @@ function Get-EbpfMsiUrl {
 }
 
 function Get-FnVersion {
-    return "0.4.1"
-}
-
-function Get-FnDevKitUrl {
-    "https://github.com/microsoft/win-net-test/releases/download/v$(Get-FnVersion)/fn-devkit-x64.zip"
-}
-
-function Get-FnDevKitDir {
-    $RootDir = Split-Path $PSScriptRoot -Parent
-    return "$RootDir/artifacts/fn/devkit-$(Get-FnVersion)"
+    return "1.0.0"
 }
 
 function Get-FnRuntimeUrl {

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -136,24 +136,6 @@ function Download-Ebpf-Msi {
     }
 }
 
-function Download-Fn-DevKit {
-    $FnDevKitUrl = Get-FnDevKitUrl
-    $FnDevKitDir = Get-FnDevKitDir
-    $FnDevKitZip = "$FnDevKitDir/devkit.zip"
-
-    if ($Force -and (Test-Path $FnDevKitDir)) {
-        Remove-Item -Recurse -Force $FnDevKitDir
-    }
-    if (!(Test-Path $FnDevKitDir)) {
-        mkdir $FnDevKitDir | Write-Verbose
-
-        Write-Verbose "Downloading Fn dev kit"
-        Invoke-WebRequest-WithRetry -Uri $FnDevKitUrl -OutFile $FnDevKitZip
-        Expand-Archive -Path $FnDevKitZip -DestinationPath $FnDevKitDir -Force
-        Remove-Item -Path $FnDevKitZip
-    }
-}
-
 function Download-Fn-Runtime {
     $FnRuntimeUrl = Get-FnRuntimeUrl
     $FnRuntimeDir = Get-FnRuntimeDir
@@ -265,7 +247,6 @@ if ($Cleanup) {
     if ($ForBuild) {
         Download-CoreNet-Deps
         Download-eBpf-Nuget
-        Download-Fn-DevKit
     }
 
     if ($ForEbpfBuild) {


### PR DESCRIPTION
We need to update the test binaries to use the same major version as the uplevel tests.