### PR TITLE
Rename xdp_md_ to xdp_md

### DIFF
--- a/published/external/xdp/ebpfhook.h
+++ b/published/external/xdp/ebpfhook.h
@@ -19,7 +19,7 @@ extern "C" {
 
 #ifndef XDP_EXT_HELPER_FN_BASE
 
-typedef struct xdp_md_ {
+typedef struct xdp_md {
     void *data;               ///< Pointer to start of packet data.
     void *data_end;           ///< Pointer to end of packet data.
     uint64_t data_meta;       ///< Packet metadata.


### PR DESCRIPTION
## Description

struct xdp_md was incorrectly named with xdp_md_.
The ebpf programs use 'struct xdp_md" in the internal project. Hence renaming the struct to the libbpf standard.

## Testing

_Do any existing tests cover this change? Yes Are new tests needed?No

## Documentation

_Is there any documentation impact for this change? No

## Installation

_Is there any installer impact for this change? No
