### PR TITLE
remove dead perf dashboard link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,6 @@
 used to send and receive packets at high rates by bypassing most of the OS networking stack.
 
 [![CI](https://github.com/microsoft/xdp-for-windows/actions/workflows/ci.yml/badge.svg)](https://github.com/microsoft/xdp-for-windows/actions/workflows/ci.yml)
-[![Perf Dashboard](https://img.shields.io/static/v1?label=Performance&message=Dashboard&color=blue)](https://microsoft.github.io/xdp-for-windows/)
 
 ## Documentation
 


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

I noticed we still have a link to a performance dashboard on our GitHub page, but that dashboard's underlying data has been removed. Remove the link to the dashboard for now.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

No.

## Documentation

_Is there any documentation impact for this change?_

Stale documentation removed.

## Installation

_Is there any installer impact for this change?_

No.