### PR TITLE
extend functional test runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,10 +158,10 @@ jobs:
     needs: build
     env:
       # For 'main' commits
-      fullRuntime: 250 # minutes. Update timeout-minutes with any changes.
+      fullRuntime: 360 # minutes. Update timeout-minutes with any changes.
       fullIters: 10
       # For PRs
-      prRuntime: 25 # minutes. Update timeout-minutes with any changes.
+      prRuntime: 36 # minutes. Update timeout-minutes with any changes.
       prIters: 1
     strategy:
       fail-fast: false
@@ -197,12 +197,12 @@ jobs:
     - name: Run Tests (PR)
       if: ${{ github.event_name == 'pull_request' }}
       shell: PowerShell
-      timeout-minutes: 25
+      timeout-minutes: 36
       run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Iterations ${{ env.prIters }} -Timeout ${{ env.fullRuntime }}
     - name: Run Tests (main)
       if: ${{ github.event_name != 'pull_request' }}
       shell: PowerShell
-      timeout-minutes: 250
+      timeout-minutes: 360
       run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Iterations ${{ env.fullIters }} -Timeout ${{ env.fullRuntime }}
     - name: Convert Logs
       if: ${{ always() }}


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

There have been a few instances of functional tests running beyond the current timeout in `main` tests, so bump the timeout again. In the long run, we need to find a way to speed up the slow tests, e.g., move spin tests into dedicate spin jobs, run tests in parallel.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

No.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.