### PR TITLE
remove support for vs2019 in builds

### DIFF
--- a/.github/workflows/build_matrix.yml
+++ b/.github/workflows/build_matrix.yml
@@ -24,10 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Some driver developers are building for WS2022 LTSC targets using VS2019 +
-        # the Windows Server 2022 WDK, so validate our project still builds in that
-        # environment, in addition to the default WS 2022.
-        os: [2019, 2022]
+        os: [2022]
         config: [Release, Debug]
         platform: [x64, arm64]
         exclude:

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,7 +19,7 @@ git submodule update --init --recursive
 ### Prerequisites
 
 - [Visual Studio](https://visualstudio.microsoft.com/downloads/)
-  - Visual Studio 2022 is recommended; Visual Studio 2019 or newer is required.
+  - Visual Studio 2022 or newer is required.
 
   during installation, ensure the following packages/components are installed:
     - "Desktop development with C++" (via "Workload")

--- a/src/xdplwf/precomp.h
+++ b/src/xdplwf/precomp.h
@@ -13,14 +13,7 @@
 #include <ntintsafe.h>
 #include <ntstrsafe.h>
 #include <ndis.h>
-#if _MSC_VER < 1930
-#pragma warning(push)
-#pragma warning(disable:4090) // 'function': different 'const' qualifiers
-#endif
 #include <ndis/ndl/mdl.h>
-#if _MSC_VER < 1930
-#pragma warning(pop)
-#endif
 #include <ndis/ndl/nblqueue.h>
 #include <ndis/ndl/nblclassify.h>
 #include <netiodef.h>

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -21,7 +21,11 @@
 #include <lm.h>
 #include <sddl.h>
 #include <string.h>
+
+#pragma warning(push)
+#pragma warning(disable:26457) // (void) should not be used to ignore return values, use 'std::ignore =' instead (es.48)
 #include <wil/resource.h>
+#pragma warning(pop)
 
 #include <afxdp_helper.h>
 #include <xdpapi.h>

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -21,22 +21,7 @@
 #include <lm.h>
 #include <sddl.h>
 #include <string.h>
-
-#if _MSCVER < 1930
-//
-// WIL causes VS2019 to warn on benign errors.
-//
-#pragma warning(push)
-#pragma warning(disable:6001)
-#pragma warning(disable:6387)
-#endif
-#pragma warning(push)
-#pragma warning(disable:26457) // (void) should not be used to ignore return values, use 'std::ignore =' instead (es.48)
 #include <wil/resource.h>
-#pragma warning(pop)
-#if _MSCVER < 1930
-#pragma warning(pop)
-#endif
 
 #include <afxdp_helper.h>
 #include <xdpapi.h>

--- a/test/pktfuzz/pktfuzz.c
+++ b/test/pktfuzz/pktfuzz.c
@@ -212,16 +212,3 @@ Exit:
 
     return Result;
 }
-
-#if _MSC_VER < 1930
-int
-__cdecl
-main()
-{
-    //
-    // Provide a dummy main() function for the VS2019 compiler; it does not
-    // support LibFuzzer.
-    //
-    return 1;
-}
-#endif


### PR DESCRIPTION
## Description

We had added support for building the entire XDP project in VS2019 because some native XDP driver developers were using VS2019 for their existing NIC codebases several years ago. VS2019 has broken our build yet again.

Since the time horizon to VS2025 is presumably shorter than the horizon to native XDP, and because building a third-party XDP driver doesn't actually require building the entire XDP project (it only needs its headers and output libs) stop building VS2019 in automation.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

Updated required VS version.

## Installation

No.
