### PR TITLE
remove JIT relic

### DIFF
--- a/tools/functional.ps1
+++ b/tools/functional.ps1
@@ -89,7 +89,7 @@ for ($i = 1; $i -le $Iterations; $i++) {
 
         if (!$EbpfPreinstalled) {
             Write-Verbose "installing ebpf..."
-            & "$RootDir\tools\setup.ps1" -Install ebpf -Config $Config -Arch $Arch -UseJitEbpf:$UseJitEbpf
+            & "$RootDir\tools\setup.ps1" -Install ebpf -Config $Config -Arch $Arch
             Write-Verbose "installed ebpf."
         }
 


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

A JIT workaround was made redundant by a previous PR (#584) but failed to clean up a dead variable. Powershell 7 notices this and errors out. Resolves #681 

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI, verified locally.

## Documentation

_Is there any documentation impact for this change?_

N/A.

## Installation

_Is there any installer impact for this change?_

N/A.
