### PR TITLE
Make XDP build in OneBranch again

### DIFF
--- a/samples/directory.build.props
+++ b/samples/directory.build.props
@@ -1,3 +1,4 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" Condition="'$([MSBuild]::GetPathOfFileAbove(%27Directory.Build.props%27, %27$(MSBuildThisFileDirectory)../%27))' != ''" />
   <Import Project="$(SolutionDir)test\xdp.test.props" />
 </Project>

--- a/samples/directory.build.props
+++ b/samples/directory.build.props
@@ -1,4 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Pull in parent Directory.Build.props, if it exists. OneBranch auto-injects into the root. -->
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)../))" Condition="'$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)../))' != ''" />
   <Import Project="$(SolutionDir)test\xdp.test.props" />
 </Project>

--- a/samples/directory.build.props
+++ b/samples/directory.build.props
@@ -1,4 +1,4 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" Condition="'$([MSBuild]::GetPathOfFileAbove(%27Directory.Build.props%27, %27$(MSBuildThisFileDirectory)../%27))' != ''" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)../))" Condition="'$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)../))' != ''" />
   <Import Project="$(SolutionDir)test\xdp.test.props" />
 </Project>

--- a/src/onebranch/onebranch.vcxproj
+++ b/src/onebranch/onebranch.vcxproj
@@ -26,9 +26,6 @@
   <Target Name="Catalog" Condition="'$(BuildStage)' == 'Catalog'" AfterTargets="Build" >
       <MSBuild Projects="$(SolutionDir)src\xdp\xdp.vcxproj" Targets="Inf2Cat" Properties="EnableInf2Cat=true"/>
   </Target>
-  <Target Name="PackageMsi" Condition="'$(BuildStage)' == 'Package'" AfterTargets="Package" >
-      <MSBuild Projects="$(SolutionDir)src\xdpinstaller\xdpinstaller.wixproj" Targets="Build"/>
-  </Target>
   <ItemGroup Condition="'$(BuildStage)' == 'AllPackage'">
     <ProjectReference Include="$(SolutionDir)src\nuget\nuget.vcxproj">
       <Project>{fbf60d12-183d-42d1-b884-8b9fa4f1273f}</Project>

--- a/src/xdp.props
+++ b/src/xdp.props
@@ -34,7 +34,7 @@
     <PackageReference Include="win-net-test" Version="1.2.0" GeneratePathProperty="true" Condition="'$(ImportWnt)' == 'true'"/>
   </ItemGroup>
     <!-- TODO: remove or understand this OneBranch workaround. -->
-  <Import Project="$(SolutionDir)Directory.Build.props" Condition="Exists('$(SolutionDir)Directory.Build.props')" />
+  <Import Project="$(SolutionDir)..\Directory.Build.props" Condition="Exists('$(SolutionDir)Directory.Build.props')" />
   <Import Project="$(UndockedDir)vs\windows.undocked.props" Condition="'$(ImportUndocked)' != 'false'" />
   <PropertyGroup>
     <!-- TODO: remove or understand this OneBranch workaround. -->

--- a/src/xdp.props
+++ b/src/xdp.props
@@ -20,10 +20,6 @@
   <PropertyGroup Condition="'$(Platform)' != 'x64'">
     <RestoreAdditionalProjectSources>$(SolutionDir)artifacts/nuget</RestoreAdditionalProjectSources>
   </PropertyGroup>
-  <PropertyGroup>
-    <!-- TODO: remove or understand this OneBranch workaround. -->
-    <UseHalfStaticOSMode>true</UseHalfStaticOSMode>
-  </PropertyGroup>
   <ItemGroup>
     <!-- eBPF currently has separate packages for each architecture. -->
     <PackageReference Include="eBPF-for-Windows" Version="0.18.0" GeneratePathProperty="true" Condition="'$(ImportEbpf)' == 'true' AND '$(Platform)' == 'x64'"/>
@@ -38,6 +34,10 @@
     <PackageReference Include="win-net-test" Version="1.2.0" GeneratePathProperty="true" Condition="'$(ImportWnt)' == 'true'"/>
   </ItemGroup>
   <Import Project="$(UndockedDir)vs\windows.undocked.props" Condition="'$(ImportUndocked)' != 'false'" />
+  <PropertyGroup>
+    <!-- TODO: remove or understand this OneBranch workaround. -->
+    <UseHalfStaticOSMode>true</UseHalfStaticOSMode>
+  </PropertyGroup>
   <PropertyGroup>
     <WntPackagePath>$(Pkgwin-net-test)\</WntPackagePath>
   </PropertyGroup>

--- a/src/xdp.props
+++ b/src/xdp.props
@@ -20,8 +20,8 @@
   <PropertyGroup Condition="'$(Platform)' != 'x64'">
     <RestoreAdditionalProjectSources>$(SolutionDir)artifacts/nuget</RestoreAdditionalProjectSources>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(RestoreSolutionDirectory)' != ''">
-    <!-- Work around OneBranch bug during Nuget restore by setting bogus properties. -->
+  <PropertyGroup>
+    <!-- TODO: remove or understand this OneBranch workaround. -->
     <UseHalfStaticOSMode>true</UseHalfStaticOSMode>
   </PropertyGroup>
   <ItemGroup>

--- a/src/xdp.props
+++ b/src/xdp.props
@@ -33,6 +33,8 @@
     <PackageReference Include="Microsoft.Windows.WDK.$(HostPlatform)" Version="$(XdpWdkVersion)" Condition="'$(ImportWdk)' != 'false' AND '$(HostPlatform)' != '$(Platform)'" />
     <PackageReference Include="win-net-test" Version="1.2.0" GeneratePathProperty="true" Condition="'$(ImportWnt)' == 'true'"/>
   </ItemGroup>
+    <!-- TODO: remove or understand this OneBranch workaround. -->
+  <Import Project="$(SolutionDir)Directory.Build.props" Condition="Exists('$(SolutionDir)Directory.Build.props')" />
   <Import Project="$(UndockedDir)vs\windows.undocked.props" Condition="'$(ImportUndocked)' != 'false'" />
   <PropertyGroup>
     <!-- TODO: remove or understand this OneBranch workaround. -->

--- a/src/xdp.props
+++ b/src/xdp.props
@@ -33,8 +33,6 @@
     <PackageReference Include="Microsoft.Windows.WDK.$(HostPlatform)" Version="$(XdpWdkVersion)" Condition="'$(ImportWdk)' != 'false' AND '$(HostPlatform)' != '$(Platform)'" />
     <PackageReference Include="win-net-test" Version="1.2.0" GeneratePathProperty="true" Condition="'$(ImportWnt)' == 'true'"/>
   </ItemGroup>
-    <!-- TODO: remove or understand this OneBranch workaround. -->
-  <Import Project="$(SolutionDir)..\Directory.Build.props" Condition="Exists('$(SolutionDir)..\Directory.Build.props')" />
   <Import Project="$(UndockedDir)vs\windows.undocked.props" Condition="'$(ImportUndocked)' != 'false'" />
   <PropertyGroup>
     <!-- TODO: remove or understand this OneBranch workaround. -->

--- a/src/xdp.props
+++ b/src/xdp.props
@@ -35,10 +35,6 @@
   </ItemGroup>
   <Import Project="$(UndockedDir)vs\windows.undocked.props" Condition="'$(ImportUndocked)' != 'false'" />
   <PropertyGroup>
-    <!-- TODO: remove or understand this OneBranch workaround. -->
-    <UseHalfStaticOSMode>true</UseHalfStaticOSMode>
-  </PropertyGroup>
-  <PropertyGroup>
     <WntPackagePath>$(Pkgwin-net-test)\</WntPackagePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'x64'">

--- a/src/xdp.props
+++ b/src/xdp.props
@@ -20,6 +20,10 @@
   <PropertyGroup Condition="'$(Platform)' != 'x64'">
     <RestoreAdditionalProjectSources>$(SolutionDir)artifacts/nuget</RestoreAdditionalProjectSources>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(RestoreSolutionDirectory)' != ''">
+    <!-- Work around OneBranch bug during Nuget restore by setting bogus properties. -->
+    <UseHalfStaticOSMode>true</UseHalfStaticOSMode>
+  </PropertyGroup>
   <ItemGroup>
     <!-- eBPF currently has separate packages for each architecture. -->
     <PackageReference Include="eBPF-for-Windows" Version="0.18.0" GeneratePathProperty="true" Condition="'$(ImportEbpf)' == 'true' AND '$(Platform)' == 'x64'"/>

--- a/src/xdp.props
+++ b/src/xdp.props
@@ -34,7 +34,7 @@
     <PackageReference Include="win-net-test" Version="1.2.0" GeneratePathProperty="true" Condition="'$(ImportWnt)' == 'true'"/>
   </ItemGroup>
     <!-- TODO: remove or understand this OneBranch workaround. -->
-  <Import Project="$(SolutionDir)..\Directory.Build.props" Condition="Exists('$(SolutionDir)Directory.Build.props')" />
+  <Import Project="$(SolutionDir)..\Directory.Build.props" Condition="Exists('$(SolutionDir)..\Directory.Build.props')" />
   <Import Project="$(UndockedDir)vs\windows.undocked.props" Condition="'$(ImportUndocked)' != 'false'" />
   <PropertyGroup>
     <!-- TODO: remove or understand this OneBranch workaround. -->

--- a/src/xdpinstaller/xdpinstaller.wixproj
+++ b/src/xdpinstaller/xdpinstaller.wixproj
@@ -4,6 +4,7 @@
     <ProjectGuid>{93635a7b-565e-4b41-af67-5b375756b227}</ProjectGuid>
     <ImportUndocked>false</ImportUndocked>
     <ImportWdk>false</ImportWdk>
+    <UseInternalMSUniCrtPackage>true</UseInternalMSUniCrtPackage>
     <WixVer>5.0.1</WixVer>
   </PropertyGroup>
   <Import Project="$(SolutionDir)src\xdp.props" />

--- a/src/xdpinstaller/xdpinstaller.wixproj
+++ b/src/xdpinstaller/xdpinstaller.wixproj
@@ -5,6 +5,7 @@
     <ImportUndocked>false</ImportUndocked>
     <ImportWdk>false</ImportWdk>
     <WixVer>5.0.1</WixVer>
+    <UndockedOfficial>true</UndockedOfficial>
   </PropertyGroup>
   <Import Project="$(SolutionDir)src\xdp.props" />
   <PropertyGroup>

--- a/src/xdpinstaller/xdpinstaller.wixproj
+++ b/src/xdpinstaller/xdpinstaller.wixproj
@@ -4,7 +4,6 @@
     <ProjectGuid>{93635a7b-565e-4b41-af67-5b375756b227}</ProjectGuid>
     <ImportUndocked>false</ImportUndocked>
     <ImportWdk>false</ImportWdk>
-    <UseInternalMSUniCrtPackage>true</UseInternalMSUniCrtPackage>
     <WixVer>5.0.1</WixVer>
   </PropertyGroup>
   <Import Project="$(SolutionDir)src\xdp.props" />
@@ -38,11 +37,11 @@
     <Compile Include="product.wxs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="WixToolset.UI.wixext" Version="$(WixVer)" />
-    <PackageReference Include="WixToolset.Util.wixext" Version="$(WixVer)" />
+    <PackageReference Include="WixToolset.UI.wixext" Version="$(WixVer)" Condition="'$(UndockedOfficial)' != 'true'" />
+    <PackageReference Include="WixToolset.Util.wixext" Version="$(WixVer)" Condition="'$(UndockedOfficial)' != 'true'" />
   </ItemGroup>
-  <Import Project="Sdk.props" Sdk="WixToolset.Sdk" Version="$(WixVer)" />
-  <Import Project="Sdk.targets" Sdk="WixToolset.Sdk" Version="$(WixVer)" />
+  <Import Project="Sdk.props" Sdk="WixToolset.Sdk" Version="$(WixVer)" Condition="'$(UndockedOfficial)' != 'true'" />
+  <Import Project="Sdk.targets" Sdk="WixToolset.Sdk" Version="$(WixVer)" Condition="'$(UndockedOfficial)' != 'true'" />
   <Target Name="SignMsi" Condition="'$(BuildStage)' != 'Binary' and '$(SignMode)' != 'Off'" AfterTargets="Build">
     <MSBuild Projects="$(SolutionDir)src\xdpinstaller\xdpinstaller.vcxproj" Targets="SignMsi"/>
   </Target>

--- a/src/xdpinstaller/xdpinstaller.wixproj
+++ b/src/xdpinstaller/xdpinstaller.wixproj
@@ -5,7 +5,6 @@
     <ImportUndocked>false</ImportUndocked>
     <ImportWdk>false</ImportWdk>
     <WixVer>5.0.1</WixVer>
-    <UndockedOfficial>true</UndockedOfficial>
   </PropertyGroup>
   <Import Project="$(SolutionDir)src\xdp.props" />
   <PropertyGroup>
@@ -37,6 +36,9 @@
   <ItemGroup Condition="'$(BuildStage)' != 'Binary'">
     <Compile Include="product.wxs" />
   </ItemGroup>
+  <!-- OneBranch doesn't build the WiX project, but loading the .props and .targets files during
+       NuGet restore causes unrelated OneBranch errors. Suppress these internally for now.
+       -->
   <ItemGroup>
     <PackageReference Include="WixToolset.UI.wixext" Version="$(WixVer)" Condition="'$(UndockedOfficial)' != 'true'" />
     <PackageReference Include="WixToolset.Util.wixext" Version="$(WixVer)" Condition="'$(UndockedOfficial)' != 'true'" />

--- a/test/directory.build.props
+++ b/test/directory.build.props
@@ -1,3 +1,4 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" Condition="'$([MSBuild]::GetPathOfFileAbove(%27Directory.Build.props%27, %27$(MSBuildThisFileDirectory)../%27))' != ''" />
   <Import Project="$(SolutionDir)test\xdp.test.props" />
 </Project>

--- a/test/directory.build.props
+++ b/test/directory.build.props
@@ -1,4 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Pull in parent Directory.Build.props, if it exists. OneBranch auto-injects into the root. -->
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)../))" Condition="'$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)../))' != ''" />
   <Import Project="$(SolutionDir)test\xdp.test.props" />
 </Project>

--- a/test/directory.build.props
+++ b/test/directory.build.props
@@ -1,4 +1,4 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" Condition="'$([MSBuild]::GetPathOfFileAbove(%27Directory.Build.props%27, %27$(MSBuildThisFileDirectory)../%27))' != ''" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)../))" Condition="'$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)../))' != ''" />
   <Import Project="$(SolutionDir)test\xdp.test.props" />
 </Project>


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

We paused OneBranch builds several months ago, and in the meantime, both XDP and OneBranch made breaking changes. Fix all of those. Resolves #789 

## Testing

_Do any existing tests cover this change? Are new tests needed?_

It builds in OneBranch or your money back.

## Documentation

_Is there any documentation impact for this change?_

A bit of comments were added.

## Installation

_Is there any installer impact for this change?_

No.