### PR TITLE
add driver start callback API

### DIFF
--- a/published/external/xdpapi.h
+++ b/published/external/xdpapi.h
@@ -52,6 +52,26 @@ XdpInterfaceOpen(
     _Out_ HANDLE *InterfaceHandle
     );
 
+#ifdef _KERNEL_MODE
+
+DECLARE_HANDLE(XDP_CALLBACK_HANDLE);
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+XDP_STATUS
+XdpRegisterDriverStartCallback(
+    _Out_ XDP_CALLBACK_HANDLE *CallbackRegistration,
+    _In_ PCALLBACK_FUNCTION CallbackFunction,
+    _In_opt_ VOID *CallbackContext
+    );
+
+_IRQL_requires_max_(PASSIVE_LEVEL)
+VOID
+XdpDeregisterDriverStartCallback(
+    _In_ XDP_CALLBACK_HANDLE CallbackRegistration
+    );
+
+#endif
+
 #include <xdp/details/xdpapi.h>
 #endif
 

--- a/src/xdp/dispatch.c
+++ b/src/xdp/dispatch.c
@@ -505,22 +505,6 @@ Exit:
     return Status;
 }
 
-// TODO remove
-static
-_IRQL_requires_same_
-_Function_class_(CALLBACK_FUNCTION)
-VOID
-XdpDriverCallback(
-    _In_opt_ PVOID CallbackContext,
-    _In_opt_ PVOID Argument1,
-    _In_opt_ PVOID Argument2
-    )
-{
-    UNREFERENCED_PARAMETER(CallbackContext);
-    UNREFERENCED_PARAMETER(Argument1);
-    UNREFERENCED_PARAMETER(Argument2);
-}
-
 static
 NTSTATUS
 XdpNotifyDriverStart(


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Add a driver start callback API. This callback will be invoked each time the XDP driver has been started.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI for callback producer.

## Documentation

_Is there any documentation impact for this change?_

This API will remain undocumented.

## Installation

_Is there any installer impact for this change?_

No.