### PR TITLE
fix MSI test signing

### DIFF
--- a/src/xdpinstaller/xdpinstaller.wixproj
+++ b/src/xdpinstaller/xdpinstaller.wixproj
@@ -41,7 +41,7 @@
   </ItemGroup>
   <Import Project="Sdk.props" Sdk="WixToolset.Sdk" Version="$(WixVer)" />
   <Import Project="Sdk.targets" Sdk="WixToolset.Sdk" Version="$(WixVer)" />
-  <Target Name="SignMsi" Condition="'$(BuildStage)' != 'Binary' and '$(SignMode)' != 'Off'" AfterTargets="Link">
+  <Target Name="SignMsi" Condition="'$(BuildStage)' != 'Binary' and '$(SignMode)' != 'Off'" AfterTargets="Build">
     <MSBuild Projects="$(SolutionDir)src\xdpinstaller\xdpinstaller.vcxproj" Targets="SignMsi"/>
   </Target>
 </Project>


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

WiX 5 no longer has a `Link` target, so the `SignMsi` target is never executed in the MSI project.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Verified locally.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

Not really.