### PR TITLE
un-support ipv6 extensions with tx offload for now

### DIFF
--- a/src/xdplwf/send.c
+++ b/src/xdplwf/send.c
@@ -224,8 +224,6 @@ XdpGenericBuildTxNbl(
                 break;
 
             case XdpFrameLayer3TypeIPv6NoExtensions:
-            case XdpFrameLayer3TypeIPv6UnspecifiedExtensions:
-            case XdpFrameLayer3TypeIPv6WithExtensions:
                 const IPV6_HEADER *Ipv6 = RTL_PTR_ADD(Mdl->MappedSystemVa, sizeof(ETHERNET_HEADER));
 
                 if (Buffer->DataLength < sizeof(ETHERNET_HEADER) + sizeof(*Ipv6) ||

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -6428,7 +6428,7 @@ GenericTxChecksumOffloadUdp(
     Layout->Layer2HeaderLength = sizeof(ETHERNET_HEADER);
     Layout->Layer3Type =
         Af == AF_INET6 ?
-            XdpFrameLayer3TypeIPv6UnspecifiedExtensions : XdpFrameLayer3TypeIPv4UnspecifiedOptions;
+            XdpFrameLayer3TypeIPv6NoExtensions : XdpFrameLayer3TypeIPv4UnspecifiedOptions;
     Layout->Layer3HeaderLength = Af == AF_INET6 ? sizeof(IPV6_HEADER) : sizeof(IPV4_HEADER);
     Layout->Layer4Type = XdpFrameLayer4TypeUdp;
     Layout->Layer4HeaderLength = sizeof(UDP_HDR);

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -6348,7 +6348,7 @@ GenericTxChecksumOffloadTcp(
     Layout->Layer2HeaderLength = sizeof(ETHERNET_HEADER);
     Layout->Layer3Type =
         Af == AF_INET6 ?
-            XdpFrameLayer3TypeIPv6UnspecifiedExtensions : XdpFrameLayer3TypeIPv4UnspecifiedOptions;
+            XdpFrameLayer3TypeIPv6NoExtensions : XdpFrameLayer3TypeIPv4UnspecifiedOptions;
     Layout->Layer3HeaderLength = Af == AF_INET6 ? sizeof(IPV6_HEADER) : sizeof(IPV4_HEADER);
     Layout->Layer4Type = XdpFrameLayer4TypeTcp;
     Layout->Layer4HeaderLength = sizeof(TCP_HDR);


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

We were already implicitly supporting only no-extension IPv6 for checksum offloads, so formalize this for now. We can add full support for IPv6 extensions in the future if we get a customer ask, which will require more careful validation on behalf of NICs.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Updated.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.