### PR TITLE
make xdp build again on latest wdk

### DIFF
--- a/src/rtl/inc/xdprtl.h
+++ b/src/rtl/inc/xdprtl.h
@@ -108,6 +108,8 @@ XdpRtlStop(
     VOID
     );
 
+#if (!defined(NTDDI_WIN10_NI) || (WDK_NTDDI_VERSION < NTDDI_WIN10_NI))
+
 __forceinline
 VOID
 RtlCopyVolatileMemory(
@@ -119,6 +121,8 @@ RtlCopyVolatileMemory(
     RtlCopyMemory(Destination, (const VOID *)Source, Size);
     _ReadWriteBarrier();
 }
+
+#endif
 
 __forceinline
 HANDLE

--- a/src/rtl/inc/xdprtl.h
+++ b/src/rtl/inc/xdprtl.h
@@ -108,7 +108,7 @@ XdpRtlStop(
     VOID
     );
 
-#if (!defined(NTDDI_WIN10_NI) || (WDK_NTDDI_VERSION < NTDDI_WIN10_NI))
+#ifndef _RTL_VOL_MEM_ACCESSORS_
 
 __forceinline
 VOID

--- a/src/xdp.cpp.props
+++ b/src/xdp.cpp.props
@@ -26,6 +26,7 @@
   <PropertyGroup>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <InfVerif_AdditionalOptions>/rulever 10.0.17763 $(InfVerif_AdditionalOptions)</InfVerif_AdditionalOptions>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TestCode)' == 'true'">
     <OutDir>$(OutDir)test\</OutDir>

--- a/src/xdp/xdp.inx
+++ b/src/xdp/xdp.inx
@@ -17,9 +17,9 @@ xdpapi.dll = 1
 1 = disk
 
 [Manufacturer]
-%Msft% = MSFT,NT$ARCH$.10.0...16299
+%Msft% = MSFT,NT$ARCH$.10.0...17763
 
-[MSFT.NT$ARCH$.10.0...16299]
+[MSFT.NT$ARCH$.10.0...17763]
 %Xdp% = Install, ms_xdp
 
 [Install]

--- a/src/xdp/xdp.inx
+++ b/src/xdp/xdp.inx
@@ -17,9 +17,9 @@ xdpapi.dll = 1
 1 = disk
 
 [Manufacturer]
-%Msft% = MSFT,NT$ARCH$
+%Msft% = MSFT,NT$ARCH$.10.0...16299
 
-[MSFT.NT$ARCH$]
+[MSFT.NT$ARCH$.10.0...16299]
 %Xdp% = Install, ms_xdp
 
 [Install]

--- a/src/xdp/xdp.vcxproj
+++ b/src/xdp/xdp.vcxproj
@@ -137,7 +137,7 @@
       </AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(TargetPlatformVersion)' &gt;= '$(TargetPlatformVersion_NI)'">
+  <ItemDefinitionGroup Condition="'$(TargetPlatformVersion_NI)' != '' AND $(TargetPlatformVersion)' &gt;= '$(TargetPlatformVersion_NI)'">
     <Link>
       <AdditionalDependencies>
         volatileaccessk.lib;

--- a/src/xdp/xdp.vcxproj
+++ b/src/xdp/xdp.vcxproj
@@ -137,7 +137,8 @@
       </AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(TargetPlatformVersion_NI)' != '' AND $(TargetPlatformVersion)' &gt;= '$(TargetPlatformVersion_NI)'">
+  <ItemDefinitionGroup Condition="'$(LatestWdkPlatformVersion)' &gt;= '10.0.26100.0'">
+    <!-- volatileaccessk.lib is introduced in WDK version 10.0.22621.0, i.e., ge_release. -->
     <Link>
       <AdditionalDependencies>
         volatileaccessk.lib;

--- a/src/xdp/xdp.vcxproj
+++ b/src/xdp/xdp.vcxproj
@@ -137,6 +137,14 @@
       </AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(TargetPlatformVersion)' &gt;= '$(TargetPlatformVersion_NI)'">
+    <Link>
+      <AdditionalDependencies>
+        volatileaccessk.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <Inf Include="xdp.inx">
       <CatalogFileName>xdp.cat</CatalogFileName>

--- a/src/xdplwf/precomp.h
+++ b/src/xdplwf/precomp.h
@@ -61,8 +61,6 @@
 
 #ifndef NDIS_RUNTIME_VERSION_688
 #define NDIS_RUNTIME_VERSION_688 ((6 << 16) | 88)
-#else
-C_ASSERT(!"NDIS_RUNTIME_VERSION_688 has been publicly defined. Remove redundant definition.");
 #endif
 
 #pragma warning(disable:4200) // nonstandard extension used: zero-sized array in struct/union

--- a/test/xdpmp/inf/xdpmp.inx
+++ b/test/xdpmp/inf/xdpmp.inx
@@ -10,8 +10,8 @@
  PnpLockdown = 1
 
 [Manufacturer]
-%Msft%=Microsoft, NT$ARCH$.10.0...16299
-[Microsoft.NT$ARCH$.10.0...16299]
+%Msft%=Microsoft, NT$ARCH$.10.0...17763
+[Microsoft.NT$ARCH$.10.0...17763]
 %xdpmp.DeviceDesc%  = xdpmp.ndi,   ms_xdpmp
 
 [xdpmp.ndi.NT]

--- a/test/xdpmp/inf/xdpmp.inx
+++ b/test/xdpmp/inf/xdpmp.inx
@@ -10,8 +10,8 @@
  PnpLockdown = 1
 
 [Manufacturer]
-%Msft%=Microsoft, NT$ARCH$
-[Microsoft.NT$ARCH$]
+%Msft%=Microsoft, NT$ARCH$.10.0...16299
+[Microsoft.NT$ARCH$.10.0...16299]
 %xdpmp.DeviceDesc%  = xdpmp.ndi,   ms_xdpmp
 
 [xdpmp.ndi.NT]


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Resolves #652 

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Tested locally. Newest WDK is not readily available in CI, though with a nuget package, we could do it.

## Documentation

_Is there any documentation impact for this change?_

No, the newest WDK is still not recommended or officially supported for builds by XDP.

## Installation

_Is there any installer impact for this change?_

No.
