### PR TITLE
replace "arch" with "platform"

### DIFF
--- a/.azure/onebranch.test.yml
+++ b/.azure/onebranch.test.yml
@@ -9,7 +9,7 @@ resources:
 name: 0.$(Date:yyyy).$(Date:MM).$(DayOfMonth).$(Rev:rr).0
 
 parameters:
-- name: architectures
+- name: platforms
   type: object
   default:
   - x64
@@ -35,43 +35,43 @@ variables:
   functionalIterations: 10
 
 stages:
-  - ${{ each arch in parameters.architectures }}:
+  - ${{ each platform in parameters.platforms }}:
     - ${{ each config in parameters.configurations }}:
-      - stage: build_${{arch}}_${{config}}
-        displayName: Build (${{arch}}_${{config}})
+      - stage: build_${{platform}}_${{config}}
+        displayName: Build (${{platform}}_${{config}})
         dependsOn: []
         jobs:
         - template: ./templates/build.yml
           parameters:
-            arch: ${{arch}}
+            platform: ${{platform}}
             config: ${{config}}
 
       - ${{ each os in parameters.oses }}:
-        - stage: functional_${{os}}_${{arch}}_${{config}}
-          displayName: Functional ${{os}} (${{arch}}_${{config}})
+        - stage: functional_${{os}}_${{platform}}_${{config}}
+          displayName: Functional ${{os}} (${{platform}}_${{config}})
           dependsOn:
-          - build_${{arch}}_${{config}}
+          - build_${{platform}}_${{config}}
           jobs:
           - template: ./templates/tests.yml
             parameters:
               pool: XDP-CI-1ES-Functional-2
               image: WS${{os}}-Functional
-              arch: ${{arch}}
+              platform: ${{platform}}
               config: ${{config}}
               osName: ${{os}}
               timeoutInMinutes: ${{ variables.functionalRuntime }}
               iterations: ${{ variables.functionalIterations }}
 
-        - stage: stress_${{os}}_${{arch}}_${{config}}
-          displayName: Stress ${{os}} (${{arch}}_${{config}})
+        - stage: stress_${{os}}_${{platform}}_${{config}}
+          displayName: Stress ${{os}} (${{platform}}_${{config}})
           dependsOn:
-          - build_${{arch}}_${{config}}
+          - build_${{platform}}_${{config}}
           jobs:
           - template: ./templates/spinxsk.yml
             parameters:
               pool: XDP-CI-1ES-Spinxsk-2
               image: WS${{os}}-Spinxsk
-              arch: ${{arch}}
+              platform: ${{platform}}
               config: ${{config}}
               osName: ${{os}}
               runtimeMinutes: ${{ variables.spinxskRuntime }}

--- a/.azure/templates/build.yml
+++ b/.azure/templates/build.yml
@@ -1,15 +1,15 @@
 # This template contains steps to build, package and sign the solution.
 
 parameters:
-  arch: 'x64'
+  platform: 'x64'
   config: 'Debug'
   onebranchArtifactPrefix: 'drop_build_official_main_build_project'
 
 jobs:
-- job: build_${{ parameters.arch }}_${{ parameters.config }}
-  displayName: ${{ parameters.arch }}_${{ parameters.config }}
+- job: build_${{ parameters.platform }}_${{ parameters.config }}
+  displayName: ${{ parameters.platform }}_${{ parameters.config }}
   variables:
-    platconfig: ${{ parameters.arch }}_${{ parameters.config }}
+    platconfig: ${{ parameters.platform }}_${{ parameters.config }}
   pool:
     vmImage: windows-2022
   steps:
@@ -69,7 +69,7 @@ jobs:
     displayName: Build Solution
     inputs:
       solution: xdp.sln
-      platform: ${{ parameters.arch }}
+      platform: ${{ parameters.platform }}
       configuration: ${{ parameters.config }}
       msbuildArgs: -m /p:SignMode=TestSign /p:IsAdmin=true
 

--- a/.azure/templates/spinxsk.yml
+++ b/.azure/templates/spinxsk.yml
@@ -5,7 +5,7 @@ parameters:
   default: ''
 - name: image
   default: ''
-- name: arch
+- name: platform
   default: 'x64'
 - name: config
   default: 'Debug'
@@ -29,8 +29,8 @@ parameters:
 - name: osName
 
 jobs:
-- job: spinxsk__${{ parameters.arch }}_${{ parameters.config }}_${{ parameters.osName }}_${{ replace(parameters.pool, '-', '_') }}
-  displayName: spinxsk-${{ parameters.osName }}-${{ parameters.arch }}_${{ parameters.config }} (${{ parameters.pool }})
+- job: spinxsk__${{ parameters.platform }}_${{ parameters.config }}_${{ parameters.osName }}_${{ replace(parameters.pool, '-', '_') }}
+  displayName: spinxsk-${{ parameters.osName }}-${{ parameters.platform }}_${{ parameters.config }} (${{ parameters.pool }})
 
   # Either run on our self-hosted 'pool' or an AZP managed 'image'.
   ${{ if ne(parameters.pool, '') }}:
@@ -47,7 +47,7 @@ jobs:
   variables:
     runCodesignValidationInjection: false
     logMode: 'File'
-    platconfig: ${{ parameters.arch }}_${{ parameters.config }}
+    platconfig: ${{ parameters.platform }}_${{ parameters.config }}
   timeoutInMinutes: ${{ parameters.jobTimeoutMinutes }}
   steps:
   - checkout: self
@@ -56,7 +56,7 @@ jobs:
     displayName: Prepare Machine
     inputs:
       filePath: tools/prepare-machine.ps1
-      arguments: -ForSpinxskTest -NoReboot -Platform ${{ parameters.arch }} -Verbose
+      arguments: -ForSpinxskTest -NoReboot -Platform ${{ parameters.platform }} -Verbose
 
   - task: DownloadPipelineArtifact@2
     displayName: Download Build Artifacts
@@ -70,7 +70,7 @@ jobs:
     continueOnError: ${{ parameters.ignoreFailures }}
     inputs:
       filePath: tools/spinxsk.ps1
-      arguments: -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -QueueCount 2
+      arguments: -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -QueueCount 2
         -Minutes ${{ parameters.runtimeMinutes }} -XdpmpPollProvider ${{ parameters.xdpmpPollProvider }}
         -Verbose -Stats -SuccessThresholdPercent ${{ parameters.successThresholdPercent }}
         -EnableEbpf
@@ -81,7 +81,7 @@ jobs:
     condition: always()
     inputs:
       filePath: tools/log.ps1
-      arguments: -Convert -Name spinxsk -Verbose -Config ${{ parameters.config }} -Arch ${{ parameters.arch }}
+      arguments: -Convert -Name spinxsk -Verbose -Config ${{ parameters.config }} -Platform ${{ parameters.platform }}
 
   - task: CopyFiles@2
     displayName: Stage Logs
@@ -89,7 +89,7 @@ jobs:
     inputs:
       sourceFolder: artifacts/logs
       contents: '**/!(*.ilk|*.exp|*.lastcodeanalysissucceeded)'
-      targetFolder: $(Build.ArtifactStagingDirectory)/logs/spinxsk_${{ parameters.arch }}_${{ parameters.config }}_${{ parameters.osName }}_${{ parameters.pool }}
+      targetFolder: $(Build.ArtifactStagingDirectory)/logs/spinxsk_${{ parameters.platform }}_${{ parameters.config }}_${{ parameters.osName }}_${{ parameters.pool }}
 
   - task: PublishBuildArtifacts@1
     displayName: Upload Logs
@@ -104,4 +104,4 @@ jobs:
     condition: always()
     inputs:
       filePath: tools/check-drivers.ps1
-      arguments: -Verbose -Config ${{ parameters.config }} -Arch ${{ parameters.arch }}
+      arguments: -Verbose -Config ${{ parameters.config }} -Platform ${{ parameters.platform }}

--- a/.azure/templates/tests.yml
+++ b/.azure/templates/tests.yml
@@ -3,7 +3,7 @@
 parameters:
   pool: ''
   image: ''
-  arch: 'x64'
+  platform: 'x64'
   config: 'Debug'
   ignoreFailures: false
   timeoutInMinutes: 10
@@ -11,8 +11,8 @@ parameters:
   osName:
 
 jobs:
-- job: tests_${{ parameters.arch }}_${{ parameters.config }}_${{ parameters.osName }}_${{ replace(parameters.pool, '-', '_') }}
-  displayName: functional-${{ parameters.osName }}-${{ parameters.arch }}_${{ parameters.config }} (${{ parameters.pool }})
+- job: tests_${{ parameters.platform }}_${{ parameters.config }}_${{ parameters.osName }}_${{ replace(parameters.pool, '-', '_') }}
+  displayName: functional-${{ parameters.osName }}-${{ parameters.platform }}_${{ parameters.config }} (${{ parameters.pool }})
   # Either run on our self-hosted 'pool' or an AZP managed 'image'.
   ${{ if ne(parameters.pool, '') }}:
     pool:
@@ -27,7 +27,7 @@ jobs:
   continueOnError: ${{ parameters.ignoreFailures }}
   variables:
     runCodesignValidationInjection: false
-    platconfig: ${{ parameters.arch }}_${{ parameters.config }}
+    platconfig: ${{ parameters.platform }}_${{ parameters.config }}
   steps:
   - checkout: self
 
@@ -35,7 +35,7 @@ jobs:
     displayName: Prepare Machine
     inputs:
       filePath: tools/prepare-machine.ps1
-      arguments: -ForFunctionalTest -NoReboot -Platform ${{ parameters.arch }} -Verbose
+      arguments: -ForFunctionalTest -NoReboot -Platform ${{ parameters.platform }} -Verbose
 
   - task: DownloadPipelineArtifact@2
     displayName: Download Build Artifacts
@@ -48,7 +48,7 @@ jobs:
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     inputs:
       filePath: tools/functional.ps1
-      arguments: -Verbose -Config ${{ parameters.config }} -Arch ${{ parameters.arch }} -Iterations ${{ parameters.iterations }} -Timeout ${{ parameters.timeoutInMinutes }}
+      arguments: -Verbose -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Iterations ${{ parameters.iterations }} -Timeout ${{ parameters.timeoutInMinutes }}
 
   - task: PowerShell@2
     displayName: Convert Logs
@@ -56,7 +56,7 @@ jobs:
     timeoutInMinutes: 15
     inputs:
       filePath: tools/log.ps1
-      arguments: -Convert -Name xdpfunc* -Verbose -Config ${{ parameters.config }} -Arch ${{ parameters.arch }}
+      arguments: -Convert -Name xdpfunc* -Verbose -Config ${{ parameters.config }} -Platform ${{ parameters.platform }}
 
   - task: CopyFiles@2
     displayName: Stage Logs
@@ -64,7 +64,7 @@ jobs:
     inputs:
       sourceFolder: artifacts/logs
       contents: '**/!(*.ilk|*.exp|*.lastcodeanalysissucceeded)'
-      targetFolder: $(Build.ArtifactStagingDirectory)/logs/${{ parameters.arch }}_${{ parameters.config }}_${{ parameters.osName }}_${{ parameters.pool }}
+      targetFolder: $(Build.ArtifactStagingDirectory)/logs/${{ parameters.platform }}_${{ parameters.config }}_${{ parameters.osName }}_${{ parameters.pool }}
 
   - task: PublishBuildArtifacts@1
     displayName: Upload Logs
@@ -88,4 +88,4 @@ jobs:
     condition: always()
     inputs:
       filePath: tools/check-drivers.ps1
-      arguments: -Verbose -Config ${{ parameters.config }} -Arch ${{ parameters.arch }}
+      arguments: -Verbose -Config ${{ parameters.config }} -Platform ${{ parameters.platform }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ on:
         # options:
         #   - 2019
         #   - 2022
-      arch:
+      platform:
         required: false
         default: 'x64'
         type: string
@@ -60,22 +60,22 @@ jobs:
       uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce
     - name: Prepare Machine
       shell: PowerShell
-      run: tools/prepare-machine.ps1 -ForBuild -Verbose -Platform ${{ inputs.arch }}
+      run: tools/prepare-machine.ps1 -ForBuild -Verbose -Platform ${{ inputs.platform }}
     - name: Install LLVM 11.0
       run: |
         choco install -y llvm --version 11.0.1 --allow-downgrade
         echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Nuget Restore
-      run: msbuild.exe xdp.sln /t:restore /p:RestoreConfigFile=src/nuget.config /p:Configuration=${{ inputs.config }} /p:Platform=${{ inputs.arch }}
+      run: msbuild.exe xdp.sln /t:restore /p:RestoreConfigFile=src/nuget.config /p:Configuration=${{ inputs.config }} /p:Platform=${{ inputs.platform }}
     - name: Prepare for compiling eBPF programs
-      run: tools/prepare-machine.ps1 -ForEbpfBuild -Verbose -Platform ${{ inputs.arch }}
+      run: tools/prepare-machine.ps1 -ForEbpfBuild -Verbose -Platform ${{ inputs.platform }}
     - name: Build
-      run: msbuild xdp.sln /m /p:configuration=${{ inputs.config }} /p:platform=${{ inputs.arch }} /p:SignMode=TestSign /p:IsAdmin=true
+      run: msbuild xdp.sln /m /p:configuration=${{ inputs.config }} /p:platform=${{ inputs.platform }} /p:SignMode=TestSign /p:IsAdmin=true
     - name: Upload Artifacts
       if: inputs.upload_artifacts
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
       with:
-        name: bin_${{ inputs.config }}_${{ inputs.arch }}
+        name: bin_${{ inputs.config }}_${{ inputs.platform }}
         path: |
           artifacts/bin
           !artifacts/bin/**/*.ilk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,7 +350,7 @@ jobs:
       shell: PowerShell
       run: |
         Invoke-WebRequest -Uri "https://github.com/microsoft/xdp-for-windows/releases/download/v${{ matrix.downlevel_release }}/xdp-tests-${{ matrix.platform }}-${{ matrix.downlevel_release }}.zip" -OutFile "artifacts/downlevel-test.zip"
-        Expand-Platformive -Path artifacts/downlevel-test.zip -DestinationPath artifacts/downlevel-test/${{ matrix.platform }}
+        Expand-Archive -Path artifacts/downlevel-test.zip -DestinationPath artifacts/downlevel-test/${{ matrix.platform }}
         tools/merge-artifacts.ps1 -SourcePath artifacts/downlevel-test/${{ matrix.platform }}/bin/* -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
     - name: Run Tests
       shell: PowerShell
@@ -391,7 +391,7 @@ jobs:
         path: artifacts/bin
     - name: Create Test Archive
       shell: PowerShell
-      run: tools/create-test-platformive.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
+      run: tools/create-test-archive.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
     - name: Upload Release Artifacts
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
         # environment, in addition to the default WS 2022.
         os: [2019, 2022]
         config: [Release, Debug]
-        arch: [x64, arm64]
+        platform: [x64, arm64]
         exclude:
         - os: 2019
-          arch: arm64
+          platform: arm64
     permissions:
       actions: read
       contents: read
@@ -45,7 +45,7 @@ jobs:
     with:
       config: ${{ matrix.config }}
       os: ${{ matrix.os }}
-      arch: ${{ matrix.arch }}
+      platform: ${{ matrix.platform }}
       codeql: ${{ github.event_name == 'schedule' }}
       upload_artifacts: ${{ matrix.os == 2022 }}
 
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         config: [Release, Debug]
-        arch: [x64]
+        platform: [x64]
     permissions:
       actions: read
       contents: read
@@ -70,17 +70,17 @@ jobs:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce
     - name: Nuget Restore
-      run: msbuild.exe xdp.sln /t:restore /p:RestoreConfigFile=src/nuget.config /p:Configuration=${{ matrix.config }} /p:Platform=${{ matrix.arch }}
+      run: msbuild.exe xdp.sln /t:restore /p:RestoreConfigFile=src/nuget.config /p:Configuration=${{ matrix.config }} /p:Platform=${{ matrix.platform }}
     - name: Build Binary
-      run: msbuild xdp.sln /m  /t:onebranch /p:configuration=${{ matrix.config }} /p:platform=${{ matrix.arch }} /p:SignMode=Off /p:IsAdmin=true /p:BuildStage=Binary
+      run: msbuild xdp.sln /m  /t:onebranch /p:configuration=${{ matrix.config }} /p:platform=${{ matrix.platform }} /p:SignMode=Off /p:IsAdmin=true /p:BuildStage=Binary
     - name: Build Catalog
-      run: msbuild xdp.sln /m  /t:onebranch /p:configuration=${{ matrix.config }} /p:platform=${{ matrix.arch }} /p:SignMode=Off /p:IsAdmin=true /p:BuildStage=Catalog
+      run: msbuild xdp.sln /m  /t:onebranch /p:configuration=${{ matrix.config }} /p:platform=${{ matrix.platform }} /p:SignMode=Off /p:IsAdmin=true /p:BuildStage=Catalog
     - name: Build Package
-      run: msbuild xdp.sln /m  /t:onebranch /p:configuration=${{ matrix.config }} /p:platform=${{ matrix.arch }} /p:SignMode=Off /p:IsAdmin=true /p:BuildStage=Package
+      run: msbuild xdp.sln /m  /t:onebranch /p:configuration=${{ matrix.config }} /p:platform=${{ matrix.platform }} /p:SignMode=Off /p:IsAdmin=true /p:BuildStage=Package
     - name: Upload Artifacts
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
       with:
-        name: onebranch_bin_${{ matrix.config }}_${{ matrix.arch }}
+        name: onebranch_bin_${{ matrix.config }}_${{ matrix.platform }}
         path: |
           artifacts/bin
           !artifacts/bin/**/*.ilk
@@ -119,7 +119,7 @@ jobs:
         sparse-checkout: tools
     - name: Check Drivers
       shell: PowerShell
-      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Verbose
+      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Verbose
     - name: Prepare Machine
       shell: PowerShell
       run: tools/prepare-machine.ps1 -Platform ${{ matrix.platform }} -ForFunctionalTest -RequireNoReboot -Verbose
@@ -132,17 +132,17 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
       shell: PowerShell
       timeout-minutes: 25
-      run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Iterations ${{ env.prIters }} -Timeout ${{ env.fullRuntime }}
+      run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Iterations ${{ env.prIters }} -Timeout ${{ env.fullRuntime }}
     - name: Run Tests (main)
       if: ${{ github.event_name != 'pull_request' }}
       shell: PowerShell
       timeout-minutes: 250
-      run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Iterations ${{ env.fullIters }} -Timeout ${{ env.fullRuntime }}
+      run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Iterations ${{ env.fullIters }} -Timeout ${{ env.fullRuntime }}
     - name: Convert Logs
       if: ${{ always() }}
       timeout-minutes: 15
       shell: PowerShell
-      run: tools/log.ps1 -Convert -Name xdpfunc* -Verbose -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }}
+      run: tools/log.ps1 -Convert -Name xdpfunc* -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
     - name: Upload Logs
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
       if: ${{ always() }}
@@ -152,7 +152,7 @@ jobs:
     - name: Check Drivers
       if: ${{ always() }}
       shell: PowerShell
-      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Verbose
+      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Verbose
 
   stress_tests:
     name: Stress Tests
@@ -187,7 +187,7 @@ jobs:
         sparse-checkout: tools
     - name: Check Drivers
       shell: PowerShell
-      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Verbose
+      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Verbose
     - name: Prepare Machine
       shell: PowerShell
       run: tools/prepare-machine.ps1 -ForSpinxskTest -Platform ${{ matrix.platform }} -RequireNoReboot -Verbose
@@ -200,17 +200,17 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
       shell: PowerShell
       timeout-minutes: 20
-      run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Minutes ${{ env.prRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf
+      run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Minutes ${{ env.prRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf
     - name: Run spinxsk (main)
       if: ${{ github.event_name != 'pull_request' }}
       shell: PowerShell
       timeout-minutes: 70
-      run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Minutes ${{ env.fullRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf
+      run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Minutes ${{ env.fullRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf
     - name: Convert Logs
       if: ${{ always() }}
       timeout-minutes: 15
       shell: PowerShell
-      run: tools/log.ps1 -Convert -Name spinxsk -Verbose -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }}
+      run: tools/log.ps1 -Convert -Name spinxsk -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
     - name: Upload Logs
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
       if: ${{ always() }}
@@ -220,7 +220,7 @@ jobs:
     - name: Check Drivers
       if: ${{ always() }}
       shell: PowerShell
-      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Verbose
+      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Verbose
 
   pktfuzz_tests:
     name: Fuzz Packet Parsing
@@ -247,7 +247,7 @@ jobs:
         path: artifacts/bin
     - name: Run pktfuzz
       shell: PowerShell
-      run: tools/pktfuzz.ps1 -Minutes 10 -Workers 8 -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Verbose
+      run: tools/pktfuzz.ps1 -Minutes 10 -Workers 8 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Verbose
     - name: Upload Logs
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
       if: ${{ always() }}
@@ -284,7 +284,7 @@ jobs:
         sparse-checkout: tools
     - name: Check Drivers
       shell: PowerShell
-      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Verbose
+      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Verbose
     - name: Prepare Machine
       shell: PowerShell
       run: tools/prepare-machine.ps1 -ForPerfTest -Platform ${{ matrix.platform }} -RequireNoReboot -Verbose
@@ -295,13 +295,13 @@ jobs:
         path: artifacts/bin
     - name: Run xskperfsuite (Generic, Native)
       shell: PowerShell
-      run: tools/xskperfsuite.ps1 -Verbose -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Fndis -Iterations ${{ env.ITERATIONS }} -RawResultsFile "artifacts/logs/xskperfsuite.csv" -XperfDirectory "artifacts/logs" -CommitHash ${{ github.sha }}
+      run: tools/xskperfsuite.ps1 -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Fndis -Iterations ${{ env.ITERATIONS }} -RawResultsFile "artifacts/logs/xskperfsuite.csv" -XperfDirectory "artifacts/logs" -CommitHash ${{ github.sha }}
     - name: Run xskperfsuite (TX-inspect, RX-inject)
       shell: PowerShell
-      run: tools/xskperfsuite.ps1 -Verbose -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Fndis -Iterations ${{ env.ITERATIONS }} -XdpModes "Generic" -TxInspect -RxInject -RawResultsFile "artifacts/logs/xskperfsuite.csv" -XperfDirectory "artifacts/logs" -CommitHash ${{ github.sha }}
+      run: tools/xskperfsuite.ps1 -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Fndis -Iterations ${{ env.ITERATIONS }} -XdpModes "Generic" -TxInspect -RxInject -RawResultsFile "artifacts/logs/xskperfsuite.csv" -XperfDirectory "artifacts/logs" -CommitHash ${{ github.sha }}
     - name: Run xskperfsuite (Winsock, RIO)
       shell: PowerShell
-      run: tools/xskperfsuite.ps1 -Verbose -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Fndis -Iterations ${{ env.ITERATIONS }} -XdpModes "Winsock", "RIO" -Modes "RX", "TX" -RawResultsFile "artifacts/logs/xskperfsuite.csv" -XperfDirectory "artifacts/logs" -CommitHash ${{ github.sha }}
+      run: tools/xskperfsuite.ps1 -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Fndis -Iterations ${{ env.ITERATIONS }} -XdpModes "Winsock", "RIO" -Modes "RX", "TX" -RawResultsFile "artifacts/logs/xskperfsuite.csv" -XperfDirectory "artifacts/logs" -CommitHash ${{ github.sha }}
     - name: Upload Logs
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
       if: ${{ always() }}
@@ -311,7 +311,7 @@ jobs:
     - name: Check Drivers
       if: ${{ always() }}
       shell: PowerShell
-      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Verbose
+      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Verbose
 
   downlevel_functional_tests:
     name: Downlevel Functional Tests
@@ -337,7 +337,7 @@ jobs:
         sparse-checkout: tools
     - name: Check Drivers
       shell: PowerShell
-      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Verbose
+      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Verbose
     - name: Prepare Machine
       shell: PowerShell
       run: tools/prepare-machine.ps1 -ForFunctionalTest -Platform ${{ matrix.platform }} -RequireNoReboot -Verbose
@@ -350,17 +350,17 @@ jobs:
       shell: PowerShell
       run: |
         Invoke-WebRequest -Uri "https://github.com/microsoft/xdp-for-windows/releases/download/v${{ matrix.downlevel_release }}/xdp-tests-${{ matrix.platform }}-${{ matrix.downlevel_release }}.zip" -OutFile "artifacts/downlevel-test.zip"
-        Expand-Archive -Path artifacts/downlevel-test.zip -DestinationPath artifacts/downlevel-test/${{ matrix.platform }}
-        tools/merge-artifacts.ps1 -SourcePath artifacts/downlevel-test/${{ matrix.platform }}/bin/* -Verbose -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }}
+        Expand-Platformive -Path artifacts/downlevel-test.zip -DestinationPath artifacts/downlevel-test/${{ matrix.platform }}
+        tools/merge-artifacts.ps1 -SourcePath artifacts/downlevel-test/${{ matrix.platform }}/bin/* -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
     - name: Run Tests
       shell: PowerShell
       timeout-minutes: 25
-      run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Iterations ${{ env.Iters }} -NoPrerelease -Timeout ${{ env.Runtime }}
+      run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Iterations ${{ env.Iters }} -NoPrerelease -Timeout ${{ env.Runtime }}
     - name: Convert Logs
       if: ${{ always() }}
       timeout-minutes: 15
       shell: PowerShell
-      run: tools/log.ps1 -Convert -Name xdpfunc* -Verbose -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }}
+      run: tools/log.ps1 -Convert -Name xdpfunc* -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
     - name: Upload Logs
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
       if: ${{ always() }}
@@ -370,7 +370,7 @@ jobs:
     - name: Check Drivers
       if: ${{ always() }}
       shell: PowerShell
-      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Arch ${{ matrix.platform }} -Verbose
+      run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Verbose
 
   create_artifacts:
     name: Create Release Artifacts
@@ -391,7 +391,7 @@ jobs:
         path: artifacts/bin
     - name: Create Test Archive
       shell: PowerShell
-      run: tools/create-test-archive.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
+      run: tools/create-test-platformive.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
     - name: Upload Release Artifacts
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
       with:

--- a/src/nuget/nuget.vcxproj
+++ b/src/nuget/nuget.vcxproj
@@ -23,7 +23,7 @@
   <ItemDefinitionGroup>
     <PostBuildEvent>
       <Command>
-        powershell -NonInteractive -ExecutionPolicy Unrestricted ..\..\tools\update-nuspec.ps1 -InputFile xdp-for-windows.nuspec.in -OutputFile $(IntDir)xdp-for-windows.nuspec -Arch $(Platform) -Config $(Configuration)
+        powershell -NonInteractive -ExecutionPolicy Unrestricted ..\..\tools\update-nuspec.ps1 -InputFile xdp-for-windows.nuspec.in -OutputFile $(IntDir)xdp-for-windows.nuspec -Platform $(Platform) -Config $(Configuration)
         NuGet.exe pack $(IntDir)xdp-for-windows.nuspec -OutputDirectory $(OutDir) -BasePath $(ProjectDir)
       </Command>
     </PostBuildEvent>

--- a/src/xdpruntime/xdpruntime.vcxproj
+++ b/src/xdpruntime/xdpruntime.vcxproj
@@ -29,7 +29,7 @@
       <Exec Command="powershell.exe /c &quot;&amp; '$(WDKBinRoot)\$(HostPlatform)\signtool.exe' sign /sha1 ([system.security.cryptography.x509certificates.x509certificate2]::new([System.IO.File]::ReadAllBytes('$(OutDir)xdp\xdp.sys'))).Thumbprint /fd sha256  $(OutDir)xdp-setup.ps1&quot;" />
   </Target>
   <Target Name="BuildNuget" AfterTargets="Build" Condition="$(BuildStage) != 'Binary'">
-      <Exec Command="powershell.exe /c &quot;$(SolutionDir)tools\update-nuspec.ps1 -InputFile xdp-for-windows-runtime.nuspec.in -OutputFile $(IntDir)xdp-for-windows-runtime.nuspec -Arch $(Platform) -Config $(Configuration)&quot;" />
+      <Exec Command="powershell.exe /c &quot;$(SolutionDir)tools\update-nuspec.ps1 -InputFile xdp-for-windows-runtime.nuspec.in -OutputFile $(IntDir)xdp-for-windows-runtime.nuspec -Platform $(Platform) -Config $(Configuration)&quot;" />
       <Exec Command="NuGet.exe pack $(IntDir)xdp-for-windows-runtime.nuspec -OutputDirectory $(OutDir) -BasePath $(ProjectDir) -Properties NoWarn=NU5100,NU5110,NU5111" />
   </Target>
 </Project>

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -97,5 +97,5 @@ if (!$?) {
 }
 
 if ($TestArchive) {
-    & $RootDir\tools\create-test-archive.ps1 -Config $Config
+    & $RootDir\tools\create-test-Platformive.ps1 -Config $Config
 }

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -97,5 +97,5 @@ if (!$?) {
 }
 
 if ($TestArchive) {
-    & $RootDir\tools\create-test-Platformive.ps1 -Config $Config
+    & $RootDir\tools\create-test-Archive.ps1 -Config $Config
 }

--- a/tools/check-drivers.ps1
+++ b/tools/check-drivers.ps1
@@ -12,7 +12,7 @@ This checks for the presence of any XDP drivers currently loaded.
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("x64", "arm64")]
-    [string]$Arch = "x64",
+    [string]$Platform = "x64",
 
     [Parameter(Mandatory = $false)]
     [switch]$IgnoreEbpf = $false
@@ -40,7 +40,7 @@ function Check-Driver($Driver) {
 function Check-And-Remove-Driver($Driver, $Component) {
     if (Check-Driver $Driver) {
         Write-Host "Detected $Driver is loaded. Uninstalling $Component..."
-        & $RootDir\tools\setup.ps1 -Uninstall $Component -Config $Config -Arch $Arch
+        & $RootDir\tools\setup.ps1 -Uninstall $Component -Config $Config -Platform $Platform
 
         # Update cached driverquery output.
         $AllDrivers = driverquery /v /fo list

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -174,10 +174,10 @@ function Get-ArtifactBinPathBase {
         [Parameter()]
         [string]$Config,
         [Parameter()]
-        [string]$Arch
+        [string]$Platform
     )
 
-    return "artifacts\bin\$($Arch)_$($Config)"
+    return "artifacts\bin\$($Platform)_$($Config)"
 }
 
 function Get-ArtifactBinPath {
@@ -185,11 +185,11 @@ function Get-ArtifactBinPath {
         [Parameter()]
         [string]$Config,
         [Parameter()]
-        [string]$Arch
+        [string]$Platform
     )
 
     $RootDir = Split-Path $PSScriptRoot -Parent
-    return "$RootDir\$(Get-ArtifactBinPathBase -Config $Config -Arch $Arch)"
+    return "$RootDir\$(Get-ArtifactBinPathBase -Config $Config -Platform $Platform)"
 }
 
 function Get-XdpBuildVersion {

--- a/tools/create-test-archive.ps1
+++ b/tools/create-test-archive.ps1
@@ -22,7 +22,7 @@ $ErrorActionPreference = 'Stop'
 
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
-$ArtifactBin = Get-ArtifactBinPath -Config $Config -Arch $Platform
+$ArtifactBin = Get-ArtifactBinPath -Config $Config -Platform $Platform
 
 $Name = "xdp-tests-$Platform"
 if ($Config -eq "Debug") {
@@ -42,4 +42,4 @@ copy "$ArtifactBin\test\xdpfunctionaltests.pdb" $DstPath\symbols
 
 $VersionString = Get-XdpBuildVersionString
 
-Compress-Archive -DestinationPath "$DstPath\$Name-$VersionString.zip" -Path $DstPath\*
+Compress-Platformive -DestinationPath "$DstPath\$Name-$VersionString.zip" -Path $DstPath\*

--- a/tools/create-test-archive.ps1
+++ b/tools/create-test-archive.ps1
@@ -42,4 +42,4 @@ copy "$ArtifactBin\test\xdpfunctionaltests.pdb" $DstPath\symbols
 
 $VersionString = Get-XdpBuildVersionString
 
-Compress-Platformive -DestinationPath "$DstPath\$Name-$VersionString.zip" -Path $DstPath\*
+Compress-Archive -DestinationPath "$DstPath\$Name-$VersionString.zip" -Path $DstPath\*

--- a/tools/functional.ps1
+++ b/tools/functional.ps1
@@ -6,7 +6,7 @@ This script runs the XDP functional tests.
 .PARAMETER Config
     Specifies the build configuration to use.
 
-.PARAMETER Arch
+.PARAMETER Platform
     The CPU architecture to use.
 
 .PARAMETER TestCaseFilter
@@ -23,7 +23,7 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("x64", "arm64")]
-    [string]$Arch = "x64",
+    [string]$Platform = "x64",
 
     [Parameter(Mandatory = $false)]
     [string]$TestCaseFilter = "",
@@ -53,7 +53,7 @@ $ErrorActionPreference = 'Stop'
 # Important paths.
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
-$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Arch $Arch
+$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Platform $Platform
 $LogsDir = "$RootDir\artifacts\logs"
 $IterationFailureCount = 0
 $IterationTimeout = 0
@@ -65,7 +65,7 @@ if ($VsTestPath -eq $null) {
     Write-Error "Could not find VSTest path"
 }
 $VsTestConsole = "vstest.console"
-if ($Arch -eq "arm64") {
+if ($Platform -eq "arm64") {
     $VsTestConsole = "vstest.console.arm64"
 }
 
@@ -89,28 +89,28 @@ for ($i = 1; $i -le $Iterations; $i++) {
             $LogName += "-$i"
         }
 
-        & "$RootDir\tools\log.ps1" -Start -Name $LogName -Profile XdpFunctional.Verbose -Config $Config -Arch $Arch
+        & "$RootDir\tools\log.ps1" -Start -Name $LogName -Profile XdpFunctional.Verbose -Config $Config -Platform $Platform
 
         if (!$EbpfPreinstalled) {
             Write-Verbose "installing ebpf..."
-            & "$RootDir\tools\setup.ps1" -Install ebpf -Config $Config -Arch $Arch
+            & "$RootDir\tools\setup.ps1" -Install ebpf -Config $Config -Platform $Platform
             Write-Verbose "installed ebpf."
         }
 
         Write-Verbose "installing xdp..."
-        & "$RootDir\tools\setup.ps1" -Install xdp -Config $Config -Arch $Arch -EnableEbpf
+        & "$RootDir\tools\setup.ps1" -Install xdp -Config $Config -Platform $Platform -EnableEbpf
         Write-Verbose "installed xdp."
 
         Write-Verbose "installing fnmp..."
-        & "$RootDir\tools\setup.ps1" -Install fnmp -Config $Config -Arch $Arch
+        & "$RootDir\tools\setup.ps1" -Install fnmp -Config $Config -Platform $Platform
         Write-Verbose "installed fnmp."
 
         Write-Verbose "installing fnlwf..."
-        & "$RootDir\tools\setup.ps1" -Install fnlwf -Config $Config -Arch $Arch
+        & "$RootDir\tools\setup.ps1" -Install fnlwf -Config $Config -Platform $Platform
         Write-Verbose "installed fnlwf."
 
         Write-Verbose "installing fnsock..."
-        & "$RootDir\tools\setup.ps1" -Install fnsock -Config $Config -Arch $Arch
+        & "$RootDir\tools\setup.ps1" -Install fnsock -Config $Config -Platform $Platform
         Write-Verbose "installed fnsock."
 
         $TestArgs = @()
@@ -153,14 +153,14 @@ for ($i = 1; $i -le $Iterations; $i++) {
         if ($Watchdog -ne $null) {
             Remove-Job -Job $Watchdog -Force
         }
-        & "$RootDir\tools\setup.ps1" -Uninstall fnsock -Config $Config -Arch $Arch -ErrorAction 'Continue'
-        & "$RootDir\tools\setup.ps1" -Uninstall fnlwf -Config $Config -Arch $Arch -ErrorAction 'Continue'
-        & "$RootDir\tools\setup.ps1" -Uninstall fnmp -Config $Config -Arch $Arch -ErrorAction 'Continue'
-        & "$RootDir\tools\setup.ps1" -Uninstall xdp -Config $Config -Arch $Arch -ErrorAction 'Continue'
+        & "$RootDir\tools\setup.ps1" -Uninstall fnsock -Config $Config -Platform $Platform -ErrorAction 'Continue'
+        & "$RootDir\tools\setup.ps1" -Uninstall fnlwf -Config $Config -Platform $Platform -ErrorAction 'Continue'
+        & "$RootDir\tools\setup.ps1" -Uninstall fnmp -Config $Config -Platform $Platform -ErrorAction 'Continue'
+        & "$RootDir\tools\setup.ps1" -Uninstall xdp -Config $Config -Platform $Platform -ErrorAction 'Continue'
         if (!$EbpfPreinstalled) {
-            & "$RootDir\tools\setup.ps1" -Uninstall ebpf -Config $Config -Arch $Arch -ErrorAction 'Continue'
+            & "$RootDir\tools\setup.ps1" -Uninstall ebpf -Config $Config -Platform $Platform -ErrorAction 'Continue'
         }
-        & "$RootDir\tools\log.ps1" -Stop -Name $LogName -Config $Config -Arch $Arch -ErrorAction 'Continue'
+        & "$RootDir\tools\log.ps1" -Stop -Name $LogName -Config $Config -Platform $Platform -ErrorAction 'Continue'
     }
 }
 

--- a/tools/log.ps1
+++ b/tools/log.ps1
@@ -6,7 +6,7 @@ This helps start and stop ETW logging.
 .PARAMETER Config
     When using an artifacts directory, specifies the build configuration to use.
 
-.PARAMETER Arch
+.PARAMETER Platform
     When using an artifacts directory, specifies the CPU architecture to use.
 
 .PARAMETER SymbolPath
@@ -40,7 +40,7 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("x64", "arm64")]
-    [string]$Arch = "x64",
+    [string]$Platform = "x64",
 
     [Parameter(Mandatory = $false)]
     [string]$SymbolPath = $null,
@@ -77,15 +77,15 @@ $ErrorActionPreference = 'Stop'
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
 
-$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Arch $Arch
+$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Platform $Platform
 $TracePdb = Get-CoreNetCiArtifactPath -Name "tracepdb.exe"
 $WprpFile = "$RootDir\tools\xdptrace.wprp"
 $TmfPath = "$ArtifactsDir\tmfs"
 $LogsDir = "$RootDir\artifacts\logs"
 
-& $RootDir/tools/prepare-machine.ps1 -ForLogging -Platform $Arch
+& $RootDir/tools/prepare-machine.ps1 -ForLogging -Platform $Platform
 
-if ($Arch -eq "arm64") {
+if ($Platform -eq "arm64") {
     Write-Warning "Not logging on arm64."
     return
 }

--- a/tools/merge-artifacts.ps1
+++ b/tools/merge-artifacts.ps1
@@ -7,7 +7,7 @@ artifacts directory.
 .PARAMETER Config
     Specifies the build configuration to use.
 
-.PARAMETER Arch
+.PARAMETER Platform
     The CPU architecture to use.
 
 .PARAMETER SourcePath
@@ -22,7 +22,7 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("x64", "arm64")]
-    [string]$Arch = "x64",
+    [string]$Platform = "x64",
 
     [Parameter(Mandatory = $true)]
     [string]$SourcePath
@@ -34,6 +34,6 @@ $ErrorActionPreference = 'Stop'
 # Important paths.
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
-$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Arch $Arch
+$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Platform $Platform
 
 Copy-Item -Path $SourcePath -Destination $ArtifactsDir -Recurse -Force

--- a/tools/pktfuzz.ps1
+++ b/tools/pktfuzz.ps1
@@ -5,7 +5,7 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("x64", "arm64")]
-    [string]$Arch = "x64",
+    [string]$Platform = "x64",
 
     [Parameter(Mandatory = $false)]
     [int]$Minutes = 0,
@@ -20,7 +20,7 @@ $ErrorActionPreference = 'Stop'
 # Important paths.
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
-$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Arch $Arch
+$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Platform $Platform
 $LogsDir = "$RootDir\artifacts\logs"
 
 # Ensure the output path exists.

--- a/tools/rxfilter.ps1
+++ b/tools/rxfilter.ps1
@@ -5,7 +5,7 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("x64", "arm64")]
-    [string]$Arch = "x64",
+    [string]$Platform = "x64",
 
     [Parameter(Mandatory = $false)]
     [string]$AdapterName = "XDPMP",
@@ -27,7 +27,7 @@ $ErrorActionPreference = 'Stop'
 # Important paths.
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
-$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Arch $Arch
+$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Platform $Platform
 
 for ($i = 0; $i -lt $QueueCount; $i++) {
     Start-Process $ArtifactsDir\test\rxfilter.exe -ArgumentList `

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -6,7 +6,7 @@ This script installs or uninstalls various XDP components.
 .PARAMETER Config
     Specifies the build configuration to use.
 
-.PARAMETER Arch
+.PARAMETER Platform
     The CPU architecture to use.
 
 .PARAMETER Install
@@ -26,7 +26,7 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("x64", "arm64")]
-    [string]$Arch = "x64",
+    [string]$Platform = "x64",
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("", "fndis", "xdp", "xdpmp", "fnmp", "fnlwf", "fnsock", "ebpf")]
@@ -56,7 +56,7 @@ $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
 
 # Important paths.
-$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Arch $Arch
+$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Platform $Platform
 $LogsDir = "$RootDir\artifacts\logs"
 $DevCon = Get-CoreNetCiArtifactPath -Name "devcon.exe"
 $DswDevice = Get-CoreNetCiArtifactPath -Name "dswdevice.exe"
@@ -70,7 +70,7 @@ $XdpFileVersion = (Get-Item $XdpSys).VersionInfo.FileVersion
 # Determine the XDP build version string from xdp.sys. The Windows file version
 # format is "A.B.C.D", but XDP (and semver) use only the "A.B.C".
 $XdpFileVersion = $XdpFileVersion.substring(0, $XdpFileVersion.LastIndexOf('.'))
-$XdpMsiFullPath = "$ArtifactsDir\xdp-for-windows.$Arch.$XdpFileVersion.msi"
+$XdpMsiFullPath = "$ArtifactsDir\xdp-for-windows.$Platform.$XdpFileVersion.msi"
 $FndisSys = "$ArtifactsDir\test\fndis\fndis.sys"
 $XdpMpSys = "$ArtifactsDir\test\xdpmp\xdpmp.sys"
 $XdpMpInf = "$ArtifactsDir\test\xdpmp\xdpmp.inf"
@@ -249,8 +249,8 @@ function Uninstall-Driver($Inf) {
 function Install-DebugCrt {
     # The debug CRT does not have an official redistributable, so use our own repackaged version.
     if ($Config -eq "Debug") {
-        Write-Verbose "Installing debugcrt from $(Get-ArtifactBinPath -Arch $Arch -Config $Config)\test\debugcrt\* to $env:WINDIR\system32"
-        Copy-Item -Recurse -Force "$(Get-ArtifactBinPath -Arch $Arch -Config $Config)\test\debugcrt\*" "$env:WINDIR\system32" | Write-Verbose
+        Write-Verbose "Installing debugcrt from $(Get-ArtifactBinPath -Platform $Platform -Config $Config)\test\debugcrt\* to $env:WINDIR\system32"
+        Copy-Item -Recurse -Force "$(Get-ArtifactBinPath -Platform $Platform -Config $Config)\test\debugcrt\*" "$env:WINDIR\system32" | Write-Verbose
     }
 }
 
@@ -464,8 +464,8 @@ function Uninstall-XdpMp {
 
 # Installs the fnmp driver.
 function Install-FnMp {
-    Write-Verbose "$(Get-FnRuntimeDir)/tools/setup.ps1 -Install fnmp -Config $Config -Arch $Arch -FnMpCount 2 -ArtifactsDir $(Get-FnRuntimeDir)/bin -LogsDir $LogsDir"
-    & "$(Get-FnRuntimeDir)/tools/setup.ps1" -Install fnmp -Config $Config -Arch $Arch -FnMpCount 2 -ArtifactsDir "$(Get-FnRuntimeDir)/bin" -LogsDir $LogsDir
+    Write-Verbose "$(Get-FnRuntimeDir)/tools/setup.ps1 -Install fnmp -Config $Config -Arch $Platform -FnMpCount 2 -ArtifactsDir $(Get-FnRuntimeDir)/bin -LogsDir $LogsDir"
+    & "$(Get-FnRuntimeDir)/tools/setup.ps1" -Install fnmp -Config $Config -Arch $Platform -FnMpCount 2 -ArtifactsDir "$(Get-FnRuntimeDir)/bin" -LogsDir $LogsDir
 
     Write-Verbose "Renaming adapters"
     Rename-NetAdapter-With-Retry FNMP XDPFNMP
@@ -514,39 +514,39 @@ function Uninstall-FnMp {
     netsh int ipv6 delete address xdpfnmp1q fc00::201:1 | Out-Null
     netsh int ipv6 delete neighbors xdpfnmp1q | Out-Null
 
-    Write-Verbose "$(Get-FnRuntimeDir)/tools/setup.ps1 -Uninstall fnmp -Config $Config -Arch $Arch -FnMpCount 2 -ArtifactsDir $(Get-FnRuntimeDir)/bin -LogsDir $LogsDir"
-    & "$(Get-FnRuntimeDir)/tools/setup.ps1" -Uninstall fnmp -Config $Config -Arch $Arch -FnMpCount 2 -ArtifactsDir "$(Get-FnRuntimeDir)/bin" -LogsDir $LogsDir
+    Write-Verbose "$(Get-FnRuntimeDir)/tools/setup.ps1 -Uninstall fnmp -Config $Config -Arch $Platform -FnMpCount 2 -ArtifactsDir $(Get-FnRuntimeDir)/bin -LogsDir $LogsDir"
+    & "$(Get-FnRuntimeDir)/tools/setup.ps1" -Uninstall fnmp -Config $Config -Arch $Platform -FnMpCount 2 -ArtifactsDir "$(Get-FnRuntimeDir)/bin" -LogsDir $LogsDir
 
     Write-Verbose "fnmp.sys uninstall complete!"
 }
 
 # Installs the fnlwf driver.
 function Install-FnLwf {
-    Write-Verbose "$(Get-FnRuntimeDir)/tools/setup.ps1 -Install fnlwf -Config $Config -Arch $Arch -ArtifactsDir $(Get-FnRuntimeDir)/bin -LogsDir $LogsDir"
-    & "$(Get-FnRuntimeDir)/tools/setup.ps1" -Install fnlwf -Config $Config -Arch $Arch -ArtifactsDir "$(Get-FnRuntimeDir)/bin" -LogsDir $LogsDir
+    Write-Verbose "$(Get-FnRuntimeDir)/tools/setup.ps1 -Install fnlwf -Config $Config -Arch $Platform -ArtifactsDir $(Get-FnRuntimeDir)/bin -LogsDir $LogsDir"
+    & "$(Get-FnRuntimeDir)/tools/setup.ps1" -Install fnlwf -Config $Config -Arch $Platform -ArtifactsDir "$(Get-FnRuntimeDir)/bin" -LogsDir $LogsDir
 }
 
 # Uninstalls the fnlwf driver.
 function Uninstall-FnLwf {
-    Write-Verbose "$(Get-FnRuntimeDir)/tools/setup.ps1 -Uninstall fnlwf -Config $Config -Arch $Arch -ArtifactsDir $(Get-FnRuntimeDir)/bin -LogsDir $LogsDir"
-    & "$(Get-FnRuntimeDir)/tools/setup.ps1" -Uninstall fnlwf -Config $Config -Arch $Arch -ArtifactsDir "$(Get-FnRuntimeDir)/bin" -LogsDir $LogsDir
+    Write-Verbose "$(Get-FnRuntimeDir)/tools/setup.ps1 -Uninstall fnlwf -Config $Config -Arch $Platform -ArtifactsDir $(Get-FnRuntimeDir)/bin -LogsDir $LogsDir"
+    & "$(Get-FnRuntimeDir)/tools/setup.ps1" -Uninstall fnlwf -Config $Config -Arch $Platform -ArtifactsDir "$(Get-FnRuntimeDir)/bin" -LogsDir $LogsDir
 }
 
 # Installs fnsock.
 function Install-FnSock {
-    Write-Verbose "$(Get-FnRuntimeDir)/tools/setup.ps1 -Install fnsock -Config $Config -Arch $Arch -ArtifactsDir $(Get-FnRuntimeDir)/bin/fnsock -LogsDir $LogsDir"
-    & "$(Get-FnRuntimeDir)/tools/setup.ps1" -Install fnsock -Config $Config -Arch $Arch -ArtifactsDir "$(Get-FnRuntimeDir)/bin/fnsock" -LogsDir $LogsDir
+    Write-Verbose "$(Get-FnRuntimeDir)/tools/setup.ps1 -Install fnsock -Config $Config -Arch $Platform -ArtifactsDir $(Get-FnRuntimeDir)/bin/fnsock -LogsDir $LogsDir"
+    & "$(Get-FnRuntimeDir)/tools/setup.ps1" -Install fnsock -Config $Config -Arch $Platform -ArtifactsDir "$(Get-FnRuntimeDir)/bin/fnsock" -LogsDir $LogsDir
 }
 
 # Uninstalls fnsock.
 function Uninstall-FnSock {
-    Write-Verbose "$(Get-FnRuntimeDir)/tools/setup.ps1 -Uninstall fnsock -Config $Config -Arch $Arch -ArtifactsDir $(Get-FnRuntimeDir)/bin/fnsock -LogsDir $LogsDir"
-    & "$(Get-FnRuntimeDir)/tools/setup.ps1" -Uninstall fnsock -Config $Config -Arch $Arch -ArtifactsDir "$(Get-FnRuntimeDir)/bin/fnsock" -LogsDir $LogsDir
+    Write-Verbose "$(Get-FnRuntimeDir)/tools/setup.ps1 -Uninstall fnsock -Config $Config -Arch $Platform -ArtifactsDir $(Get-FnRuntimeDir)/bin/fnsock -LogsDir $LogsDir"
+    & "$(Get-FnRuntimeDir)/tools/setup.ps1" -Uninstall fnsock -Config $Config -Arch $Platform -ArtifactsDir "$(Get-FnRuntimeDir)/bin/fnsock" -LogsDir $LogsDir
 }
 
 function Install-Ebpf {
     $EbpfPath = Get-EbpfInstallPath
-    $EbpfMsiFullPath = Get-EbpfMsiFullPath -Platform $Arch
+    $EbpfMsiFullPath = Get-EbpfMsiFullPath -Platform $Platform
 
     Write-Verbose "Installing eBPF for Windows"
 
@@ -571,7 +571,7 @@ function Install-Ebpf {
 
 function Uninstall-Ebpf {
     $EbpfPath = Get-EbpfInstallPath
-    $EbpfMsiFullPath = Get-EbpfMsiFullPath -Platform $Arch
+    $EbpfMsiFullPath = Get-EbpfMsiFullPath -Platform $Platform
     $Timeout = 60
 
     if (!(Test-Path $EbpfPath)) {

--- a/tools/spinxsk.ps1
+++ b/tools/spinxsk.ps1
@@ -9,7 +9,7 @@ more coverage for setup and cleanup.
 .PARAMETER Config
     Specifies the build configuration to use.
 
-.PARAMETER Arch
+.PARAMETER Platform
     The CPU architecture to use.
 
 .PARAMETER Minutes
@@ -48,7 +48,7 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("x64", "arm64")]
-    [string]$Arch = "x64",
+    [string]$Platform = "x64",
 
     [Parameter(Mandatory = $false)]
     [Int32]$Minutes = 0,
@@ -92,7 +92,7 @@ $ErrorActionPreference = 'Stop'
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
 
-$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Arch $Arch
+$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Platform $Platform
 $LogsDir = "$RootDir\artifacts\logs"
 $SpinXsk = "$ArtifactsDir\test\spinxsk.exe"
 $LiveKD = Get-CoreNetCiArtifactPath -Name "livekd64.exe"
@@ -125,28 +125,28 @@ while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes))
 
     try {
         if (!$NoLogs) {
-            & "$RootDir\tools\log.ps1" -Start -Name spinxsk -Profile SpinXsk.Verbose -Config $Config -Arch $Arch
-            & "$RootDir\tools\log.ps1" -Start -Name spinxskebpf -Profile SpinXskEbpf.Verbose -LogMode Memory -Config $Config -Arch $Arch
-            & "$RootDir\tools\log.ps1" -Start -Name spinxskcpu -Profile CpuCswitchSample.Verbose -Config $Config -Arch $Arch
+            & "$RootDir\tools\log.ps1" -Start -Name spinxsk -Profile SpinXsk.Verbose -Config $Config -Platform $Platform
+            & "$RootDir\tools\log.ps1" -Start -Name spinxskebpf -Profile SpinXskEbpf.Verbose -LogMode Memory -Config $Config -Platform $Platform
+            & "$RootDir\tools\log.ps1" -Start -Name spinxskcpu -Profile CpuCswitchSample.Verbose -Config $Config -Platform $Platform
         }
         if ($XdpmpPollProvider -eq "FNDIS") {
             Write-Verbose "installing fndis..."
-            & "$RootDir\tools\setup.ps1" -Install fndis -Config $Config -Arch $Arch
+            & "$RootDir\tools\setup.ps1" -Install fndis -Config $Config -Platform $Platform
             Write-Verbose "installed fndis."
         }
 
         if (!$EbpfPreinstalled) {
             Write-Verbose "installing ebpf..."
-            & "$RootDir\tools\setup.ps1" -Install ebpf -Config $Config -Arch $Arch
+            & "$RootDir\tools\setup.ps1" -Install ebpf -Config $Config -Platform $Platform
             Write-Verbose "installed ebpf."
         }
 
         Write-Verbose "installing xdp..."
-        & "$RootDir\tools\setup.ps1" -Install xdp -Config $Config -Arch $Arch -EnableEbpf:$EnableEbpf
+        & "$RootDir\tools\setup.ps1" -Install xdp -Config $Config -Platform $Platform -EnableEbpf:$EnableEbpf
         Write-Verbose "installed xdp."
 
         Write-Verbose "installing xdpmp..."
-        & "$RootDir\tools\setup.ps1" -Install xdpmp -XdpmpPollProvider $XdpmpPollProvider -Config $Config -Arch $Arch
+        & "$RootDir\tools\setup.ps1" -Install xdpmp -XdpmpPollProvider $XdpmpPollProvider -Config $Config -Platform $Platform
         Write-Verbose "installed xdpmp."
 
         Write-Verbose "Set-NetAdapterRss XDPMP -NumberOfReceiveQueues $QueueCount"
@@ -185,18 +185,18 @@ while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes))
             throw "SpinXsk failed with $LastExitCode"
         }
     } finally {
-        & "$RootDir\tools\setup.ps1" -Uninstall xdpmp -Config $Config -Arch $Arch -ErrorAction 'Continue'
-        & "$RootDir\tools\setup.ps1" -Uninstall xdp -Config $Config -Arch $Arch -ErrorAction 'Continue'
+        & "$RootDir\tools\setup.ps1" -Uninstall xdpmp -Config $Config -Platform $Platform -ErrorAction 'Continue'
+        & "$RootDir\tools\setup.ps1" -Uninstall xdp -Config $Config -Platform $Platform -ErrorAction 'Continue'
         if (!$EbpfPreinstalled) {
-            & "$RootDir\tools\setup.ps1" -Uninstall ebpf -Config $Config -Arch $Arch -ErrorAction 'Continue'
+            & "$RootDir\tools\setup.ps1" -Uninstall ebpf -Config $Config -Platform $Platform -ErrorAction 'Continue'
         }
         if ($XdpmpPollProvider -eq "FNDIS") {
-            & "$RootDir\tools\setup.ps1" -Uninstall fndis -Config $Config -Arch $Arch -ErrorAction 'Continue'
+            & "$RootDir\tools\setup.ps1" -Uninstall fndis -Config $Config -Platform $Platform -ErrorAction 'Continue'
         }
         if (!$NoLogs) {
-            & "$RootDir\tools\log.ps1" -Stop -Name spinxskcpu -Config $Config -Arch $Arch -ErrorAction 'Continue'
-            & "$RootDir\tools\log.ps1" -Stop -Name spinxskebpf -Config $Config -Arch $Arch -ErrorAction 'Continue'
-            & "$RootDir\tools\log.ps1" -Stop -Name spinxsk -Config $Config -Arch $Arch -ErrorAction 'Continue'
+            & "$RootDir\tools\log.ps1" -Stop -Name spinxskcpu -Config $Config -Platform $Platform -ErrorAction 'Continue'
+            & "$RootDir\tools\log.ps1" -Stop -Name spinxskebpf -Config $Config -Platform $Platform -ErrorAction 'Continue'
+            & "$RootDir\tools\log.ps1" -Stop -Name spinxsk -Config $Config -Platform $Platform -ErrorAction 'Continue'
         }
     }
 }

--- a/tools/update-nuspec.ps1
+++ b/tools/update-nuspec.ps1
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation
 
-param ($InputFile, $OutputFile, $Arch, $Config)
+param ($InputFile, $OutputFile, $Platform, $Config)
 
 Set-StrictMode -Version 'Latest'
 $ErrorActionPreference = 'Stop'
@@ -15,6 +15,6 @@ $content = Get-Content $InputFile
 $content = $content.Replace("{commit}", $Commit)
 $content = $content.Replace("{version}", $VersionString)
 $content = $content.Replace("{rootpath}", $RootDir)
-$content = $content.Replace("{anyarch}", $Arch)
-$content = $content.Replace("{binpath_anyarch}", $(Get-ArtifactBinPath -Arch $Arch -Config $Config))
+$content = $content.Replace("{anyarch}", $Platform)
+$content = $content.Replace("{binpath_anyarch}", $(Get-ArtifactBinPath -Platform $Platform -Config $Config))
 set-content $OutputFile $content

--- a/tools/xskperf.ps1
+++ b/tools/xskperf.ps1
@@ -14,7 +14,7 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("x64", "arm64")]
-    [string]$Arch = "x64",
+    [string]$Platform = "x64",
 
     [Parameter(Mandatory=$true)]
     [string]$AdapterName,
@@ -132,7 +132,7 @@ function Wait-NetAdapterUpStatus {
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
 
-$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Arch $Arch
+$ArtifactsDir = Get-ArtifactBinPath -Config $Config -Platform $Platform
 $WsaRio = Get-CoreNetCiArtifactPath -Name "wsario.exe"
 $Mode = $Mode.ToUpper()
 $Adapter = Get-NetAdapter $AdapterName
@@ -330,7 +330,7 @@ try {
 
     if (-not [string]::IsNullOrEmpty($XperfFile)) {
         & $RootDir\tools\log.ps1 -Start -Name xskcpu -Profile CpuSample.Verbose `
-            -Config $Config -Arch $Arch
+            -Config $Config -Platform $Platform
     }
 
     if (@("System", "Generic", "Native").Contains($XdpMode)) {
@@ -394,7 +394,7 @@ try {
 } finally {
 
     if (-not [string]::IsNullOrEmpty($XperfFile)) {
-        & $RootDir\tools\log.ps1 -Stop -Name xskcpu -Config $Config -Arch $Arch `
+        & $RootDir\tools\log.ps1 -Stop -Name xskcpu -Config $Config -Platform $Platform `
             -EtlPath $XperfFile
     }
 

--- a/tools/xskperfsuite.ps1
+++ b/tools/xskperfsuite.ps1
@@ -9,7 +9,7 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("x64", "arm64")]
-    [string]$Arch = "x64",
+    [string]$Platform = "x64",
 
     [Parameter(Mandatory=$false)]
     [string[]]$AdapterNames = @("XDPMP"),
@@ -146,17 +146,17 @@ try {
             $XdpmpPollProvider = "FNDIS"
 
             Write-Verbose "installing fndis..."
-            & "$RootDir\tools\setup.ps1" -Install fndis -Config $Config -Arch $Arch
+            & "$RootDir\tools\setup.ps1" -Install fndis -Config $Config -Platform $Platform
             Write-Verbose "installed fndis."
         }
 
         Write-Verbose "installing xdpmp..."
-        & "$RootDir\tools\setup.ps1" -Install xdpmp -Config $Config -Arch $Arch -XdpmpPollProvider $XdpmpPollProvider
+        & "$RootDir\tools\setup.ps1" -Install xdpmp -Config $Config -Platform $Platform -XdpmpPollProvider $XdpmpPollProvider
         Write-Verbose "installed xdpmp."
     }
 
     Write-Verbose "installing xdp..."
-    & "$RootDir\tools\setup.ps1" -Install xdp -Config $Config -Arch $Arch
+    & "$RootDir\tools\setup.ps1" -Install xdp -Config $Config -Platform $Platform
     Write-Verbose "installed xdp."
 
     $Format = "{0,-73} {1,-14} {2,-14}"
@@ -209,7 +209,7 @@ try {
                                     -RxInject:$RxInject -TxInspect:$TxInspect `
                                     -TxInspectContentionCount $TxInspectContentionCount `
                                     -SocketCount:$SocketCount -Fndis:$Fndis -Config $Config `
-                                    -Arch $Arch -XperfFile $XperfFile
+                                    -Platform $Platform -XperfFile $XperfFile
 
                                 $kppsList += ExtractKppsStat $TmpFile
                             }
@@ -236,11 +236,11 @@ try {
         }
     }
 } finally {
-    & "$RootDir\tools\setup.ps1" -Uninstall xdp -Config $Config -Arch $Arch -ErrorAction 'Continue'
+    & "$RootDir\tools\setup.ps1" -Uninstall xdp -Config $Config -Platform $Platform -ErrorAction 'Continue'
     if ($AdapterNames.Contains("XDPMP")) {
-        & "$RootDir\tools\setup.ps1" -Uninstall xdpmp -Config $Config -Arch $Arch -ErrorAction 'Continue'
+        & "$RootDir\tools\setup.ps1" -Uninstall xdpmp -Config $Config -Platform $Platform -ErrorAction 'Continue'
         if ($Fndis) {
-            & "$RootDir\tools\setup.ps1" -Uninstall fndis -Config $Config -Arch $Arch -ErrorAction 'Continue'
+            & "$RootDir\tools\setup.ps1" -Uninstall fndis -Config $Config -Platform $Platform -ErrorAction 'Continue'
         }
     }
 }


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

For some reason lost to the sands of time, we have a mix of "arch", "architecture", and "platform" across scripts and YAML, and all have the same meaning. Use "platform" consistently, because this aligns with the msbuild system.

## Testing

_Do any existing tests cover this change? Are new tests needed?_
CI.

## Documentation

_Is there any documentation impact for this change?_
No.

## Installation

_Is there any installer impact for this change?_
No.