### PR TITLE
don't rebuild runtime deps during package stage

### DIFF
--- a/src/onebranch/onebranch.vcxproj
+++ b/src/onebranch/onebranch.vcxproj
@@ -21,11 +21,13 @@
     </ProjectReference>
   </ItemGroup>
   <Target Name="Package" Condition="'$(BuildStage)' == 'Binary' or '$(BuildStage)' == 'Package'" AfterTargets="Build" >
-      <MSBuild Projects="$(SolutionDir)src\xdpinstaller\xdpinstaller.wixproj" Targets="Build"/>
       <MSBuild Projects="$(SolutionDir)src\xdpruntime\xdpruntime.vcxproj" Targets="Build"/>
   </Target>
   <Target Name="Catalog" Condition="'$(BuildStage)' == 'Catalog'" AfterTargets="Build" >
       <MSBuild Projects="$(SolutionDir)src\xdp\xdp.vcxproj" Targets="Inf2Cat" Properties="EnableInf2Cat=true"/>
+  </Target>
+  <Target Name="PackageMsi" Condition="'$(BuildStage)' == 'Package'" AfterTargets="Package" >
+      <MSBuild Projects="$(SolutionDir)src\xdpinstaller\xdpinstaller.wixproj" Targets="Build"/>
   </Target>
   <ItemGroup Condition="'$(BuildStage)' == 'Package'">
     <ProjectReference Include="$(SolutionDir)src\nuget\nuget.vcxproj">

--- a/src/xdppcw/xdppcw.vcxproj
+++ b/src/xdppcw/xdppcw.vcxproj
@@ -21,10 +21,8 @@
       <ResourceFileName>$(IntDir)%(Filename)counters.rc</ResourceFileName>
     </Ctrpp>
   </ItemDefinitionGroup>
-  <ItemGroup>
-    <Content Include="xdppcw.man">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   <Import Project="$(SolutionDir)src\xdp.targets" />
+  <Target Name="CopyFiles" AfterTargets="Build">
+    <Copy SourceFiles="xdppcw.man" DestinationFolder="$(OutDir)" />
+  </Target>
 </Project>

--- a/src/xdpruntime/xdpruntime.vcxproj
+++ b/src/xdpruntime/xdpruntime.vcxproj
@@ -7,7 +7,7 @@
     <UndockedUseDriverToolset>true</UndockedUseDriverToolset>
   </PropertyGroup>
   <Import Project="$(SolutionDir)src\xdp.cpp.props" />
- <ItemGroup>
+ <ItemGroup Condition="'$(BuildStage)' != 'Package'">
     <ProjectReference Include="$(SolutionDir)src\bpfexport\bpfexport.vcxproj">
       <Project>{8f8830ff-1648-4772-87ed-f5da091fc931}</Project>
     </ProjectReference>


### PR DESCRIPTION
We unintentionally started rebuilding binaries during package stage in #638 