### PR TITLE
add perf tests without memcpy

### DIFF
--- a/.github/actions/perf/action.yml
+++ b/.github/actions/perf/action.yml
@@ -62,6 +62,9 @@ runs:
   - name: Run xskperfsuite (TX-inspect, RX-inject)
     shell: PowerShell
     run: ./${{ inputs.id }}/tools/xskperfsuite.ps1 -Verbose -Config ${{ inputs.config }} -Platform ${{ inputs.platform }} -Fndis -Iterations ${{ env.ITERATIONS }} -XdpModes "Generic" -TxInspect -RxInject -RawResultsFile "./${{ inputs.id }}/artifacts/logs/xskperfsuite.csv" -XperfDirectory "./${{ inputs.id }}/artifacts/logs" -CommitHash ${{ github.sha }}
+  - name: Run xskperfsuite (ZerocopySimulation)
+    shell: PowerShell
+    run: ./${{ inputs.id }}/tools/xskperfsuite.ps1 -Verbose -Config ${{ inputs.config }} -Platform ${{ inputs.platform }} -Fndis -Iterations ${{ env.ITERATIONS }} -ZerocopySimulation -RawResultsFile "./${{ inputs.id }}/artifacts/logs/xskperfsuite.csv" -XperfDirectory "./${{ inputs.id }}/artifacts/logs" -CommitHash ${{ github.sha }}
   - name: Run xskperfsuite (Winsock, RIO)
     shell: PowerShell
     run: ./${{ inputs.id }}/tools/xskperfsuite.ps1 -Verbose -Config ${{ inputs.config }} -Platform ${{ inputs.platform }} -Fndis -Iterations ${{ env.ITERATIONS }} -XdpModes "Winsock", "RIO" -Modes "RX", "TX" -RawResultsFile "./${{ inputs.id }}/artifacts/logs/xskperfsuite.csv" -XperfDirectory "./${{ inputs.id }}/artifacts/logs" -CommitHash ${{ github.sha }}

--- a/tools/xskperf.ps1
+++ b/tools/xskperf.ps1
@@ -167,10 +167,10 @@ if ($AdapterRss.BaseProcessorGroup -ne 0 -or
 }
 
 Write-Verbose "reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XskDisableTxBounce /d $([int]!!$ZerocopySimulation) /t REG_DWORD /f"
-reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XskDisableTxBounce /d [int]!!$ZerocopySimulation /t REG_DWORD /f | Write-Verbose
+reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XskDisableTxBounce /d $([int]!!$ZerocopySimulation) /t REG_DWORD /f | Write-Verbose
 
 Write-Verbose "reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XskRxZeroCopy /d $([int]!!$ZerocopySimulation) /t REG_DWORD /f"
-reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XskRxZeroCopy /d [int]!!$ZerocopySimulation /t REG_DWORD /f | Write-Verbose
+reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XskRxZeroCopy /d $([int]!!$ZerocopySimulation) /t REG_DWORD /f | Write-Verbose
 
 Write-Verbose "Restarting XDP"
 Restart-Service xdp

--- a/tools/xskperf.ps1
+++ b/tools/xskperf.ps1
@@ -166,11 +166,11 @@ if ($AdapterRss.BaseProcessorGroup -ne 0 -or
     $NicReset = $true
 }
 
-Write-Verbose "reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XskDisableTxBounce /d $([int]$ZerocopySimulation) /t REG_DWORD /f"
-reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XskDisableTxBounce /d [int]$ZerocopySimulation /t REG_DWORD /f | Write-Verbose
+Write-Verbose "reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XskDisableTxBounce /d $([int]!!$ZerocopySimulation) /t REG_DWORD /f"
+reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XskDisableTxBounce /d [int]!!$ZerocopySimulation /t REG_DWORD /f | Write-Verbose
 
-Write-Verbose "reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XskRxZeroCopy /d $([int]$ZerocopySimulation) /t REG_DWORD /f"
-reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XskRxZeroCopy /d [int]$ZerocopySimulation /t REG_DWORD /f | Write-Verbose
+Write-Verbose "reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XskRxZeroCopy /d $([int]!!$ZerocopySimulation) /t REG_DWORD /f"
+reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XskRxZeroCopy /d [int]!!$ZerocopySimulation /t REG_DWORD /f | Write-Verbose
 
 Write-Verbose "Restarting XDP"
 Restart-Service xdp

--- a/tools/xskperf.ps1
+++ b/tools/xskperf.ps1
@@ -64,6 +64,9 @@ param (
     [switch]$RateSimulation = $false,
 
     [Parameter(Mandatory=$false)]
+    [switch]$ZerocopySimulation = $false,
+
+    [Parameter(Mandatory=$false)]
     [switch]$LargePages = $false,
 
     [Parameter(Mandatory=$false)]
@@ -162,6 +165,12 @@ if ($AdapterRss.BaseProcessorGroup -ne 0 -or
         -Profile ClosestStatic
     $NicReset = $true
 }
+
+Write-Verbose "reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XskDisableTxBounce /d $([int]$ZerocopySimulation) /t REG_DWORD /f"
+reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XskDisableTxBounce /d [int]$ZerocopySimulation /t REG_DWORD /f | Write-Verbose
+
+Write-Verbose "reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XskRxZeroCopy /d $([int]$ZerocopySimulation) /t REG_DWORD /f"
+reg.exe add HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XskRxZeroCopy /d [int]$ZerocopySimulation /t REG_DWORD /f | Write-Verbose
 
 Write-Verbose "Restarting XDP"
 Restart-Service xdp

--- a/tools/xskperfsuite.ps1
+++ b/tools/xskperfsuite.ps1
@@ -41,6 +41,9 @@ param (
     [switch]$DeepInspection = $false,
 
     [Parameter(Mandatory=$false)]
+    [switch]$ZerocopySimulation = $false,
+
+    [Parameter(Mandatory=$false)]
     [switch]$LargePages = $false,
 
     [Parameter(Mandatory=$false)]
@@ -182,6 +185,9 @@ try {
                         if ($Fndis) {
                             $Options += "-FNDIS"
                         }
+                        if ($ZerocopySimulation) {
+                            $Options += "-ZEROCOPY"
+                        }
 
                         $ScenarioName = `
                             $AdapterName `
@@ -208,6 +214,7 @@ try {
                                     -UdpDstPort $UdpDstPort -XdpMode $XdpMode -LargePages:$LargePages `
                                     -RxInject:$RxInject -TxInspect:$TxInspect `
                                     -TxInspectContentionCount $TxInspectContentionCount `
+                                    -ZerocopySimulation:$ZerocopySimulation `
                                     -SocketCount:$SocketCount -Fndis:$Fndis -Config $Config `
                                     -Platform $Platform -XperfFile $XperfFile
 


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

To determine the performance cost of AF_XDP memcpy, run the tests with both RX and TX copying disabled. This also provides an estimate of the eventual performance of a native zerocopy driver API.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.