### PR TITLE
Force inline XdppReceiveBatch

### DIFF
--- a/src/xdp/rx.c
+++ b/src/xdp/rx.c
@@ -176,6 +176,7 @@ XdpFlushReceive(
 }
 
 static
+FORCEINLINE
 _IRQL_requires_max_(DISPATCH_LEVEL)
 VOID
 XdppReceiveBatch(


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

The `XdppReceiveBatch` routine calls a parameterized inspection routine for each frame in a batch, and the routine is always known at compile time. However, our arm64 builds do not inline this routine, causing an indirect function call at runtime, which is showing up as a hot spot in perf graphs.

Force the compiler to inline this routine and (hopefully) convert the function parameter to a direct call.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI. Verified arm64 assembly is as expected locally.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.