### PR TITLE
replace 0xFF+ literals with macros

### DIFF
--- a/src/rtl/inc/xdprtl.h
+++ b/src/rtl/inc/xdprtl.h
@@ -66,7 +66,7 @@
 #define ntohl _byteswap_ulong
 #endif
 
-#define CONST_HTONS(_x) ((((UINT16)(_x)) >> 8 | (((UINT16)((_x) & 0xFF)) << 8)))
+#define CONST_HTONS(_x) ((((UINT16)(_x)) >> 8 | (((UINT16)((_x) & MAXUINT8)) << 8)))
 
 #ifdef KERNEL_MODE
 

--- a/src/xdplwf/offloadtask.c
+++ b/src/xdplwf/offloadtask.c
@@ -72,7 +72,7 @@ XdpOffloadChecksumNb(
             // We're at an odd offset into the logical buffer, so we need to
             // swap the bytes that XdpPartialChecksum returns.
             //
-            Checksum += (BufferChecksum >> 8) + ((BufferChecksum & 0xFF) << 8);
+            Checksum += (BufferChecksum >> 8) + ((BufferChecksum & MAXUINT8) << 8);
         }
 
         Offset += BufferLength;
@@ -90,7 +90,7 @@ XdpOffloadChecksumNb(
     //
     // Take ones-complement and replace 0 with 0xffff.
     //
-    if (Checksum != 0xffff) {
+    if (Checksum != MAXUINT16) {
         Checksum = (UINT16)~Checksum;
     }
 

--- a/src/xdplwf/recv.c
+++ b/src/xdplwf/recv.c
@@ -441,7 +441,7 @@ XdpGenericReceiveExpandFragmentBuffer(
     // the size to MAXUINT32.
     //
     FRE_ASSERT(RxQueue->FragmentBufferSize < MAXUINT32);
-    NewBufferSize = (max(RxQueue->FragmentBufferSize, 0xffff) << 1) | 1;
+    NewBufferSize = (max(RxQueue->FragmentBufferSize, MAXUINT16) << 1) | 1;
 
     NewBuffer =
         ExAllocatePoolPriorityZero(NonPagedPoolNx, NewBufferSize, POOLTAG_RECV, LowPoolPriority);

--- a/test/xskbench/xskbench.c
+++ b/test/xskbench/xskbench.c
@@ -664,7 +664,7 @@ QpcToUs64(
     // Taken from QuicTimePlatToUs64 (https://github.com/microsoft/msquic).
     //
     UINT64 High = (Qpc >> 32) * 1000000;
-    UINT64 Low = (Qpc & 0xFFFFFFFF) * 1000000;
+    UINT64 Low = (Qpc & MAXUINT32) * 1000000;
     return
         ((High / QpcFrequency) << 32) +
         ((Low + ((High % QpcFrequency) << 32)) / QpcFrequency);


### PR DESCRIPTION
Make it harder to be an F short or long in a literal by using macros instead.