### PR TITLE
bump perf test timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,7 +328,7 @@ jobs:
     needs: [build, build_base, resolve_base]
     env:
       ITERATIONS: ${{ (github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch' ) && '8' || '3' }}
-    timeout-minutes: 90 # Ideally this would be only 30 min for PR runs, but GitHub Actions don't support that.
+    timeout-minutes: 120 # Ideally this would be only 30 min for PR runs, but GitHub Actions don't support that.
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Our perf tests started timing out in main after I added a zerocopy test. Bump the timeout again.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.