### PR TITLE
use JSON instead of CSV for xskperfsuite and perf comparison script

### DIFF
--- a/.github/actions/perf/action.yml
+++ b/.github/actions/perf/action.yml
@@ -58,13 +58,13 @@ runs:
       path: ./${{ inputs.id }}/artifacts/bin
   - name: Run xskperfsuite (Generic, Native)
     shell: PowerShell
-    run: ./${{ inputs.id }}/tools/xskperfsuite.ps1 -Verbose -Config ${{ inputs.config }} -Platform ${{ inputs.platform }} -Fndis -Iterations ${{ env.ITERATIONS }} -RawResultsFile "./${{ inputs.id }}/artifacts/logs/xskperfsuite.csv" -XperfDirectory "./${{ inputs.id }}/artifacts/logs" -CommitHash ${{ github.sha }}
+    run: ./${{ inputs.id }}/tools/xskperfsuite.ps1 -Verbose -Config ${{ inputs.config }} -Platform ${{ inputs.platform }} -Fndis -Iterations ${{ env.ITERATIONS }} -RawResultsFile "./${{ inputs.id }}/artifacts/logs/xskperfsuite.json" -XperfDirectory "./${{ inputs.id }}/artifacts/logs" -CommitHash ${{ github.sha }}
   - name: Run xskperfsuite (TX-inspect, RX-inject)
     shell: PowerShell
-    run: ./${{ inputs.id }}/tools/xskperfsuite.ps1 -Verbose -Config ${{ inputs.config }} -Platform ${{ inputs.platform }} -Fndis -Iterations ${{ env.ITERATIONS }} -XdpModes "Generic" -TxInspect -RxInject -RawResultsFile "./${{ inputs.id }}/artifacts/logs/xskperfsuite.csv" -XperfDirectory "./${{ inputs.id }}/artifacts/logs" -CommitHash ${{ github.sha }}
+    run: ./${{ inputs.id }}/tools/xskperfsuite.ps1 -Verbose -Config ${{ inputs.config }} -Platform ${{ inputs.platform }} -Fndis -Iterations ${{ env.ITERATIONS }} -XdpModes "Generic" -TxInspect -RxInject -RawResultsFile "./${{ inputs.id }}/artifacts/logs/xskperfsuite.json" -XperfDirectory "./${{ inputs.id }}/artifacts/logs" -CommitHash ${{ github.sha }}
   - name: Run xskperfsuite (Winsock, RIO)
     shell: PowerShell
-    run: ./${{ inputs.id }}/tools/xskperfsuite.ps1 -Verbose -Config ${{ inputs.config }} -Platform ${{ inputs.platform }} -Fndis -Iterations ${{ env.ITERATIONS }} -XdpModes "Winsock", "RIO" -Modes "RX", "TX" -RawResultsFile "./${{ inputs.id }}/artifacts/logs/xskperfsuite.csv" -XperfDirectory "./${{ inputs.id }}/artifacts/logs" -CommitHash ${{ github.sha }}
+    run: ./${{ inputs.id }}/tools/xskperfsuite.ps1 -Verbose -Config ${{ inputs.config }} -Platform ${{ inputs.platform }} -Fndis -Iterations ${{ env.ITERATIONS }} -XdpModes "Winsock", "RIO" -Modes "RX", "TX" -RawResultsFile "./${{ inputs.id }}/artifacts/logs/xskperfsuite.json" -XperfDirectory "./${{ inputs.id }}/artifacts/logs" -CommitHash ${{ github.sha }}
   - name: Upload Logs
     uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
     if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,7 +365,7 @@ jobs:
         id: "baseref"
     - name: Compare Results
       shell: PowerShell
-      run: tools\xskperfcompare.ps1 -DataFile1 baseref/artifacts/logs/xskperfsuite.csv -DataFile2 artifacts/logs/xskperfsuite.csv
+      run: tools\perfcompare.ps1 -DataFile1 baseref/artifacts/logs/xskperfsuite.csv -DataFile2 artifacts/logs/xskperfsuite.csv -Metric pps
 
   ring_perf_tests:
     name: Ring Perf Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,7 +365,7 @@ jobs:
         id: "baseref"
     - name: Compare Results
       shell: PowerShell
-      run: tools\perfcompare.ps1 -DataFile1 baseref/artifacts/logs/xskperfsuite.csv -DataFile2 artifacts/logs/xskperfsuite.csv -Metric pps
+      run: tools\perfcompare.ps1 -DataFile1 baseref/artifacts/logs/xskperfsuite.json -DataFile2 artifacts/logs/xskperfsuite.json -Metric pps
 
   ring_perf_tests:
     name: Ring Perf Tests

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -211,6 +211,10 @@ function Get-XdpBuildVersionString {
     return $VersionString;
 }
 
+function Get-OsBuildVersionString {
+    return (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion').BuildLabEx
+}
+
 # Returns whether the script is running as a built-in administrator.
 function Test-Admin {
     return ([Security.Principal.WindowsPrincipal] `
@@ -290,4 +294,30 @@ function Initiate-Bugcheck {
 
     Write-Host "$NotMyFault -accepteula -bugcheck $Code"
     & $NotMyFault -accepteula -bugcheck $Code
+}
+
+function New-PerfData {
+    param (
+        [Parameter()]
+        [string]$ScenarioName,
+
+        [Parameter()]
+        [string]$Platform,
+
+        [Parameter()]
+        [string]$CommitHash,
+
+        [Parameter()]
+        [hashtable[]]$Metrics
+    )
+
+    return @{
+        ScenarioName = $ScenarioName
+        Platform = $Platform
+        CommitHash = $CommitHash
+        Timestamp = (Get-Date).toString("o")
+        OsBuild = Get-OsBuildVersionString
+        MachineName = $env:ComputerName
+        Metrics = $Metrics
+    }
 }

--- a/tools/perfcompare.ps1
+++ b/tools/perfcompare.ps1
@@ -16,11 +16,34 @@ param (
 Set-StrictMode -Version 'Latest'
 $ErrorActionPreference = 'Stop'
 
+function ImportCsvDataset {
+    param($File)
+
+    $dataset = [ordered]@{}
+
+    $contents = Get-Content $File
+
+    foreach ($line in $contents) {
+        $array = $line.Split(",")
+        $scenarioName = $array[0]
+        $scenarioData = $array[3..$array.Count]
+        $dataset.Add($scenarioName, $scenarioData)
+    }
+
+    return $dataset
+}
+
 function ImportDataset {
     param($File)
 
     $dataset = [ordered]@{}
-    $contents = Get-Content -Raw $File | ConvertFrom-Json
+
+    try {
+        $contents = Get-Content -Raw $File | ConvertFrom-Json
+    } catch {
+        Write-Warning "Failed to parse $File as JSON. Attempting to parse as legacy CSV."
+        return ImportCsvDataset $File
+    }
 
     foreach ($data in $contents) {
         $scenarioName = $data.ScenarioName

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -98,7 +98,7 @@ if ($RequireNoReboot) {
 
 # Log the OS version.
 Write-Verbose "Querying OS BuildLabEx"
-(Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion').BuildLabEx | Write-Verbose
+Get-OsBuildVersionString | Write-Verbose
 
 function Download-CoreNet-Deps {
     $CoreNetCiCommit = Get-CoreNetCiCommit


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Instead using of an opaque, fragile, and hard-to-extend CSV file to store performance data, use JSON. The JSON file is an array of perf test cases, with each test case containing an array of metrics, along with other metadata.

Sample output file:

```
[
    {
        "MachineName":  "WINLATEST",
        "Timestamp":  "2025-01-08T16:56:55.6232183-05:00",
        "CommitHash":  "",
        "Metrics":  [
                        {
                            "Scale":  1000,
                            "Name":  "pps",
                            "Value":  5140.379
                        }
                    ],
        "ScenarioName":  "XDPMP-GENERIC-RX-BUSY-2048chunksize-64iosize",
        "Platform":  "x64",
        "OsBuild":  "26330.5002.amd64fre.ge_current_directiof.241117-1100"
    },
    {
        "MachineName":  "WINLATEST",
        "Timestamp":  "2025-01-08T16:57:04.2804892-05:00",
        "CommitHash":  "",
        "Metrics":  [
                        {
                            "Scale":  1000,
                            "Name":  "pps",
                            "Value":  8207.655
                        }
                    ],
        "ScenarioName":  "XDPMP-GENERIC-RX-BUSY-2048chunksize-64iosize",
        "Platform":  "x64",
        "OsBuild":  "26330.5002.amd64fre.ge_current_directiof.241117-1100"
    }
]
```

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI. Validated locally, too.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.