### PR TITLE
silently ignore non-existent files

### DIFF
--- a/src/xdpruntime/xdp-setup.ps1
+++ b/src/xdpruntime/xdp-setup.ps1
@@ -84,6 +84,16 @@ function Cleanup-Service($Name) {
     }
 }
 
+function Cleanup-File($Path) {
+    Write-Verbose "Cleaning up $Path"
+    if (Test-Path $Path) {
+        Write-Verbose "Remove-Item $Path -Force"
+        Remove-Item $Path -Force
+    } else {
+        Write-Verbose "$Path did not exist"
+    }
+}
+
 # Helper to uninstall a driver from its inf file.
 function Uninstall-Driver($Inf) {
     # Expected pnputil enum output is:
@@ -155,8 +165,8 @@ function Uninstall-XdpComponent($ComponentId) {
 
     Cleanup-Service xdp
 
-    Remove-Item $env:WINDIR\system32\xdpapi.dll -Force
-    Remove-Item $env:WINDIR\system32\drivers\xdp.sys -Force
+    Cleanup-File $env:WINDIR\system32\xdpapi.dll
+    Cleanup-File $env:WINDIR\system32\drivers\xdp.sys
 
     Write-Verbose "xdp.sys uninstall complete!"
 }


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

The XDP installer script produces an error when uninstalling an already uninstalled component, which was not by design. Attempt to remove files only if they actually exist.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.