### PR TITLE
Allow xdp to build from detached HEAD state on dev box

### DIFF
--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -35,14 +35,10 @@ function Invoke-WebRequest-WithRetry {
 
 function Get-CurrentBranch {
     $env:GIT_REDIRECT_STDERR = '2>&1'
-    $CurrentBranch = $null
-    try {
-        $CurrentBranch = git branch --show-current
-        if ([string]::IsNullOrWhiteSpace($CurrentBranch)) {
-            throw
-        }
-    } catch {
-        Write-Error "Failed to get branch from git"
+    $CurrentBranch = git branch --show-current
+    if ([string]::IsNullOrWhiteSpace($CurrentBranch)) {
+        Write-Warning "Failed to get branch from git"
+        return $null
     }
     return $CurrentBranch
 }


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Resolves #710 by allowing developers to build the project in detached HEAD state on dev boxes. This now only raises a warning, because official builds depend on deducing the target branch or tag.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Verified locally.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.