### PR TITLE
enable non-sampling logs on arm64

### DIFF
--- a/tools/log.ps1
+++ b/tools/log.ps1
@@ -85,7 +85,7 @@ $LogsDir = "$RootDir\artifacts\logs"
 
 & $RootDir/tools/prepare-machine.ps1 -ForLogging -Platform $Platform
 
-if ($Platform -eq "arm64" -and (@("CpuCswitchSample", "CpuSample") -contains $Profile)) {
+if ($Platform -eq "arm64" -and (@("CpuCswitchSample", "CpuSample") -contains $Profile.Split(".")[0])) {
     Write-Warning "Skipping sampling profile: not currently supported on arm64."
     return
 }


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Our ARM64 VMs do not support sampling profiles, but otherwise should support logging. See if that works.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

Nope.

## Installation

_Is there any installer impact for this change?_

Nope.
