### PR TITLE
Re-enable CPU profiling on arm64

### DIFF
--- a/tools/log.ps1
+++ b/tools/log.ps1
@@ -85,11 +85,6 @@ $LogsDir = "$RootDir\artifacts\logs"
 
 & $RootDir/tools/prepare-machine.ps1 -ForLogging -Platform $Platform
 
-if ($Platform -eq "arm64" -and (@("CpuCswitchSample", "CpuSample") -contains $Profile.Split(".")[0])) {
-    Write-Warning "Skipping sampling profile: not currently supported on arm64."
-    return
-}
-
 if (!$EtlPath) {
     $EtlPath = "$LogsDir\$Name.etl"
 }
@@ -119,12 +114,8 @@ try {
         Write-Verbose "wpr.exe -stop $EtlPath -instancename $Name"
         cmd /c "wpr.exe -stop $EtlPath -instancename $Name 2>&1"
         if ($LastExitCode -ne 0) {
-            if ($Platform -eq "arm64" -and $LastExitCode -eq -984076288) {
-                Write-Warning "Suppressing failure to stop trace (error code = not running) on arm64"
-            } else {
-                Write-Host "##vso[task.setvariable variable=NeedsReboot]true"
-                Write-Error "wpr.exe failed: $LastExitCode"
-            }
+            Write-Host "##vso[task.setvariable variable=NeedsReboot]true"
+            Write-Error "wpr.exe failed: $LastExitCode"
         }
 
         # Enumerate log file sizes.

--- a/tools/spinxsk.ps1
+++ b/tools/spinxsk.ps1
@@ -127,7 +127,10 @@ while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes))
         if (!$NoLogs) {
             & "$RootDir\tools\log.ps1" -Start -Name spinxsk -Profile SpinXsk.Verbose -Config $Config -Platform $Platform
             & "$RootDir\tools\log.ps1" -Start -Name spinxskebpf -Profile SpinXskEbpf.Verbose -LogMode Memory -Config $Config -Platform $Platform
-            & "$RootDir\tools\log.ps1" -Start -Name spinxskcpu -Profile CpuCswitchSample.Verbose -Config $Config -Platform $Platform
+            if ($Platform -ne "arm64") {
+                # Our spinxsk pool does not yet support Gen6 VMs, so skip the profile.
+                & "$RootDir\tools\log.ps1" -Start -Name spinxskcpu -Profile CpuCswitchSample.Verbose -Config $Config -Platform $Platform
+            }
         }
         if ($XdpmpPollProvider -eq "FNDIS") {
             Write-Verbose "installing fndis..."
@@ -194,7 +197,10 @@ while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes))
             & "$RootDir\tools\setup.ps1" -Uninstall fndis -Config $Config -Platform $Platform -ErrorAction 'Continue'
         }
         if (!$NoLogs) {
-            & "$RootDir\tools\log.ps1" -Stop -Name spinxskcpu -Config $Config -Platform $Platform -ErrorAction 'Continue'
+            if ($Platform -ne "arm64") {
+                # Our spinxsk pool does not yet support Gen6 VMs, so skip the profile.
+                & "$RootDir\tools\log.ps1" -Stop -Name spinxskcpu -Config $Config -Platform $Platform -ErrorAction 'Continue'
+            }
             & "$RootDir\tools\log.ps1" -Stop -Name spinxskebpf -Config $Config -Platform $Platform -ErrorAction 'Continue'
             & "$RootDir\tools\log.ps1" -Stop -Name spinxsk -Config $Config -Platform $Platform -ErrorAction 'Continue'
         }


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

We've upgraded our amd64 perf pool to gen6 VMs, which support CPU profiling, so re-enable that profile in our logging script. Our spinxsk pool is in a different region, which doesn't yet have gen6 VMs, so keep profiling disabled there.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI. Verified ETLs are uploaded for perf runs.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.