### PR TITLE
clean up stale global msbuild property

### DIFF
--- a/src/xdp.props
+++ b/src/xdp.props
@@ -6,8 +6,6 @@
     <XdpPatchVersion>0</XdpPatchVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Project-wide properties -->
-    <WntPackagePath>$(SolutionDir)packages\win-net-test.1.2.0\</WntPackagePath>
     <!-- Undocked project properties -->
     <UndockedDir>$(SolutionDir)submodules\cxplat\submodules\undocked\</UndockedDir>
     <UndockedOut>$(SolutionDir)artifacts\</UndockedOut>


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

`WntPackagePath` was defined twice, and the first definition is wrong and unconditionally overridden.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.