### PR TITLE
rxfilterperf: test both LWF and native XDP code paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,9 +432,12 @@ jobs:
     - name: Prepare Machine
       shell: PowerShell
       run: tools/prepare-machine.ps1 -ForPerfTest -Platform ${{ matrix.platform }} -RequireNoReboot -Verbose
-    - name: Run rxfilter (drop)
+    - name: Run rxfilter (drop, generic)
       shell: PowerShell
-      run: tools/rxfilterperf.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Verbose -Fndis -QueueCount 4 -Action Drop
+      run: tools/rxfilterperf.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Verbose -Fndis -QueueCount 4 -Action Drop -XdpMode Generic
+    - name: Run rxfilter (drop, native)
+      shell: PowerShell
+      run: tools/rxfilterperf.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Verbose -Fndis -QueueCount 4 -Action Drop -XdpMode Native
     - name: Upload Logs
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
       if: ${{ always() }}

--- a/tools/rxfilterperf.ps1
+++ b/tools/rxfilterperf.ps1
@@ -61,7 +61,7 @@ try {
     Write-Verbose "Set-NetAdapterRss XDPMP -NumberOfReceiveQueues $QueueCount"
     Set-NetAdapterRss XDPMP -NumberOfReceiveQueues $QueueCount
 
-    & "$RootDir\tools\log.ps1" -Start -Name rxfiltercpu -Profile CpuCswitchSample.Verbose -Config $Config -Platform $Platform
+    & "$RootDir\tools\log.ps1" -Start -Name rxfiltercpu_$XdpMode -Profile CpuCswitchSample.Verbose -Config $Config -Platform $Platform
 
     $ArgList = `
         "-IfIndex", (Get-NetAdapter -Name XDPMP).ifIndex, `
@@ -90,7 +90,7 @@ try {
         Stop-Process -InputObject $RxFilterProcess
     }
 
-    & "$RootDir\tools\log.ps1" -Stop -Name rxfiltercpu -Config $Config -Platform $Platform -ErrorAction 'Continue'
+    & "$RootDir\tools\log.ps1" -Stop -Name rxfiltercpu_$XdpMode -Config $Config -Platform $Platform -ErrorAction 'Continue'
 
     & "$RootDir\tools\setup.ps1" -Uninstall xdpmp -Config $Config -Platform $Platform -ErrorAction 'Continue'
     & "$RootDir\tools\setup.ps1" -Uninstall xdp -Config $Config -Platform $Platform -ErrorAction 'Continue'


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

We are testing only the "system" mode by default, which for XDPMP defaults to native mode. Since the LWF mode is what all scenarios currently use, we need to add coverage for that, too.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.