### PR TITLE
fix arm64 barrier optimization

### DIFF
--- a/published/external/afxdp_helper.h
+++ b/published/external/afxdp_helper.h
@@ -82,7 +82,7 @@ XskRingConsumerRelease(
     _In_ UINT32 Count
     )
 {
-    *Ring->SharedConsumer += Count;
+    WriteUInt32Release(Ring->SharedConsumer, *Ring->SharedConsumer + Count);
 }
 
 inline

--- a/published/external/xdp/rtl.h
+++ b/published/external/xdp/rtl.h
@@ -67,7 +67,7 @@ WriteUInt32NoFence(
 
 #endif
 
-#ifdef _M_ARM64_
+#ifdef _M_ARM64
 //
 // A pair of acquire and release operations is sufficient on ARM64
 // because they cannot be reordered relative to each other.

--- a/src/xdp/xsk.c
+++ b/src/xdp/xsk.c
@@ -330,7 +330,7 @@ XskRingConsRelease(
     _In_ UINT32 Count
     )
 {
-    Ring->Shared->ConsumerIndex += Count;
+    WriteUInt32Release(&Ring->Shared->ConsumerIndex, Ring->Shared->ConsumerIndex + Count);
 }
 
 static


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

I used the wrong macro to detect arm64, so we were using a full barrier needlessly.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI

## Documentation

_Is there any documentation impact for this change?_

No

## Installation

_Is there any installer impact for this change?_

No