### PR TITLE
clean up warning for no logs uploaded in fuzz tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,7 @@ jobs:
       with:
         name: logs_pktfuzz_win${{ matrix.windows }}_${{ matrix.configuration }}_${{ matrix.platform }}
         path: artifacts/logs
+        if-no-files-found: ignore
 
   perf_tests:
     name: Perf Tests


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._
Our CI has 2 warnings in GitHub because the fuzz tests do not create logs on pass. Suppress the warning since this is expected behavior.

## Testing

_Do any existing tests cover this change? Are new tests needed?_
CI.

## Documentation

_Is there any documentation impact for this change?_
N/A.

## Installation

_Is there any installer impact for this change?_
N/A.