### PR TITLE
Further refactor perf data creation into common.ps1

### DIFF
--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -296,6 +296,36 @@ function Initiate-Bugcheck {
     & $NotMyFault -accepteula -bugcheck $Code
 }
 
+function New-PerfDataSet {
+    param (
+        [Parameter()]
+        [string[]]$Files = @()
+    )
+
+    $Results = [System.Collections.ArrayList]::new()
+
+    foreach ($File in $Files) {
+        if (-not [string]::IsNullOrEmpty($File) -and (Test-Path $File)) {
+            $Results.AddRange($(Get-Content -Raw $File | ConvertFrom-Json))
+        }
+    }
+
+    return Write-Output -NoEnumerate $Results
+}
+
+function Write-PerfDataSet {
+    param (
+        [Parameter()]
+        [object]$DataSet,
+
+        [Parameter()]
+        [string]$File
+    )
+
+    New-Item -ItemType Directory -Force -Path (Split-Path $File) | Out-Null
+    $DataSet | ConvertTo-Json -Depth 100 | Out-File -FilePath $File -Encoding utf8
+}
+
 function New-PerfData {
     param (
         [Parameter()]

--- a/tools/xskperfsuite.ps1
+++ b/tools/xskperfsuite.ps1
@@ -205,11 +205,7 @@ try {
                         }
 
                         try {
-                            $Results = [System.Collections.ArrayList]::new()
-
-                            if (-not [string]::IsNullOrEmpty($RawResultsFile) -and (Test-Path $RawResultsFile)) {
-                                $Results.AddRange($(Get-Content -Raw $RawResultsFile | ConvertFrom-Json))
-                            }
+                            $Results = New-PerfDataSet -Files $RawResultsFile
 
                             for ($i = 0; $i -lt $Iterations; $i++) {
                                 $TmpFile = [System.IO.Path]::GetTempFileName()
@@ -246,7 +242,7 @@ try {
                             Write-Host $($Format -f $ScenarioName, [Math]::ceiling($avg), [Math]::ceiling($stddev))
 
                             if (-not [string]::IsNullOrEmpty($RawResultsFile)) {
-                                Set-Content -Path $RawResultsFile -Value $($Results | ConvertTo-Json -Depth 100)
+                                Write-PerfDataSet -DataSet $Results -File $RawResultsFile
                             }
                         } catch {
                             Write-Error "$($PSItem.Exception.Message)`n$($PSItem.ScriptStackTrace)"


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

This unblocks #786 by splitting the refactoring of perf data out from the new summary steps. This also ensures arbitrary file paths can be specified for the filename by creating the parent directory, if necessary.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.