### PR TITLE
fix XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES when RSS is not supported

### DIFF
--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -1360,7 +1360,11 @@ XdpProgramAttach(
             TRACE_CORE, "Attaching ProgramObject=%p to all %u queues",
             ProgramObject, RssCapabilities.NumberOfReceiveQueues);
         QueueIdStart = 0;
-        QueueIdEnd = RssCapabilities.NumberOfReceiveQueues;
+
+        //
+        // Ensure the implicit 0th queue is bound when RSS is not supported.
+        //
+        QueueIdEnd = max(1, RssCapabilities.NumberOfReceiveQueues);
     }
 
     for (UINT32 QueueId = QueueIdStart; QueueId < QueueIdEnd; ++QueueId) {


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

If a NIC does not support RSS, it will report zero RSS queues. In that case, the program should bind to the implicit 0th queue for all traffic.

Resolves #734 

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Regression tests. This is not a generally important XDP scenario for testing, since all medium- and high-performance NICs support RSS.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.
