### PR TITLE
fix up stats macros to use atomic get/set

### DIFF
--- a/src/rtl/inc/xdprtl.h
+++ b/src/rtl/inc/xdprtl.h
@@ -50,6 +50,10 @@
 #define ReadUInt64NoFence ReadULong64NoFence
 #endif
 
+#ifndef WriteUInt64NoFence
+#define WriteUInt64NoFence WriteULong64NoFence
+#endif
+
 #ifndef htons
 #define htons _byteswap_ushort
 #endif

--- a/src/xdppcw/inc/xdppcw.h
+++ b/src/xdppcw/inc/xdppcw.h
@@ -45,9 +45,9 @@ typedef struct _XDP_PCW_LWF_TX_QUEUE {
     UINT64 FramesInvalidChecksumOffload;
 } XDP_PCW_LWF_TX_QUEUE;
 
-#define STAT_INC(_Stats, _Field) (((_Stats)->_Field)++)
-#define STAT_ADD(_Stats, _Field, _Bias) (((_Stats)->_Field) += (_Bias))
-#define STAT_SET(_Stats, _Field, _Value) (((_Stats)->_Field) = (_Value))
+#define STAT_SET(_Stats, _Field, _Value) WriteUInt64NoFence(&((_Stats)->_Field), (_Value))
+#define STAT_ADD(_Stats, _Field, _Bias) STAT_SET(_Stats, _Field, ReadUInt64NoFence(&((_Stats)->_Field)) + (_Bias))
+#define STAT_INC(_Stats, _Field) STAT_ADD(_Stats, _Field, 1)
 
 #ifdef KERNEL_MODE
 //


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Our stats macros were using plain read/write operations, which could result in torn values. This was somewhat acceptable, but we might as well ensure the operations are atomic.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.