### PR TITLE
switch to dynamic linked VCRT

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,6 +10,14 @@ XDP for Windows consists of a usermode library (xdpapi.dll) and a driver (xdp.sy
 
 ### Install the Latest (1.x) Official
 
+Install [Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version) (2022)
+
+```Text
+https://aka.ms/vs/17/release/vc_redist.x64.exe
+```
+
+Install XDP
+
 ```PowerShell
 Invoke-WebRequest https://aka.ms/xdp-v1.msi -OutFile xdp.msi
 msiexec /i xdp.msi /quiet

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,14 +10,6 @@ XDP for Windows consists of a usermode library (xdpapi.dll) and a driver (xdp.sy
 
 ### Install the Latest (1.x) Official
 
-Install [Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version) (2022)
-
-```Text
-https://aka.ms/vs/17/release/vc_redist.x64.exe
-```
-
-Install XDP
-
 ```PowerShell
 Invoke-WebRequest https://aka.ms/xdp-v1.msi -OutFile xdp.msi
 msiexec /i xdp.msi /quiet

--- a/src/xdp.cpp.user.props
+++ b/src/xdp.cpp.user.props
@@ -4,12 +4,12 @@
   <!-- Statically link the CRT -->
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WholeProgramOptimization>true</WholeProgramOptimization>
     </ClCompile>
     <Link>

--- a/src/xdp.cpp.user.props
+++ b/src/xdp.cpp.user.props
@@ -9,7 +9,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WholeProgramOptimization>true</WholeProgramOptimization>
     </ClCompile>
     <Link>

--- a/test/common/lib/util/util.vcxproj
+++ b/test/common/lib/util/util.vcxproj
@@ -35,6 +35,16 @@
       </AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
+  <!-- Redistribute the debug CRT to test machines. -->
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <VCRedistVersion Condition="exists('$(VCInstallDir)Auxiliary\Build\Microsoft.VCRedistVersion.default.txt')">$([System.IO.File]::ReadAllText($(VCInstallDir)Auxiliary\Build\Microsoft.VCRedistVersion.default.txt).Trim())</VCRedistVersion>
+    <VCOutDir>$(OutDir)debugcrt\</VCOutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <PostBuildEvent>
+      <Command>xcopy "$(VCInstallDir)redist\MSVC\$(VCRedistVersion)\onecore\debug_nonredist\$(PlatformShortName)\Microsoft.VC$(PlatformToolsetVersion).DebugCRT\*.dll" "$(VCOutDir)" /D /Y &amp;&amp; xcopy "$(UniversalDebugCRT_ExecutablePath_x64)\*.dll" "$(VCOutDir)" /D /Y </Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <!-- The following lines configure the targets necessary for sourcelink -->
   <ItemGroup>

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -212,6 +212,15 @@ function Refresh-Path {
     ) -match '.' -join ';'
 }
 
+function Add-Path {
+    param (
+        [Parameter()]
+        [string]$NewPath
+    )
+    [Environment]::SetEnvironmentVariable("Path", $env:Path + ";$NewPath", "Machine")
+    Refresh-Path
+}
+
 function Collect-LiveKD {
     param (
         [Parameter()]

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -174,6 +174,11 @@ function Setup-VcRuntime {
         Invoke-WebRequest-WithRetry -Uri "https://aka.ms/vs/17/release/vc_redist.x64.exe" -OutFile "$ArtifactsDir\vc_redist.x64.exe"
         & $ArtifactsDir\vc_redist.x64.exe /install /passive | Write-Verbose
     }
+
+    # The debug CRT does not have an official redistributable, so use our own repackaged version.
+    if ($Config -eq "Debug") {
+        Add-Path -NewPath "$(Get-ArtifactBinPath -Arch $Arch -Config $Config)\test\debugcrt\"
+    }
 }
 
 function Setup-VsTest {

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -174,11 +174,6 @@ function Setup-VcRuntime {
         Invoke-WebRequest-WithRetry -Uri "https://aka.ms/vs/17/release/vc_redist.x64.exe" -OutFile "$ArtifactsDir\vc_redist.x64.exe"
         & $ArtifactsDir\vc_redist.x64.exe /install /passive | Write-Verbose
     }
-
-    # The debug CRT does not have an official redistributable, so use our own repackaged version.
-    if ($Config -eq "Debug") {
-        Add-Path -NewPath "$(Get-ArtifactBinPath -Arch $Arch -Config $Config)\test\debugcrt\"
-    }
 }
 
 function Setup-VsTest {

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -249,7 +249,8 @@ function Uninstall-Driver($Inf) {
 function Install-DebugCrt {
     # The debug CRT does not have an official redistributable, so use our own repackaged version.
     if ($Config -eq "Debug") {
-        Add-Path -NewPath "$(Get-ArtifactBinPath -Arch $Arch -Config $Config)\test\debugcrt\"
+        Write-Verbose "Installing debugcrt from $(Get-ArtifactBinPath -Arch $Arch -Config $Config)\test\debugcrt\* to $env:WINDIR\system32"
+        Copy-Item -Recurse -Force "$(Get-ArtifactBinPath -Arch $Arch -Config $Config)\test\debugcrt\*" "$env:WINDIR\system32" | Write-Verbose
     }
 }
 

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -246,9 +246,17 @@ function Uninstall-Driver($Inf) {
     }
 }
 
+function Install-DebugCrt {
+    # The debug CRT does not have an official redistributable, so use our own repackaged version.
+    if ($Config -eq "Debug") {
+        Add-Path -NewPath "$(Get-ArtifactBinPath -Arch $Arch -Config $Config)\test\debugcrt\"
+    }
+}
+
 # Installs the xdp driver.
 function Install-Xdp {
     Install-SignedDriverCertificate $XdpCat
+    Install-DebugCrt
 
     if ($XdpInstaller -eq "MSI") {
         $XdpPath = Get-XdpInstallPath


### PR DESCRIPTION
Technically a breaking change. We need to use dynamic linking to VCRT in our internal, official builds for the debug flavor, so we should use it everywhere.