### PR TITLE
remove clang 11 requirement

### DIFF
--- a/.azure/templates/build.yml
+++ b/.azure/templates/build.yml
@@ -33,14 +33,6 @@ jobs:
       filePath: tools/prepare-machine.ps1
       arguments: -ForBuild -Verbose
 
-  - task: PowerShell@2
-    displayName: Install LLVM 11.0
-    inputs:
-      targetType: inline
-      script: |
-        choco install -y llvm --version 11.0.1 --allow-downgrade
-        Write-Host '##vso[task.prependpath]C:\Program Files\LLVM\bin'
-
   # Use the latest NuGet version so we can reference local NuGet packages.
   - task: NuGetToolInstaller@1
     displayName: 'Use NuGet 6.4.0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,10 +61,6 @@ jobs:
     - name: Prepare Machine
       shell: PowerShell
       run: tools/prepare-machine.ps1 -ForBuild -Verbose -Platform ${{ inputs.platform }}
-    - name: Install LLVM 11.0
-      run: |
-        choco install -y llvm --version 11.0.1 --allow-downgrade
-        echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Nuget Restore
       run: msbuild.exe xdp.sln /t:restore /p:RestoreConfigFile=src/nuget.config /p:Configuration=${{ inputs.config }} /p:Platform=${{ inputs.platform }}
     - name: Prepare for compiling eBPF programs

--- a/docs/development.md
+++ b/docs/development.md
@@ -25,11 +25,9 @@ git submodule update --init --recursive
     - "Desktop development with C++" (via "Workload")
     - Latest Spectre-mitigated libs (via "Individual components")
     - C++ Address Sanitizer (via "Individual components")
+    - C++ Clang Compiler for Windows
 - [Windows Driver Kit](https://docs.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk)
   - WDK for Windows 11, version 22H2 (version 10.0.22621.x) is recommended; WDK for Windows Server 2022 LTSC or newer is required.
-- [LLVM 11.0.1](https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.1/LLVM-11.0.1-win64.exe)
-  - This is required to build eBPF programs. XDP drivers do not require LLVM.
-  - The eBPF project is currently [incompatible](https://github.com/microsoft/ebpf-for-windows/blob/main/docs/GettingStarted.md#prerequisites) with newer LLVM versions.
 - [NuGet Windows x86 Commandline](https://www.nuget.org/downloads)
   - Version 6.3.1 or higher is required by the eBPF-for-Windows project.
 

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -275,10 +275,6 @@ if ($Cleanup) {
         if (!(Get-Command clang.exe)) {
             Write-Error "clang.exe is not detected"
         }
-
-        if (!(cmd /c "clang --version 2>&1" | Select-String "clang version 11.")) {
-            Write-Error "Compiling eBPF programs on Windows requires clang version 11"
-        }
     }
 
     if ($ForFunctionalTest) {


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

eBPF removed the clang version 11 requirement, so remove XDP's matching requirement. Developers should use the latest clang now.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

Yes.

## Installation

_Is there any installer impact for this change?_

No.
