### PR TITLE
rxfilter: use sample-only cpu profile

### DIFF
--- a/tools/rxfilterperf.ps1
+++ b/tools/rxfilterperf.ps1
@@ -61,7 +61,7 @@ try {
     Write-Verbose "Set-NetAdapterRss XDPMP -NumberOfReceiveQueues $QueueCount"
     Set-NetAdapterRss XDPMP -NumberOfReceiveQueues $QueueCount
 
-    & "$RootDir\tools\log.ps1" -Start -Name rxfiltercpu -Profile CpuCswitchSample.Verbose -Config $Config -Platform $Platform
+    & "$RootDir\tools\log.ps1" -Start -Name rxfiltercpu -Profile CpuSample.Verbose -Config $Config -Platform $Platform
 
     $ArgList = `
         "-IfIndex", (Get-NetAdapter -Name XDPMP).ifIndex, `


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

I accidentally used sample + precise profile in the new rxfilter perf test, which introduces a ton of profiling overhead. Switch to the intended profile.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.