### PR TITLE
fix up a few cases where user mode was assumed

### DIFF
--- a/samples/xskfwd/xskfwdkm.h
+++ b/samples/xskfwd/xskfwdkm.h
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+
+#pragma once
+
+static
+VOID
+DriverUnload(
+    _In_ DRIVER_OBJECT *DriverObject
+    )
+{
+
+}
+
+_Function_class_(DRIVER_INITIALIZE)
+_IRQL_requires_same_
+_IRQL_requires_(PASSIVE_LEVEL)
+NTSTATUS
+DriverEntry(
+    _In_ struct _DRIVER_OBJECT *DriverObject,
+    _In_ PUNICODE_STRING RegistryPath
+    )
+{
+    NTSTATUS Status;
+    UNICODE_STRING DeviceName;
+
+#pragma prefast(suppress : __WARNING_BANNED_MEM_ALLOCATION_UNSAFE, "Non executable pool is enabled via -DPOOL_NX_OPTIN_AUTO=1.")
+    ExInitializeDriverRuntime(0);
+
+    DriverObject->DriverUnload = DriverUnload;
+
+Exit:
+
+    if (!NT_SUCCESS(Status)) {
+        DriverUnload(DriverObject);
+    }
+
+    return Status;
+}

--- a/src/xdp/xsk.c
+++ b/src/xdp/xsk.c
@@ -2996,12 +2996,6 @@ XskSockoptSetUmem(
         goto Exit;
     }
 
-    //
-    // If support is needed for kernel mode AF_XDP sockets, UMEM MDL setup
-    // needs more thought.
-    //
-    ASSERT(RequestorMode == UserMode);
-
     Umem->Mapping.Mdl =
         IoAllocateMdl(
             Umem->Reg.Address,
@@ -3709,7 +3703,7 @@ XskPollSocket(
             } else {
                 Status =
                     KeWaitForSingleObject(
-                        &Xsk->PollRequested, UserRequest, UserMode, FALSE, WaitTimePtr);
+                        &Xsk->PollRequested, UserRequest, ExGetPreviousMode(), FALSE, WaitTimePtr);
                 if (Status != STATUS_SUCCESS) {
                     return Status;
                 }
@@ -4293,7 +4287,7 @@ XskNotify(
         Timeout.QuadPart = -1 * RTL_MILLISEC_TO_100NANOSEC(TimeoutMilliseconds);
         Status =
             KeWaitForSingleObject(
-                &Xsk->IoWaitEvent, UserRequest, UserMode, FALSE,
+                &Xsk->IoWaitEvent, UserRequest, ExGetPreviousMode(), FALSE,
                 (TimeoutMilliseconds == XDP_INFINITE) ? NULL : &Timeout);
     } else {
         ASSERT(Status == STATUS_PENDING);


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

From code review, there are a few places where we assume/assert the IO caller is user mode.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Not yet - adding test coverage and any final fixes in a standalone PR officially adding KM support.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.