### PR TITLE
remove CSV perf data support

### DIFF
--- a/tools/perfcompare.ps1
+++ b/tools/perfcompare.ps1
@@ -16,34 +16,11 @@ param (
 Set-StrictMode -Version 'Latest'
 $ErrorActionPreference = 'Stop'
 
-function ImportCsvDataset {
-    param($File)
-
-    $dataset = [ordered]@{}
-
-    $contents = Get-Content $File
-
-    foreach ($line in $contents) {
-        $array = $line.Split(",")
-        $scenarioName = $array[0]
-        $scenarioData = $array[3..$array.Count]
-        $dataset.Add($scenarioName, $scenarioData)
-    }
-
-    return $dataset
-}
-
 function ImportDataset {
     param($File)
 
     $dataset = [ordered]@{}
-
-    try {
-        $contents = Get-Content -Raw $File | ConvertFrom-Json
-    } catch {
-        Write-Warning "Failed to parse $File as JSON. Attempting to parse as legacy CSV."
-        return ImportCsvDataset $File
-    }
+    $contents = Get-Content -Raw $File | ConvertFrom-Json
 
     foreach ($data in $contents) {
         $scenarioName = $data.ScenarioName


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

When making a breaking change to the perf schema, we had to keep support for the old schema when we compare to build N-1. Now that build N-1 also uses JSON, remove CSV.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.