### PR TITLE
make the xsk shared rings more cache-friendly

### DIFF
--- a/src/xdp/xsk.c
+++ b/src/xdp/xsk.c
@@ -296,7 +296,7 @@ XskRingProdReserve(
     )
 {
     UINT32 Available;
-    
+
     //
     // First, try to satisfy the request using the cached consumer index, since another CPU will
     // often own the uncached consumer field's cache line.
@@ -322,7 +322,7 @@ XskRingConsPeek(
     )
 {
     UINT32 Available;
-    
+
     //
     // First, try to satisfy the request using the cached producer index, since another CPU will
     // often own the uncached producer field's cache line.
@@ -598,7 +598,8 @@ XskGetAvailableTxCompletion(
     _In_ UINT32 Count
     )
 {
-    UINT32 XskCompletionAvailable = XskRingProdReserve(&Xsk->Tx.CompletionRing, Count);
+    UINT32 XskCompletionAvailable =
+        XskRingProdReserve(&Xsk->Tx.CompletionRing, Xsk->Tx.Xdp.OutstandingFrames + Count);
 
     if (!NT_VERIFY(XskCompletionAvailable >= Xsk->Tx.Xdp.OutstandingFrames)) {
         //

--- a/src/xdp/xsk.c
+++ b/src/xdp/xsk.c
@@ -19,10 +19,9 @@ typedef enum _XSK_STATE {
 } XSK_STATE;
 
 typedef struct _XSK_SHARED_RING {
-    UINT32 ProducerIndex;
-    UINT32 ConsumerIndex;
-    UINT32 Flags;
-    UINT32 Reserved;
+    DECLSPEC_CACHEALIGN UINT32 ProducerIndex;
+    DECLSPEC_CACHEALIGN UINT32 ConsumerIndex;
+    DECLSPEC_CACHEALIGN UINT32 Flags;
     //
     // Followed by power-of-two array of ring elements, starting on 8-byte alignment.
     // XSK_FRAME_DESCRIPTOR[] for rx/tx, UINT64[] for fill/completion
@@ -31,6 +30,8 @@ typedef struct _XSK_SHARED_RING {
 
 typedef struct _XSK_KERNEL_RING {
     XSK_SHARED_RING *Shared;
+    UINT32 CachedProducerIndex;
+    UINT32 CachedConsumerIndex;
     MDL *Mdl;
     UINT32 Size;
     UINT32 Mask;
@@ -294,9 +295,22 @@ XskRingProdReserve(
     _In_ UINT32 Count
     )
 {
-    UINT32 Available =
-        Ring->Size - (ReadUInt32NoFence(&Ring->Shared->ProducerIndex) -
-            ReadUInt32NoFence(&Ring->Shared->ConsumerIndex));
+    UINT32 Available;
+    
+    //
+    // First, try to satisfy the request using the cached consumer index, since another CPU will
+    // often own the uncached consumer field's cache line.
+    //
+    Available = Ring->Size - Ring->Shared->ProducerIndex - Ring->CachedConsumerIndex;
+    if (Available >= Count) {
+        return Count;
+    }
+
+    //
+    // Update the cached value and return the latest result.
+    //
+    Ring->CachedConsumerIndex = ReadUInt32Acquire(&Ring->Shared->ConsumerIndex);
+    Available = Ring->Size - Ring->Shared->ProducerIndex - Ring->CachedConsumerIndex;
     return min(Available, Count);
 }
 
@@ -307,9 +321,19 @@ XskRingConsPeek(
     _In_ UINT32 Count
     )
 {
-    UINT32 Available =
-        ReadUInt32Acquire(&Ring->Shared->ProducerIndex) -
-            ReadUInt32NoFence(&Ring->Shared->ConsumerIndex);
+    UINT32 Available;
+    
+    //
+    // First, try to satisfy the request using the cached producer index, since another CPU will
+    // often own the uncached producer field's cache line.
+    //
+    Available = Ring->CachedProducerIndex - Ring->Shared->ConsumerIndex;
+    if (Available >= Count) {
+        return Count;
+    }
+
+    Ring->CachedProducerIndex = ReadUInt32Acquire(&Ring->Shared->ProducerIndex);
+    Available = Ring->CachedProducerIndex - Ring->Shared->ConsumerIndex;
     return min(Available, Count);
 }
 
@@ -570,10 +594,11 @@ static
 FORCEINLINE
 UINT32
 XskGetAvailableTxCompletion(
-    _In_ XSK *Xsk
+    _In_ XSK *Xsk,
+    _In_ UINT32 Count
     )
 {
-    UINT32 XskCompletionAvailable = XskRingProdReserve(&Xsk->Tx.CompletionRing, MAXUINT32);
+    UINT32 XskCompletionAvailable = XskRingProdReserve(&Xsk->Tx.CompletionRing, Count);
 
     if (!NT_VERIFY(XskCompletionAvailable >= Xsk->Tx.Xdp.OutstandingFrames)) {
         //
@@ -618,7 +643,7 @@ XskFillTx(
     //
     if (Xsk->Tx.Xdp.PollHandle == NULL &&
         ((XskRingConsPeek(&Xsk->Tx.Ring, 1) == 0 && Xsk->Tx.Xdp.OutstandingFrames == 0) ||
-         (XskGetAvailableTxCompletion(Xsk) == 0)) &&
+         (XskGetAvailableTxCompletion(Xsk, 1) == 0)) &&
          !(Xsk->Tx.Ring.Shared->Flags & XSK_RING_FLAG_NEED_POKE)) {
         InterlockedOrAcquire((LONG *)&Xsk->Tx.Ring.Shared->Flags, XSK_RING_FLAG_NEED_POKE);
     }
@@ -633,11 +658,11 @@ XskFillTx(
     //    - XSK TX operations outstanding
     //
 
-    XskTxAvailable = XskRingConsPeek(&Xsk->Tx.Ring, MAXUINT32);
+    XskTxAvailable = XskRingConsPeek(&Xsk->Tx.Ring, XdpTxAvailable);
+    XskCompletionAvailable = XskGetAvailableTxCompletion(Xsk, XskTxAvailable);
+    Count = XskCompletionAvailable;
 
-    XskCompletionAvailable = XskGetAvailableTxCompletion(Xsk);
-
-    Count = min(min(XdpTxAvailable, XskTxAvailable), XskCompletionAvailable);
+    ASSERT(Count == min(min(XdpTxAvailable, XskTxAvailable), XskCompletionAvailable));
 
     for (ULONG i = 0; i < Count; i++) {
         XDP_FRAME *Frame;
@@ -3125,7 +3150,7 @@ XskSockoptSetRingSize(
         goto Exit;
     }
 
-    Shared = ExAllocatePoolZero(NonPagedPoolNx, AllocationSize, POOLTAG_RING);
+    Shared = ExAllocatePoolZero(NonPagedPoolNxCacheAligned, AllocationSize, POOLTAG_RING);
     if (Shared == NULL) {
         Status = STATUS_INSUFFICIENT_RESOURCES;
         goto Exit;


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

The shared user/kernel rings contain fields that are contended between producers and consumers; in some cases, the previously witnessed values are still usable (i.e., would not block progress) and so may be cached into uncontended memory. This improves performance by reducing inter-processor cache coherence overhead.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No. The improvements are entirely contained within the helper library and XDP runtime.

## Installation

_Is there any installer impact for this change?_

No.