### PR TITLE
xdpmp: use correct alignment macro for type

### DIFF
--- a/test/xdpmp/miniport.c
+++ b/test/xdpmp/miniport.c
@@ -393,7 +393,7 @@ MpInitialize(
     }
 
     Adapter->MdlSize = (UINT32)MmSizeOfMdl((VOID *)(PAGE_SIZE - 1), Adapter->RxBufferLength);
-    Adapter->MdlSize = ALIGN_UP(Adapter->MdlSize, MEMORY_ALLOCATION_ALIGNMENT);
+    Adapter->MdlSize = ALIGN_UP_BY(Adapter->MdlSize, MEMORY_ALLOCATION_ALIGNMENT);
     if (Adapter->MdlSize > MAXUSHORT) {
         TraceError(
             TRACE_CONTROL, "NdisMiniportHandle=%p Error: MdlSize too large MdlSize=%lu",


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

XDPMP was aligning up by `sizeof(MEMORY_ALLOCATION_ALIGNMENT)` instead of by `MEMORY_ALLOCATION_ALIGNMENT`.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_

## Installation

_Is there any installer impact for this change?_
