### PR TITLE
upgrade to wix 5

### DIFF
--- a/src/xdp.props
+++ b/src/xdp.props
@@ -6,7 +6,6 @@
     <XdpPatchVersion>0</XdpPatchVersion>
     <!-- Project-wide properties -->
     <EbpfPackagePath>$(SolutionDir)packages\eBPF-for-Windows.0.18.0\</EbpfPackagePath>
-    <WiXPackagePath>$(SolutionDir)packages\wix.3.14.1\</WiXPackagePath>
     <WntPackagePath>$(SolutionDir)packages\win-net-test.1.1.0\</WntPackagePath>
     <!-- Undocked project properties -->
     <UndockedDir>$(SolutionDir)submodules\cxplat\submodules\undocked\</UndockedDir>

--- a/src/xdp/packages.config
+++ b/src/xdp/packages.config
@@ -6,5 +6,4 @@
   <package id="Microsoft.SourceLink.AzureRepos.Git" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="native" developmentDependency="true" />
-  <package id="WiX" version="3.14.1" />
 </packages>

--- a/src/xdpinstaller/product.wxs
+++ b/src/xdpinstaller/product.wxs
@@ -1,27 +1,24 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+﻿<!--
 Copyright (c) Microsoft Corporation
 SPDX-License-Identifier: MIT
 -->
 <?define ProductVersion="{9363C0E3-4DE9-4067-9F5E-6A1A06034B59}"?>
 <?define UpgradeCode="{79F93392-843E-4B85-824B-2CFC7D16F080}"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:ui="http://schemas.microsoft.com/wix/UIExtension" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-    <Product Id="$(var.ProductVersion)" Name="XDP for Windows" Language="1033" Version="$(var.XdpMajorVersion).$(var.XdpMinorVersion).$(var.XdpPatchVersion)" Manufacturer="Microsoft" UpgradeCode="$(var.UpgradeCode)">
-        <Package Description="XDP for Windows" InstallerVersion="301" Compressed="yes" InstallScope="perMachine" Manufacturer="Microsoft" Platform="x64" />
-        <MajorUpgrade AllowSameVersionUpgrades="no"
-                      Disallow="yes" DisallowUpgradeErrorMessage="An older version of [ProductName] is already installed. Please remove it first."
-                      AllowDowngrades="no" DowngradeErrorMessage="A newer version of [ProductName] is already installed. Please remove it first." Schedule="afterInstallFinalize" />
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui" xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
+    <Package Name="XDP for Windows" Language="1033" Version="$(var.XdpMajorVersion).$(var.XdpMinorVersion).$(var.XdpPatchVersion)" Manufacturer="Microsoft" UpgradeCode="$(var.UpgradeCode)" InstallerVersion="301" ProductCode="$(var.ProductVersion)">
+        <SummaryInformation Description="XDP for Windows" Manufacturer="Microsoft" />
+        <MajorUpgrade AllowSameVersionUpgrades="no" Disallow="yes" DisallowUpgradeErrorMessage="An older version of [ProductName] is already installed. Please remove it first." AllowDowngrades="no" DowngradeErrorMessage="A newer version of [ProductName] is already installed. Please remove it first." Schedule="afterInstallFinalize" />
         <MediaTemplate EmbedCab="yes" />
 
         <!-- Define global properties -->
-        <PropertyRef Id="WIX_ACCOUNT_LOCALSERVICE" />
+        <util:QueryWindowsWellKnownSIDs />
         <Property Id="ARPCONTACT" Value="opencode@microsoft.com" />
         <Property Id="INSTALLFOLDER" Secure="yes">
-            <RegistrySearch Id="FindInstallLocation" Root="HKLM" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[WIX_UPGRADE_DETECTED]" Name="InstallLocation" Type="raw" Win64="yes" />
+            <RegistrySearch Id="FindInstallLocation" Root="HKLM" Key="Software\Microsoft\Windows\CurrentVersion\Uninstall\[WIX_UPGRADE_DETECTED]" Name="InstallLocation" Type="raw" Bitness="always64" />
         </Property>
 
         <!-- Define the Product features and installation steps -->
-        <Feature Id="ProductFeature" Title="XDP for Windows Installer" ConfigurableDirectory="INSTALLFOLDER" Display="expand" Level="1" Absent="disallow" AllowAdvertise="no" InstallDefault="local" TypicalDefault="install" >
+        <Feature Id="ProductFeature" Title="XDP for Windows Installer" ConfigurableDirectory="INSTALLFOLDER" Display="expand" Level="1" AllowAdvertise="no" InstallDefault="local" TypicalDefault="install" AllowAbsent="no">
             <ComponentGroupRef Id="xdp" />
             <Feature Id="xdp_ebpf" Level="10" AllowAdvertise="no" Title="XDP eBPF" Description="Experimental eBPF support. NOT officially supported.">
                 <ComponentGroupRef Id="xdp_ebpf" />
@@ -30,47 +27,45 @@ SPDX-License-Identifier: MIT
 
         <InstallExecuteSequence>
             <!--Rollback sequence-->
-            <Custom Action="xdp_uninstall_rollback" Before="xdp_install">NOT Installed</Custom>
-            <Custom Action="xdp_ebpf_uninstall_rollback" Before="xdp_ebpf_install">NOT Installed</Custom>
+            <Custom Action="xdp_uninstall_rollback" Before="xdp_install" Condition="NOT Installed" />
+            <Custom Action="xdp_ebpf_uninstall_rollback" Before="xdp_ebpf_install" Condition="NOT Installed" />
 
             <!--Install sequence-->
-            <Custom Action="xdp_install" After="InstallFiles">NOT Installed</Custom>
-            <Custom Action="xdp_ebpf_install" After="xdp_install">(&amp;xdp_ebpf=3) AND NOT(!xdp_ebpf=3) </Custom>
+            <Custom Action="xdp_install" After="InstallFiles" Condition="NOT Installed" />
+            <Custom Action="xdp_ebpf_install" After="xdp_install" Condition="(&amp;xdp_ebpf=3) AND NOT(!xdp_ebpf=3)" />
 
             <!--Uninstall sequence-->
-            <Custom Action="xdp_ebpf_uninstall" After="InstallInitialize">(&amp;xdp_ebpf=2) AND (!xdp_ebpf=3)</Custom>
-            <Custom Action="xdp_uninstall" After="xdp_ebpf_uninstall">REMOVE="ALL"</Custom>
+            <Custom Action="xdp_ebpf_uninstall" After="InstallInitialize" Condition="(&amp;xdp_ebpf=2) AND (!xdp_ebpf=3)" />
+            <Custom Action="xdp_uninstall" After="xdp_ebpf_uninstall" Condition="REMOVE=&quot;ALL&quot;" />
         </InstallExecuteSequence>
 
         <!-- Define the UI style & behavior -->
-        <UIRef Id="WixUI_FeatureTree" />
+        <ui:WixUI Id="WixUI_FeatureTree" />
         <WixVariable Id="WixUILicenseRtf" Value="$(var.ProjectDir)license.rtf" />
         <CustomAction Id="SetWixInstallLocation" Property="ARPINSTALLLOCATION" Value="[INSTALLFOLDER]" />
         <InstallUISequence>
             <Custom Action="SetWixInstallLocation" After="CostFinalize" />
         </InstallUISequence>
-    </Product>
+    </Package>
 
     <!-- Define installation directories -->
     <Fragment>
-        <Directory Id="TARGETDIR" Name="SourceDir">
-            <Directory Id="ProgramFiles64Folder">
+            <StandardDirectory Id="ProgramFiles64Folder">
                 <Directory Id="INSTALLFOLDER" Name="xdp" />
-            </Directory>
-        </Directory>
-    </Fragment>
+            </StandardDirectory>
+        </Fragment>
 
     <!-- Define the product components -->
     <Fragment>
         <ComponentGroup Id="xdp" Directory="INSTALLFOLDER">
-            <Component Id ="xdpPATH" Guid="{0445C769-0841-4FD9-939F-C2E7F514E61A}" KeyPath="yes">
+            <Component Id="xdpPATH" Guid="{0445C769-0841-4FD9-939F-C2E7F514E61A}" KeyPath="yes">
                 <Environment Id="xdpPATH" Name="PATH" Value="[INSTALLFOLDER]" Permanent="no" Part="last" Action="set" System="yes" Separator=";" />
             </Component>
-            <Component Id="xdp_setup" Guid="{0D991B56-5C01-4E57-AB33-E81696B73D55}" Location="local" >
-                <File Id="xdp_setup_ps1" Source="$(var.TargetDir)xdp-setup.ps1" KeyPath="yes"/>
+            <Component Id="xdp_setup" Guid="{0D991B56-5C01-4E57-AB33-E81696B73D55}" Location="local">
+                <File Id="xdp_setup_ps1" Source="$(var.TargetDir)xdp-setup.ps1" KeyPath="yes" />
             </Component>
             <Component Id="xdppcw.man" Guid="{EDD336F3-5350-4046-AF01-C76B10A3B965}">
-                <File Id="xdppcw.man" Source="$(var.TargetDir)xdppcw.man" KeyPath="yes"/>
+                <File Id="xdppcw.man" Source="$(var.TargetDir)xdppcw.man" KeyPath="yes" />
             </Component>
             <Component Id="xdpapi.dll" Guid="{18A0B4FC-9F22-4E15-8AD2-64131E6E238B}">
                 <File Id="xdpapi.dll" Name="xdpapi.dll" Source="$(var.TargetDir)xdp\xdpapi.dll" KeyPath="yes" />
@@ -91,13 +86,13 @@ SPDX-License-Identifier: MIT
                 <File Id="xdp.pdb" Name="xdp.pdb" Source="$(var.TargetDir)xdp.pdb" KeyPath="yes" />
             </Component>
             <Component Id="xdp.inf" Guid="{70A53BC2-8D56-4D53-B8FA-F07EC3D4783A}">
-                <File Id="xdp.inf" Name="xdp.inf" Source="$(var.TargetDir)xdp\xdp.inf" KeyPath="yes"/>
+                <File Id="xdp.inf" Name="xdp.inf" Source="$(var.TargetDir)xdp\xdp.inf" KeyPath="yes" />
             </Component>
             <Component Id="xdp.cat" Guid="{4DE38C65-E47E-41A6-913D-3AFFE4FA5DE6}">
-                <File Id="xdp.cat" Name="xdp.cat" Source="$(var.TargetDir)xdp\xdp.cat" KeyPath="yes"/>
+                <File Id="xdp.cat" Name="xdp.cat" Source="$(var.TargetDir)xdp\xdp.cat" KeyPath="yes" />
             </Component>
             <Component Id="xdptrace.wprp" Guid="{1C280B10-A3CC-4C2D-B0D1-3F4CBE03BEAF}">
-                <File Id="xdptrace.wprp" Name="xdptrace.wprp" Source="$(var.SolutionDir)\tools\xdptrace.wprp" KeyPath="yes"/>
+                <File Id="xdptrace.wprp" Name="xdptrace.wprp" Source="$(var.SolutionDir)\tools\xdptrace.wprp" KeyPath="yes" />
             </Component>
         </ComponentGroup>
 
@@ -111,23 +106,23 @@ SPDX-License-Identifier: MIT
         </ComponentGroup>
 
         <!-- Install/Uninstall/Rollback the XDP driver installation -->
-        <SetProperty Id="xdp_install" Value="&quot;[System64Folder]WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass &quot;&amp; '[#xdp_setup_ps1]' -Install xdp -Verbose&quot;" Before="xdp_install" Sequence="execute"/>
-        <CustomAction Id="xdp_install" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Return="check" Impersonate="no"/>
+        <SetProperty Id="xdp_install" Value="&quot;[System64Folder]WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass &quot;&amp; '[#xdp_setup_ps1]' -Install xdp -Verbose&quot;" Before="xdp_install" Sequence="execute" />
+        <CustomAction Id="xdp_install" DllEntry="WixQuietExec64" Execute="deferred" Return="check" Impersonate="no" BinaryRef="Wix4UtilCA_X86" />
 
-        <SetProperty Id="xdp_uninstall" Value="&quot;[System64Folder]WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass &quot;&amp; '[#xdp_setup_ps1]' -Uninstall xdp -Verbose&quot;" Before="xdp_uninstall" Sequence="execute"/>
-        <CustomAction Id="xdp_uninstall" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Return="ignore" Impersonate="no"/>
+        <SetProperty Id="xdp_uninstall" Value="&quot;[System64Folder]WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass &quot;&amp; '[#xdp_setup_ps1]' -Uninstall xdp -Verbose&quot;" Before="xdp_uninstall" Sequence="execute" />
+        <CustomAction Id="xdp_uninstall" DllEntry="WixQuietExec64" Execute="deferred" Return="ignore" Impersonate="no" BinaryRef="Wix4UtilCA_X86" />
 
-        <SetProperty Id="xdp_uninstall_rollback" Value="&quot;[System64Folder]WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass &quot;&amp; '[#xdp_setup_ps1]' -Uninstall xdp -Verbose&quot;" Before="xdp_uninstall_rollback" Sequence="execute"/>
-        <CustomAction Id="xdp_uninstall_rollback" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="rollback" Return="ignore" Impersonate="no"/>
+        <SetProperty Id="xdp_uninstall_rollback" Value="&quot;[System64Folder]WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass &quot;&amp; '[#xdp_setup_ps1]' -Uninstall xdp -Verbose&quot;" Before="xdp_uninstall_rollback" Sequence="execute" />
+        <CustomAction Id="xdp_uninstall_rollback" DllEntry="WixQuietExec64" Execute="rollback" Return="ignore" Impersonate="no" BinaryRef="Wix4UtilCA_X86" />
 
         <!-- Install/Uninstall/Rollback the XDP eBPF installation -->
-        <SetProperty Id="xdp_ebpf_install" Value="&quot;[System64Folder]WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass &quot;&amp; '[#xdp_setup_ps1]' -Install xdpebpf -Verbose&quot;" Before="xdp_ebpf_install" Sequence="execute"/>
-        <CustomAction Id="xdp_ebpf_install" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Return="check" Impersonate="no"/>
+        <SetProperty Id="xdp_ebpf_install" Value="&quot;[System64Folder]WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass &quot;&amp; '[#xdp_setup_ps1]' -Install xdpebpf -Verbose&quot;" Before="xdp_ebpf_install" Sequence="execute" />
+        <CustomAction Id="xdp_ebpf_install" DllEntry="WixQuietExec64" Execute="deferred" Return="check" Impersonate="no" BinaryRef="Wix4UtilCA_X86" />
 
-        <SetProperty Id="xdp_ebpf_uninstall" Value="&quot;[System64Folder]WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass &quot;&amp; '[#xdp_setup_ps1]' -Uninstall xdpebpf -Verbose&quot;" Before="xdp_ebpf_uninstall" Sequence="execute"/>
-        <CustomAction Id="xdp_ebpf_uninstall" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Return="ignore" Impersonate="no"/>
+        <SetProperty Id="xdp_ebpf_uninstall" Value="&quot;[System64Folder]WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass &quot;&amp; '[#xdp_setup_ps1]' -Uninstall xdpebpf -Verbose&quot;" Before="xdp_ebpf_uninstall" Sequence="execute" />
+        <CustomAction Id="xdp_ebpf_uninstall" DllEntry="WixQuietExec64" Execute="deferred" Return="ignore" Impersonate="no" BinaryRef="Wix4UtilCA_X86" />
 
-        <SetProperty Id="xdp_ebpf_uninstall_rollback" Value="&quot;[System64Folder]WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass &quot;&amp; '[#xdp_setup_ps1]' -Uninstall xdpebpf -Verbose&quot;" Before="xdp_ebpf_uninstall_rollback" Sequence="execute"/>
-        <CustomAction Id="xdp_ebpf_uninstall_rollback" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="rollback" Return="ignore" Impersonate="no"/>
+        <SetProperty Id="xdp_ebpf_uninstall_rollback" Value="&quot;[System64Folder]WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass &quot;&amp; '[#xdp_setup_ps1]' -Uninstall xdpebpf -Verbose&quot;" Before="xdp_ebpf_uninstall_rollback" Sequence="execute" />
+        <CustomAction Id="xdp_ebpf_uninstall_rollback" DllEntry="WixQuietExec64" Execute="rollback" Return="ignore" Impersonate="no" BinaryRef="Wix4UtilCA_X86" />
     </Fragment>
 </Wix>

--- a/src/xdpinstaller/xdpinstaller.vcxproj
+++ b/src/xdpinstaller/xdpinstaller.vcxproj
@@ -17,4 +17,9 @@
   <Target Name="SignMsi">
       <Exec Command="powershell.exe /c &quot;&amp; '$(WDKBinRoot)\$(Platform)\signtool.exe' sign /sha1 ([system.security.cryptography.x509certificates.x509certificate2]::new([System.IO.File]::ReadAllBytes('$(OutDir)xdp\xdp.sys'))).Thumbprint /fd sha256  $(OutDir)*.msi &quot;" />
   </Target>
+  <!-- Allow wixproj to take a project reference on this file without chasing non-existent NuGet packages. -->
+  <Target Name="ResolveNuGetPackageAssets"
+          DependsOnTargets="$(ResolveNuGetPackageAssetsDependsOn)"
+          Condition="'$(ResolveNuGetPackages)' == 'true' and exists('$(ProjectLockFile)')">
+  </Target>
 </Project>

--- a/src/xdpinstaller/xdpinstaller.wixproj
+++ b/src/xdpinstaller/xdpinstaller.wixproj
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{93635a7b-565e-4b41-af67-5b375756b227}</ProjectGuid>
     <ImportUndocked>false</ImportUndocked>
+    <WixVer>5.0.1</WixVer>
   </PropertyGroup>
   <Import Project="$(SolutionDir)src\xdp.props" />
   <PropertyGroup>
-    <ProductVersion>3.10</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <OutputName>xdp-for-windows.$(XdpMajorVersion).$(XdpMinorVersion).$(XdpPatchVersion)</OutputName>
     <OutputType>Package</OutputType>
     <OutputPath>$(SolutionDir)artifacts\bin\$(Platform)_$(Configuration)\</OutputPath>
     <IntermediateOutputPath>$(SolutionDir)artifacts\obj\$(Platform)_$(Configuration)\$(OutputName)\</IntermediateOutputPath>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <DefineConstants>
       XdpMajorVersion=$(XdpMajorVersion);
       XdpMinorVersion=$(XdpMinorVersion);
@@ -20,7 +20,7 @@
       $(DefineConstants)
     </DefineConstants>
   </PropertyGroup>
- <ItemGroup Condition="'$(BuildStage)' != 'Package'">
+  <ItemGroup Condition="'$(BuildStage)' != 'Package'">
     <ProjectReference Include="$(SolutionDir)src\xdpinstaller\xdpinstaller.vcxproj">
       <Project>{921ea48b-3d7b-4e5c-892b-6f72f0852714}</Project>
     </ProjectReference>
@@ -28,34 +28,20 @@
   <PropertyGroup Condition=" '$(IsAdmin)' == 'False' ">
     <SuppressValidation>true</SuppressValidation>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(BuildStage)' == 'Binary'">
+    <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
+    <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+  </PropertyGroup>
   <ItemGroup Condition="'$(BuildStage)' != 'Binary'">
     <Compile Include="product.wxs" />
   </ItemGroup>
   <ItemGroup>
-    <WixExtension Include="WixUtilExtension">
-      <Name>WixUtilExtension</Name>
-    </WixExtension>
-    <WixExtension Include="WixUIExtension">
-      <Name>WixUIExtension</Name>
-    </WixExtension>
+    <PackageReference Include="WixToolset.UI.wixext" Version="$(WixVer)" />
+    <PackageReference Include="WixToolset.Util.wixext" Version="$(WixVer)" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="$(SolutionDir)src\xdp\packages.config" />
-  </ItemGroup>
-  <Import Project="$(WixPackagePath)build\wix.props"/>
-  <Import Project="$(WixTargetsPath)" />
+  <Import Project="Sdk.props" Sdk="WixToolset.Sdk" Version="$(WixVer)" />
+  <Import Project="Sdk.targets" Sdk="WixToolset.Sdk" Version="$(WixVer)" />
   <Target Name="SignMsi" Condition="'$(BuildStage)' != 'Binary' and '$(SignMode)' != 'Off'" AfterTargets="Link">
     <MSBuild Projects="$(SolutionDir)src\xdpinstaller\xdpinstaller.vcxproj" Targets="SignMsi"/>
-  </Target>
-  <!-- prevents NU1503 -->
-  <Target Name="_IsProjectRestoreSupported"
-          Returns="@(_ValidProjectsForRestore)">
-    <ItemGroup>
-      <_ValidProjectsForRestore Include="$(MSBuildProjectFullPath)" />
-    </ItemGroup>
-  </Target>
-  <Target Name="Restore" />
-  <Target Name="EnsureNuGetPackageBuildImports" Condition=" '$(WixTargetsImported)' != 'true' " BeforeTargets="PrepareForBuild">
-    <Error Text="The WiX Toolset v3 build tools must be installed to build this project. To download the WiX Toolset, see https://wixtoolset.org/releases" />
   </Target>
 </Project>


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Upgrade from WiX 3.14 to WiX 5, which includes full support for ARM64. WiX 4 uses a different build project system (.NET SDK) which required a few other changes.

## Testing

_Do any existing tests cover this change? Are new tests needed?_
Builds locally.

## Documentation

_Is there any documentation impact for this change?_
No. I need to double check that the .NET SDK magically gets installed via the new project system.

## Installation

_Is there any installer impact for this change?_
No :)
