### PR TITLE
try to resolve the previous commit in non-PR runs, too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ on:
 
 jobs:
   build:
-    name: Build ${{ inputs.platform}}_${{ inputs.config }}_${{ inputs.os }} ${{ inputs.ref }}
+    name: Build ${{ inputs.platform}}_${{ inputs.config }}_${{ inputs.os }}
     strategy:
       fail-fast: false
     runs-on: windows-${{ inputs.os }}

--- a/.github/workflows/build_matrix.yml
+++ b/.github/workflows/build_matrix.yml
@@ -38,6 +38,6 @@ jobs:
       config: ${{ matrix.config }}
       os: ${{ matrix.os }}
       platform: ${{ matrix.platform }}
-      ref: ${{ matrix.ref }}
+      ref: ${{ inputs.ref }}
       codeql: ${{ inputs.codeql && github.event_name == 'schedule' }}
       artifact_path: ${{ matrix.os == 2022 && format('bin_{0}_{1}{2}', matrix.config, matrix.platform, (inputs.id != '' && format('_{0}', inputs.id) || '')) || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       id: resolve_base_ref
       shell: PowerShell
       run: |
-        $BaseRef = "" TODO: pass github.base_ref here
+        $BaseRef = "" #TODO: pass github.base_ref here
         if ([string]::IsNullOrEmpty($BaseRef)) {
           $BaseRef = git log --pretty=%P -n 1 ${{ github.sha }}
         }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         if ([string]::IsNullOrEmpty($BaseRef)) {
           $BaseRef = git log --pretty=%P -n 1 ${{ github.sha }}
         }
-        echo "base_ref=$BaseRef >> $env:GITHUB_OUTPUT"
+        echo "base_ref=$BaseRef" >> $env:GITHUB_OUTPUT
 
   build_base:
     name: Build (${{ needs.resolve_base.outputs.base_ref }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           $BaseRef = git log --pretty=%P -n 1 ${{ github.sha }}
         #}
         echo "base_ref=$BaseRef"
-        echo "base_ref=$BaseRef" >> $env:GITHUB_OUTPUT
+        Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "base_ref=$BaseRef"
 
   build_base:
     name: Build (Base Ref)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
         if ([string]::IsNullOrEmpty($BaseRef)) {
           $BaseRef = git log --pretty=%P -n 1 ${{ github.sha }}
         }
+        echo "base_ref=$BaseRef"
         echo "base_ref=$BaseRef" >> $env:GITHUB_OUTPUT
 
   build_base:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
       with:
         repository: microsoft/xdp-for-windows
+        fetch-depth: 2
     - name: Resolve base commit reference
       id: resolve_base_ref
       shell: PowerShell
@@ -51,7 +52,7 @@ jobs:
         echo "base_ref=$BaseRef" >> $env:GITHUB_OUTPUT
 
   build_base:
-    name: Build (${{ needs.resolve_base.outputs.base_ref }})
+    name: Build (Base Ref)
     needs: resolve_base
     permissions:
       security-events: write  # For CodeQL (even though it is not enabled)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
       with:
         repository: microsoft/xdp-for-windows
         submodules: recursive
-        ref: ${{ inputs.ref }}
     - name: Download x64 Artifacts
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
       shell: PowerShell
       run: |
         $BaseRef = "" #TODO: pass github.base_ref here
-        if ([string]::IsNullOrEmpty($BaseRef)) {
+        #if ([string]::IsNullOrEmpty($BaseRef)) {
           $BaseRef = git log --pretty=%P -n 1 ${{ github.sha }}
-        }
+        #}
         echo "base_ref=$BaseRef"
         echo "base_ref=$BaseRef" >> $env:GITHUB_OUTPUT
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,13 @@ jobs:
       shell: PowerShell
       run: |
         $BaseRef = "" #TODO: pass github.base_ref here
-        #if ([string]::IsNullOrEmpty($BaseRef)) {
+        if ([string]::IsNullOrEmpty($BaseRef)) {
           $BaseRef = git log --pretty=%P -n 1 ${{ github.sha }}
-        #}
+        }
+        if (($BaseRef -split " ").Count -gt 1) {
+          Write-Warning "BaseRef has multiple parents. Choosing first of $BaseRef"
+          $BaseRef = ($BaseRef -split " ")[0]
+        }
         echo "base_ref=$BaseRef"
         Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "base_ref=$BaseRef"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,10 @@ jobs:
     - name: Resolve base commit reference
       id: resolve_base_ref
       shell: PowerShell
+      # For PR runs, this returns essentially returns "main", or the target branch.
+      # For non-PR runs, this returns the first parent of the current commit.
       run: |
-        $BaseRef = "" #TODO: pass github.base_ref here
+        $BaseRef = "${{ github.base_ref }}"
         if ([string]::IsNullOrEmpty($BaseRef)) {
           $BaseRef = git log --pretty=%P -n 1 ${{ github.sha }}
         }
@@ -52,7 +54,7 @@ jobs:
           Write-Warning "BaseRef has multiple parents. Choosing first of $BaseRef"
           $BaseRef = ($BaseRef -split " ")[0]
         }
-        echo "base_ref=$BaseRef"
+        Write-Output "base_ref=$BaseRef"
         Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "base_ref=$BaseRef"
 
   build_base:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,34 @@ jobs:
       security-events: write  # For CodeQL
     uses: ./.github/workflows/build_matrix.yml
 
+  resolve_base:
+    name: Resolve base commit reference
+    runs-on: windows-2022
+    outputs:
+      base_ref: ${{ steps.resolve_base_ref.outputs.base_ref }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+      with:
+        repository: microsoft/xdp-for-windows
+    - name: Resolve base commit reference
+      id: resolve_base_ref
+      shell: PowerShell
+      run: |
+        $BaseRef = "" TODO: pass github.base_ref here
+        if ([string]::IsNullOrEmpty($BaseRef)) {
+          $BaseRef = git log --pretty=%P -n 1 ${{ github.sha }}
+        }
+        echo "base_ref=$BaseRef >> $env:GITHUB_OUTPUT"
+
   build_base:
-    name: Build (${{ github.base_ref }})
-    if: ${{ github.base_ref != '' }}
+    name: Build (${{ needs.resolve_base.outputs.base_ref }})
+    needs: resolve_base
     permissions:
       security-events: write  # For CodeQL (even though it is not enabled)
     uses: ./.github/workflows/build_matrix.yml
     with:
-      ref: ${{ github.base_ref }}
+      ref: ${{ needs.resolve_base.outputs.base_ref }}
       id: "baseref"
       codeql: false
 
@@ -295,7 +315,7 @@ jobs:
 
   perf_tests:
     name: Perf Tests
-    needs: [build, build_base]
+    needs: [build, build_base, resolve_base]
     env:
       ITERATIONS: ${{ (github.event_name != 'pull_request') && '8' || '3' }}
     timeout-minutes: 75 # Ideally this would be only 25 min for PR runs, but GitHub Actions don't support that.
@@ -327,15 +347,13 @@ jobs:
         os: ${{ matrix.windows }}
         platform: ${{ matrix.platform }}
     - uses: ./.github/actions/perf
-      if: ${{ github.base_ref != '' }}
       with:
         config: ${{ matrix.configuration }}
         os: ${{ matrix.windows }}
         platform: ${{ matrix.platform }}
-        ref: ${{ github.base_ref }}
+        ref: ${{ needs.resolve_base.outputs.base_ref }}
         id: "baseref"
     - name: Compare Results
-      if: ${{ github.base_ref != '' }}
       shell: PowerShell
       run: tools\xskperfcompare.ps1 -DataFile1 baseref/artifacts/logs/xskperfsuite.csv -DataFile2 artifacts/logs/xskperfsuite.csv
 


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

#706 only supported PR runs, and broke non-PR runs. Try to fix that so we compare the current `github.ref` to the previous commit for non-PRs. Also, #706 was fundamentally broken: it failed to actually build the base_ref, and instead built ref again.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.