### PR TITLE
move binaries to arch-specific directories in nugets

### DIFF
--- a/src/nuget/xdp-for-windows.nuspec.in
+++ b/src/nuget/xdp-for-windows.nuspec.in
@@ -16,8 +16,8 @@
     <files>
         <file src="xdp-for-windows.props" target="build\native"/>
         <file src="{rootpath}\published\external\**" target="build\native\include"/>
-        <file src="{binpath}\xdpbpfexport.exe" target="build\native\bin"/>
-        <file src="{binpath}\xdpapi.lib" target="build\native\lib"/>
-        <file src="{binpath}\xdpnmr.lib" target="build\native\lib"/>
+        <file src="{binpath_anyarch}\xdpbpfexport.exe" target="build\native\bin\{anyarch}"/>
+        <file src="{binpath_anyarch}\xdpapi.lib" target="build\native\lib\{anyarch}"/>
+        <file src="{binpath_anyarch}\xdpnmr.lib" target="build\native\lib\{anyarch}"/>
     </files>
 </package>

--- a/src/nuget/xdp-for-windows.props
+++ b/src/nuget/xdp-for-windows.props
@@ -2,8 +2,9 @@
 <!-- Copyright (c) Microsoft Corporation -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0">
   <PropertyGroup>
+    <XdpBinPath>$(MSBuildThisFileDirectory)bin\$(Platform)</XdpBinPath>
     <XdpIncludePath>$(MSBuildThisFileDirectory)include</XdpIncludePath>
-    <XdpLibraryPath>$(MSBuildThisFileDirectory)lib</XdpLibraryPath>
+    <XdpLibraryPath>$(MSBuildThisFileDirectory)lib\$(Platform)</XdpLibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/src/xdpruntime/xdp-for-windows-runtime.nuspec.in
+++ b/src/xdpruntime/xdp-for-windows-runtime.nuspec.in
@@ -14,18 +14,18 @@
         <repository type="git" url="https://github.com/microsoft/xdp" commit="{commit}" />
     </metadata>
     <files>
-        <file src="{binpath}\xdp-setup.ps1" target="runtime\native"/>
-        <file src="{binpath}\xdpbpfexport.exe" target="runtime\native"/>
-        <file src="{binpath}\xdpbpfexport.pdb" target="runtime\native"/>
-        <file src="{binpath}\xdpcfg.exe" target="runtime\native"/>
-        <file src="{binpath}\xdpcfg.pdb" target="runtime\native"/>
-        <file src="{binpath}\xdppcw.man" target="runtime\native"/>
-        <file src="{binpath}\xdp\xdp.cat" target="runtime\native"/>
-        <file src="{binpath}\xdp\xdp.inf" target="runtime\native"/>
-        <file src="{binpath}\xdp\xdp.sys" target="runtime\native"/>
-        <file src="{binpath}\xdp.pdb" target="runtime\native"/>
-        <file src="{binpath}\xdp\xdpapi.dll" target="runtime\native"/>
-        <file src="{binpath}\xdpapi.pdb" target="runtime\native"/>
+        <file src="{binpath_anyarch}\xdp-setup.ps1" target="runtime\native\{anyarch}"/>
+        <file src="{binpath_anyarch}\xdpbpfexport.exe" target="runtime\native\{anyarch}"/>
+        <file src="{binpath_anyarch}\xdpbpfexport.pdb" target="runtime\native\{anyarch}"/>
+        <file src="{binpath_anyarch}\xdpcfg.exe" target="runtime\native\{anyarch}"/>
+        <file src="{binpath_anyarch}\xdpcfg.pdb" target="runtime\native\{anyarch}"/>
+        <file src="{binpath_anyarch}\xdppcw.man" target="runtime\native\{anyarch}"/>
+        <file src="{binpath_anyarch}\xdp\xdp.cat" target="runtime\native\{anyarch}"/>
+        <file src="{binpath_anyarch}\xdp\xdp.inf" target="runtime\native\{anyarch}"/>
+        <file src="{binpath_anyarch}\xdp\xdp.sys" target="runtime\native\{anyarch}"/>
+        <file src="{binpath_anyarch}\xdp.pdb" target="runtime\native\{anyarch}"/>
+        <file src="{binpath_anyarch}\xdp\xdpapi.dll" target="runtime\native\{anyarch}"/>
+        <file src="{binpath_anyarch}\xdpapi.pdb" target="runtime\native\{anyarch}"/>
         <file src="{rootpath}\tools\xdptrace.wprp" target="runtime\native"/>
     </files>
 </package>

--- a/src/xdpruntime/xdp-setup.ps1
+++ b/src/xdpruntime/xdp-setup.ps1
@@ -9,6 +9,10 @@ This script installs or uninstalls various XDP components.
 .PARAMETER Uninstall
     Attempts to uninstall all XDP components.
 
+.PARAMETER BinaryDirectory
+    Overrides the binary directory. The default directory is this script's
+    directory.
+
 #>
 
 param (
@@ -19,13 +23,20 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("", "xdp", "xdpebpf")]
-    [string]$Uninstall = ""
+    [string]$Uninstall = "",
+
+    [Parameter(Mandatory = $false)]
+    [string]$BinaryDirectory = ""
 )
 
 Set-StrictMode -Version 'Latest'
 $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
 
-$InstallDir = $PSScriptRoot
+if ([string]::IsNullOrWhitespace($BinaryDirectory)) {
+    $script:InstallDir = $PSScriptRoot
+} else {
+    $script:InstallDir = $BinaryDirectory
+}
 
 # Global paths.
 $XdpInf = "$InstallDir\xdp.inf"

--- a/tools/update-nuspec.ps1
+++ b/tools/update-nuspec.ps1
@@ -15,5 +15,6 @@ $content = Get-Content $InputFile
 $content = $content.Replace("{commit}", $Commit)
 $content = $content.Replace("{version}", $VersionString)
 $content = $content.Replace("{rootpath}", $RootDir)
-$content = $content.Replace("{binpath}", $(Get-ArtifactBinPath -Arch $Arch -Config $Config))
+$content = $content.Replace("{anyarch}", $Arch)
+$content = $content.Replace("{binpath_anyarch}", $(Get-ArtifactBinPath -Arch $Arch -Config $Config))
 set-content $OutputFile $content


### PR DESCRIPTION
## Description

Partially solves #674 by moving architecture-specific binaries to architecture-specific directories in nugets. Since x64 is the only arch we currently build for, this does not actually merge multiple architectures into one nuget.

## Testing

Compiles locally.

## Documentation

This is a breaking change to the file structure of our nuget packages. As of yet, no nuget packages have been included in an official and supported release.

## Installation

This does not change the MSI, which is architecture-specific.
