### PR TITLE
fix two reads missing volatile NoFence reads in test/dbg code

### DIFF
--- a/src/rtl/xdprtl.c
+++ b/src/rtl/xdprtl.c
@@ -50,7 +50,7 @@ RtlRandomNumber(
     // in order to get the mod operation for free.
     //
     do {
-        OldValue = *RandomState;
+        OldValue = ReadNoFence(RandomState);
         NewValue = (1664525 * OldValue) + 1013904223;
     } while (InterlockedCompareExchangeNoFence(RandomState, NewValue, OldValue) != OldValue);
 

--- a/test/xdpmp/hwring.h
+++ b/test/xdpmp/hwring.h
@@ -149,7 +149,7 @@ HwRingBestEffortMpReserve(
     KeRaiseIrql(DISPATCH_LEVEL, OldIrql);
     do {
         OldProducerReserved = ReadUInt32NoFence(&Ring->ProducerReserved);
-        Count = Ring->Mask + 1 - (OldProducerReserved - Ring->ConsumerIndex);
+        Count = Ring->Mask + 1 - (OldProducerReserved - ReadUInt32NoFence(&Ring->ConsumerIndex));
         Count = min(MaxCount, Count);
     } while (InterlockedCompareExchangeAcquire(
                 (LONG *)&Ring->ProducerReserved, OldProducerReserved + Count, OldProducerReserved)

--- a/test/xdpmp/hwring.h
+++ b/test/xdpmp/hwring.h
@@ -148,7 +148,7 @@ HwRingBestEffortMpReserve(
 
     KeRaiseIrql(DISPATCH_LEVEL, OldIrql);
     do {
-        OldProducerReserved = Ring->ProducerReserved;
+        OldProducerReserved = ReadUInt32NoFence(&Ring->ProducerReserved);
         Count = Ring->Mask + 1 - (OldProducerReserved - Ring->ConsumerIndex);
         Count = min(MaxCount, Count);
     } while (InterlockedCompareExchangeAcquire(


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

From code review, two variables get read without the necessary volatile accessors, potentially leading to undefined behavior.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.