### PR TITLE
disable processor profiling by default

### DIFF
--- a/docs/api/xsk-sockopts.md
+++ b/docs/api/xsk-sockopts.md
@@ -128,10 +128,13 @@ typedef enum _XSK_ERROR {
 //
 // XSK_SOCKOPT_RX_PROCESSOR_AFFINITY
 //
-// Supports: get
-// Optval type: PROCESSOR_NUMBER
-// Description: Returns the ideal processor of the kernel RX data path. This
-//              option may return errors, including but not limited to
+// Supports: set/get
+// Optval type: UINT8 (set) / PROCESSOR_NUMBER (get)
+// Description: 
+//              For set, enables or disables ideal processor profiling.
+//              This option is disabled by default.
+//              For get, returns the ideal processor of the kernel RX data path.
+//              This option may return errors, including but not limited to
 //              HRESULT_FROM_WIN32(ERROR_NOT_READY) and
 //              HRESULT_FROM_WIN32(ERROR_NOT_CAPABLE), when the ideal processor
 //              affinity is unknown or unknowable.
@@ -141,10 +144,13 @@ typedef enum _XSK_ERROR {
 //
 // XSK_SOCKOPT_TX_PROCESSOR_AFFINITY
 //
-// Supports: get
-// Optval type: PROCESSOR_NUMBER
-// Description: Returns the ideal processor of the kernel TX data path. This
-//              option may return errors, including but not limited to
+// Supports: set/get
+// Optval type: UINT8 (set) / PROCESSOR_NUMBER (get)
+// Description: 
+//              For set, enables or disables ideal processor profiling.
+//              This option is disabled by default.
+//              For get, returns the ideal processor of the kernel TX data path.
+//              This option may return errors, including but not limited to
 //              HRESULT_FROM_WIN32(ERROR_NOT_READY) and
 //              HRESULT_FROM_WIN32(ERROR_NOT_CAPABLE), when the ideal processor
 //              affinity is unknown or unknowable.

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -7789,6 +7789,13 @@ GenericXskQueryAffinity()
         //
 
         if (Case.Rx) {
+            UINT8 Enabled = TRUE;
+            Result =
+                TrySetSockopt(
+                    Socket.Handle.get(), XSK_SOCKOPT_RX_PROCESSOR_AFFINITY, &Enabled,
+                    sizeof(Enabled));
+            TEST_TRUE(FAILED(Result));
+
             ProcNumberSize = sizeof(ProcNumber);
             Result =
                 TryGetSockopt(
@@ -7799,6 +7806,13 @@ GenericXskQueryAffinity()
         }
 
         if (Case.Tx) {
+            UINT8 Enabled = TRUE;
+            Result =
+                TrySetSockopt(
+                    Socket.Handle.get(), XSK_SOCKOPT_TX_PROCESSOR_AFFINITY, &Enabled,
+                    sizeof(Enabled));
+            TEST_TRUE(FAILED(Result));
+
             ProcNumberSize = sizeof(ProcNumber);
             Result =
                 TryGetSockopt(


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

The API to query the current CPU is nontrivially expensive, so make the RX/TX ideal processor options disabled by default. This is technically a breaking change, but because nobody is known to be using the APIs at the moment, let's break them ASAP.

## Testing

_Do any existing tests cover this change? Are new tests needed?_
CI.

## Documentation

_Is there any documentation impact for this change?_
Updated.

## Installation

_Is there any installer impact for this change?_
No.