### PR TITLE
ignore RSS OIDs for non-default port

### DIFF
--- a/src/xdplwf/offloadrss.c
+++ b/src/xdplwf/offloadrss.c
@@ -1262,7 +1262,8 @@ XdpLwfOffloadRssInspectOidRequest(
     *CompletionStatus = NDIS_STATUS_SUCCESS;
 
     if (Filter->Offload.Deactivated ||
-        Request->DATA.Oid != OID_GEN_RECEIVE_SCALE_PARAMETERS) {
+        Request->DATA.Oid != OID_GEN_RECEIVE_SCALE_PARAMETERS ||
+        Request->PortNumber != NDIS_DEFAULT_PORT_NUMBER) {
         goto Exit;
     }
 


### PR DESCRIPTION
XDP has ignored the `PortNumber` field when inspecting RSS OIDs, which has caused it to conflate the NIC and underlying VF configurations. As a start towards NIC <-> VF sanity, strictly ignore VF configurations for now.