### PR TITLE
Add support for binding XDP to NDIS provider_address layer

### DIFF
--- a/src/xdp/xdp.inx
+++ b/src/xdp/xdp.inx
@@ -20,7 +20,8 @@ xdpapi.dll = 1
 %Msft% = MSFT,NT$ARCH$.10.0...17763
 
 [MSFT.NT$ARCH$.10.0...17763]
-%Xdp% = Install, ms_xdp
+XDP = Install, ms_xdp
+XDP_PA = Install_PA, ms_xdp_pa
 
 [Install]
 Characteristics     = %NCF_LW_FILTER%
@@ -28,6 +29,13 @@ NetCfgInstanceId    = "{c0be1ebc-74b8-4ba9-8c1e-ecd227e2be3b}"
 CopyFiles           = Drivers_Dir
 CopyFiles           = System_Dir
 AddReg              = XDP.NDI
+
+[Install_PA]
+Characteristics     = %NCF_LW_FILTER%
+NetCfgInstanceId    = "{c0be1ebc-74b8-4ba9-8c1e-ecd227e2be3b}"
+CopyFiles           = Drivers_Dir
+CopyFiles           = System_Dir
+AddReg              = XDP_PA.NDI
 
 [Drivers_Dir]
 xdp.sys
@@ -46,7 +54,21 @@ HKR, Ndi\Interfaces, UpperRange,, "noupper"
 HKR, Ndi\Interfaces, LowerRange,, "ndisvf"
 HKR, Ndi\Interfaces, FilterMediaTypes,, "ethernet, ndisvf"
 
+[XDP_PA.NDI]
+HKR, Ndi, Service,, "xdp"
+HKR, Ndi, CoServices, %REG_MULTI_SZ%, "xdp"
+HKR, Ndi, HelpText,, "%XdpDescription%"
+HKR, Ndi, FilterClass,, provider_address
+HKR, Ndi, FilterType, %REG_DWORD%, %FILTER_TYPE_MODIFYING%
+HKR, Ndi, FilterRunType, %REG_DWORD%, %FILTER_RUN_TYPE_OPTIONAL%
+HKR, Ndi\Interfaces, UpperRange,, "noupper"
+HKR, Ndi\Interfaces, LowerRange,, "ndisvf"
+HKR, Ndi\Interfaces, FilterMediaTypes,, "ethernet, ndisvf"
+
 [Install.Services]
+AddService=xdp,, AddService
+
+[Install_PA.Services]
 AddService=xdp,, AddService
 
 [AddService]
@@ -84,7 +106,6 @@ DelService = xdp, %SPSVCINST_STOPSERVICE%
 [Strings]
 ; localizable strings
 Msft                = "Microsoft Corporation"
-Xdp                 = "XDP"
 XdpDescription      = "Microsoft XDP Platform Driver"
 
 ; non-localizable strings

--- a/src/xdpinstaller/product.wxs
+++ b/src/xdpinstaller/product.wxs
@@ -23,19 +23,25 @@ SPDX-License-Identifier: MIT
             <Feature Id="xdp_ebpf" Level="10" AllowAdvertise="no" Title="XDP eBPF" Description="Experimental eBPF support. NOT officially supported.">
                 <ComponentGroupRef Id="xdp_ebpf" />
             </Feature>
+            <Feature Id="xdp_pa" Level="10" AllowAdvertise="no" Title="XDP PA Layer" Description="Bind XDP lower in the NDIS filter stack.">
+                <ComponentGroupRef Id="xdp_pa" />
+            </Feature>
         </Feature>
 
         <InstallExecuteSequence>
             <!--Rollback sequence-->
             <Custom Action="xdp_uninstall_rollback" Before="xdp_install" Condition="NOT Installed" />
             <Custom Action="xdp_ebpf_uninstall_rollback" Before="xdp_ebpf_install" Condition="NOT Installed" />
+            <Custom Action="xdp_pa_uninstall_rollback" Before="xdp_pa_install" Condition="NOT Installed" />
 
             <!--Install sequence-->
             <Custom Action="xdp_install" After="InstallFiles" Condition="NOT Installed" />
             <Custom Action="xdp_ebpf_install" After="xdp_install" Condition="(&amp;xdp_ebpf=3) AND NOT(!xdp_ebpf=3)" />
+            <Custom Action="xdp_pa_install" After="xdp_install" Condition="(&amp;xdp_pa=3) AND NOT(!xdp_pa=3)" />
 
             <!--Uninstall sequence-->
-            <Custom Action="xdp_ebpf_uninstall" After="InstallInitialize" Condition="(&amp;xdp_ebpf=2) AND (!xdp_ebpf=3)" />
+            <Custom Action="xdp_pa_uninstall" After="InstallInitialize" Condition="(&amp;xdp_pa=2) AND (!xdp_pa=3)" />
+            <Custom Action="xdp_ebpf_uninstall" After="xdp_pa_uninstall" Condition="(&amp;xdp_ebpf=2) AND (!xdp_ebpf=3)" />
             <Custom Action="xdp_uninstall" After="xdp_ebpf_uninstall" Condition="REMOVE=&quot;ALL&quot;" />
         </InstallExecuteSequence>
 
@@ -105,6 +111,10 @@ SPDX-License-Identifier: MIT
             </Component>
         </ComponentGroup>
 
+        <ComponentGroup Id="xdp_pa" Directory="INSTALLFOLDER">
+            <ComponentGroupRef Id="xdp" />
+        </ComponentGroup>
+
         <!-- Install/Uninstall/Rollback the XDP driver installation -->
         <SetProperty Id="xdp_install" Value="&quot;[System64Folder]WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass &quot;&amp; '[#xdp_setup_ps1]' -Install xdp -Verbose&quot;" Before="xdp_install" Sequence="execute" />
         <CustomAction Id="xdp_install" DllEntry="WixQuietExec64" Execute="deferred" Return="check" Impersonate="no" BinaryRef="Wix4UtilCA_X86" />
@@ -124,5 +134,15 @@ SPDX-License-Identifier: MIT
 
         <SetProperty Id="xdp_ebpf_uninstall_rollback" Value="&quot;[System64Folder]WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass &quot;&amp; '[#xdp_setup_ps1]' -Uninstall xdpebpf -Verbose&quot;" Before="xdp_ebpf_uninstall_rollback" Sequence="execute" />
         <CustomAction Id="xdp_ebpf_uninstall_rollback" DllEntry="WixQuietExec64" Execute="rollback" Return="ignore" Impersonate="no" BinaryRef="Wix4UtilCA_X86" />
+
+        <!-- Install/Uninstall/Rollback the XDP PA driver installation -->
+        <SetProperty Id="xdp_pa_install" Value="&quot;[System64Folder]WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass &quot;&amp; '[#xdp_setup_ps1]' -Install xdppa -Verbose&quot;" Before="xdp_pa_install" Sequence="execute" />
+        <CustomAction Id="xdp_pa_install" DllEntry="WixQuietExec64" Execute="deferred" Return="check" Impersonate="no" BinaryRef="Wix4UtilCA_X86" />
+
+        <SetProperty Id="xdp_pa_uninstall" Value="&quot;[System64Folder]WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass &quot;&amp; '[#xdp_setup_ps1]' -Uninstall xdppa -Verbose&quot;" Before="xdp_pa_uninstall" Sequence="execute" />
+        <CustomAction Id="xdp_pa_uninstall" DllEntry="WixQuietExec64" Execute="deferred" Return="ignore" Impersonate="no" BinaryRef="Wix4UtilCA_X86" />
+
+        <SetProperty Id="xdp_pa_uninstall_rollback" Value="&quot;[System64Folder]WindowsPowerShell\v1.0\powershell.exe&quot; -ExecutionPolicy Bypass &quot;&amp; '[#xdp_setup_ps1]' -Uninstall xdppa -Verbose&quot;" Before="xdp_pa_uninstall_rollback" Sequence="execute" />
+        <CustomAction Id="xdp_pa_uninstall_rollback" DllEntry="WixQuietExec64" Execute="rollback" Return="ignore" Impersonate="no" BinaryRef="Wix4UtilCA_X86" />
     </Fragment>
 </Wix>

--- a/tools/functional.ps1
+++ b/tools/functional.ps1
@@ -149,6 +149,18 @@ for ($i = 1; $i -le $Iterations; $i++) {
             Write-Error "[$i/$Iterations] xdpfunctionaltests failed with $LastExitCode" -ErrorAction Continue
             $IterationFailureCount++
         }
+
+        # Sanity test the XDP_PA installer.
+
+        Write-Verbose "Reinstalling XDP at PA layer..."
+        & "$RootDir\tools\setup.ps1" -Uninstall xdp -Config $Config -Platform $Platform
+        & "$RootDir\tools\setup.ps1" -Install xdp -Config $Config -Platform $Platform -EnableEbpf -PaLayer
+        Write-Verbose "Installed XDP PA layer."
+
+        if (!(Get-NetAdapterBinding -ComponentID ms_xdp_pa)) {
+            Write-Error "[$i/$Iterations] XDP_PA failed to install" -ErrorAction Continue
+            $IterationFailureCount++
+        }
     } finally {
         if ($Watchdog -ne $null) {
             Remove-Job -Job $Watchdog -Force

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -45,7 +45,10 @@ param (
     [string]$XdpInstaller = "MSI",
 
     [Parameter(Mandatory = $false)]
-    [switch]$EnableEbpf = $false
+    [switch]$EnableEbpf = $false,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$PaLayer = $false
 )
 
 Set-StrictMode -Version 'Latest'
@@ -263,10 +266,16 @@ function Install-Xdp {
     if ($XdpInstaller -eq "MSI") {
         $XdpPath = Get-XdpInstallPath
 
-        $AddLocal = ""
+        $AddLocal = @()
 
         if ($EnableEbpf) {
-            $AddLocal = "ADDLOCAL=xdp_ebpf"
+            $AddLocal += "xdp_ebpf"
+        }
+        if ($PaLayer) {
+            $AddLocal += "xdp_pa"
+        }
+        if ($AddLocal) {
+            $AddLocal = "ADDLOCAL=$($AddLocal -join ",")"
         }
 
         Write-Verbose "msiexec.exe /i $XdpMsiFullPath INSTALLFOLDER=$XdpPath $AddLocal /quiet /l*v $LogsDir\xdpinstall.txt"


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

In some scenarios, there may be other LWFs bound to the same `custom` layer of the filter stack, causing XDP to be placed in an unpredictable order relative to the other LWFs. Since `custom` is still the closest matching NDIS-defined layer for XDP to bind to, continue to use that layer by default.

Allow the MSI and runtime install script to optionally bind XDP to the even lower layer `provider_address`. This should be used only if the `custom` layer leads to conflicts in specific environments.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Sanity test added for end-to-end installer flow.

## Documentation

_Is there any documentation impact for this change?_

This will remain an undocumented feature for now, to avoid customers proactively or unnecessarily binding to `provider_address`, potentially exacerbating an arms race to be the "lowest" LWF filter.

## Installation

_Is there any installer impact for this change?_

Yes.