### PR TITLE
recant and make runtime nugets per-architecture

### DIFF
--- a/src/xdpruntime/xdp-for-windows-runtime.nuspec.in
+++ b/src/xdpruntime/xdp-for-windows-runtime.nuspec.in
@@ -2,30 +2,30 @@
 <!-- Copyright (c) Microsoft Corporation -->
 <package>
     <metadata>
-        <title>XDP for Windows Runtime</title>
-        <id>XDP-for-Windows-Runtime</id>
+        <title>XDP for Windows Runtime ({arch})</title>
+        <id>XDP-for-Windows-Runtime.{arch}</id>
         <version>{version}</version>
         <authors>XDP for Windows Contributors</authors>
         <owners>XDP for Windows Contributors</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<license type="expression">MIT</license>
         <projectUrl>https://github.com/microsoft/xdp-for-windows</projectUrl>
-        <description>XDP for Windows Runtime</description>
+        <description>XDP for Windows Runtime for {arch}</description>
         <repository type="git" url="https://github.com/microsoft/xdp" commit="{commit}" />
     </metadata>
     <files>
-        <file src="{binpath_anyarch}\xdp-setup.ps1" target="runtime\native\{anyarch}"/>
-        <file src="{binpath_anyarch}\xdpbpfexport.exe" target="runtime\native\{anyarch}"/>
-        <file src="{binpath_anyarch}\xdpbpfexport.pdb" target="runtime\native\{anyarch}"/>
-        <file src="{binpath_anyarch}\xdpcfg.exe" target="runtime\native\{anyarch}"/>
-        <file src="{binpath_anyarch}\xdpcfg.pdb" target="runtime\native\{anyarch}"/>
-        <file src="{binpath_anyarch}\xdppcw.man" target="runtime\native\{anyarch}"/>
-        <file src="{binpath_anyarch}\xdp\xdp.cat" target="runtime\native\{anyarch}"/>
-        <file src="{binpath_anyarch}\xdp\xdp.inf" target="runtime\native\{anyarch}"/>
-        <file src="{binpath_anyarch}\xdp\xdp.sys" target="runtime\native\{anyarch}"/>
-        <file src="{binpath_anyarch}\xdp.pdb" target="runtime\native\{anyarch}"/>
-        <file src="{binpath_anyarch}\xdp\xdpapi.dll" target="runtime\native\{anyarch}"/>
-        <file src="{binpath_anyarch}\xdpapi.pdb" target="runtime\native\{anyarch}"/>
+        <file src="{binpath_anyarch}\xdp-setup.ps1" target="runtime\native"/>
+        <file src="{binpath_anyarch}\xdpbpfexport.exe" target="runtime\native"/>
+        <file src="{binpath_anyarch}\xdpbpfexport.pdb" target="runtime\native"/>
+        <file src="{binpath_anyarch}\xdpcfg.exe" target="runtime\native"/>
+        <file src="{binpath_anyarch}\xdpcfg.pdb" target="runtime\native"/>
+        <file src="{binpath_anyarch}\xdppcw.man" target="runtime\native"/>
+        <file src="{binpath_anyarch}\xdp\xdp.cat" target="runtime\native"/>
+        <file src="{binpath_anyarch}\xdp\xdp.inf" target="runtime\native"/>
+        <file src="{binpath_anyarch}\xdp\xdp.sys" target="runtime\native"/>
+        <file src="{binpath_anyarch}\xdp.pdb" target="runtime\native"/>
+        <file src="{binpath_anyarch}\xdp\xdpapi.dll" target="runtime\native"/>
+        <file src="{binpath_anyarch}\xdpapi.pdb" target="runtime\native"/>
         <file src="{rootpath}\tools\xdptrace.wprp" target="runtime\native"/>
     </files>
 </package>

--- a/tools/update-nuspec.ps1
+++ b/tools/update-nuspec.ps1
@@ -15,6 +15,7 @@ $content = Get-Content $InputFile
 $content = $content.Replace("{commit}", $Commit)
 $content = $content.Replace("{version}", $VersionString)
 $content = $content.Replace("{rootpath}", $RootDir)
+$content = $content.Replace("{arch}", $Platform)
 $content = $content.Replace("{anyarch}", $Platform)
 $content = $content.Replace("{binpath_anyarch}", $(Get-ArtifactBinPath -Platform $Platform -Config $Config))
 set-content $OutputFile $content


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Previously, we decided to make our runtime nuget contain binaries for all architectures. This imposes more burden (package size, signing, etc.) than necessary, so split the runtimes back out. Leave the developer nuget as logically merged, because that is much more convenient for everyone.

## Testing

_Do any existing tests cover this change? Are new tests needed?_
CI.

## Documentation

_Is there any documentation impact for this change?_
No. Runtimes aren't documented yet.

## Installation

_Is there any installer impact for this change?_
Sorta.
