### PR TITLE
remove uninitialized pool allocation

### DIFF
--- a/src/xdp/xsk.c
+++ b/src/xdp/xsk.c
@@ -582,7 +582,7 @@ XskAllocateTxBounceBuffer(
         //
         ASSERT(Bounce->AllocationSource == NotAllocated);
         Bounce->Mapping.SystemAddress =
-            ExAllocatePoolUninitialized(NonPagedPoolNx, Xsk->Umem->Reg.TotalSize, POOLTAG_BOUNCE);
+            ExAllocatePoolZero(NonPagedPoolNx, Xsk->Umem->Reg.TotalSize, POOLTAG_BOUNCE);
         if (Bounce->Mapping.SystemAddress == NULL) {
             Status = STATUS_NO_MEMORY;
             goto Exit;


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

The TX bounce buffer is currently allocated without initialization, which is functionally correct and reasonably secure (the contents are not mapped into user space). For defense in depth, consistently use zero'd pool allocations across XDP unless the perf cost is unacceptable.

Some code paths may implicitly use non-initialized memory (e.g. NBLs allocated by NDIS) and are out of scope.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.