### PR TITLE
Add NuGet runtime tests

### DIFF
--- a/.azure/onebranch.test.yml
+++ b/.azure/onebranch.test.yml
@@ -61,6 +61,7 @@ stages:
               osName: ${{os}}
               timeoutInMinutes: ${{ variables.functionalRuntime }}
               iterations: ${{ variables.functionalIterations }}
+              xdpInstaller: NuGet
 
         - stage: stress_${{os}}_${{platform}}_${{config}}
           displayName: Stress ${{os}} (${{platform}}_${{config}})
@@ -81,3 +82,4 @@ stages:
                 xdpmpPollProvider: NDIS
               ${{ if ne(os, 'Prerelease') }}:
                 xdpmpPollProvider: FNDIS
+              xdpInstaller: NuGet

--- a/.azure/templates/build.yml
+++ b/.azure/templates/build.yml
@@ -46,6 +46,8 @@ jobs:
 
   - task: NuGetCommand@2
     displayName: Nuget Restore
+    env:
+      NUGET_RESTORE_MSBUILD_ARGS: /p:IsAdmin=true /p:Platform=${{ parameters.platform }} /p:Configuration=${{ parameters.config }}
     inputs:
       restoreSolution: xdp.sln
       feedsToUse: config
@@ -64,6 +66,7 @@ jobs:
       platform: ${{ parameters.platform }}
       configuration: ${{ parameters.config }}
       msbuildArgs: -m /p:SignMode=TestSign /p:IsAdmin=true
+      msBuildArchitecture: x64
 
   - task: CopyFiles@2
     displayName: Filter Artifacts

--- a/.azure/templates/spinxsk.yml
+++ b/.azure/templates/spinxsk.yml
@@ -27,6 +27,8 @@ parameters:
 - name: xdpmpPollProvider
   default: 'NDIS'
 - name: osName
+- name: xdpInstaller
+  default: 'MSI'
 
 jobs:
 - job: spinxsk__${{ parameters.platform }}_${{ parameters.config }}_${{ parameters.osName }}_${{ replace(parameters.pool, '-', '_') }}
@@ -73,7 +75,7 @@ jobs:
       arguments: -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -QueueCount 2
         -Minutes ${{ parameters.runtimeMinutes }} -XdpmpPollProvider ${{ parameters.xdpmpPollProvider }}
         -Verbose -Stats -SuccessThresholdPercent ${{ parameters.successThresholdPercent }}
-        -EnableEbpf
+        -EnableEbpf -XdpInstaller ${{ parameters.xdpInstaller }}
 
   - task: PowerShell@2
     displayName: Convert logs

--- a/.azure/templates/tests.yml
+++ b/.azure/templates/tests.yml
@@ -9,6 +9,7 @@ parameters:
   timeoutInMinutes: 10
   iterations: 1
   osName:
+  xdpInstaller: 'MSI'
 
 jobs:
 - job: tests_${{ parameters.platform }}_${{ parameters.config }}_${{ parameters.osName }}_${{ replace(parameters.pool, '-', '_') }}
@@ -48,7 +49,7 @@ jobs:
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     inputs:
       filePath: tools/functional.ps1
-      arguments: -Verbose -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Iterations ${{ parameters.iterations }} -Timeout ${{ parameters.timeoutInMinutes }}
+      arguments: -Verbose -Config ${{ parameters.config }} -Platform ${{ parameters.platform }} -Iterations ${{ parameters.iterations }} -Timeout ${{ parameters.timeoutInMinutes }} -XdpInstaller ${{ parameters.xdpInstaller }}
 
   - task: PowerShell@2
     displayName: Convert Logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,12 +267,12 @@ jobs:
       if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
       shell: PowerShell
       timeout-minutes: 20
-      run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Minutes ${{ env.prRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf
+      run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Minutes ${{ env.prRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf -XdpInstaller NuGet
     - name: Run spinxsk (main)
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch'}}
       shell: PowerShell
       timeout-minutes: 70
-      run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Minutes ${{ env.fullRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf
+      run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Minutes ${{ env.fullRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf -XdpInstaller NuGet
     - name: Convert Logs
       if: ${{ always() }}
       timeout-minutes: 15

--- a/src/nuget/nuget.vcxproj
+++ b/src/nuget/nuget.vcxproj
@@ -35,5 +35,13 @@
       </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
+  <Target Name="CleanNuget" BeforeTargets="Clean" Condition="$(BuildStage) == '' OR $(BuildStage) == 'AllPackage'">
+     <ItemGroup>
+       <FilesToDelete Include="$(OutDir)XDP-for-Windows.*.nupkg"/>
+     </ItemGroup>
+     <Delete Files="@(FilesToDelete)">
+       <Output TaskParameter="DeletedFiles" ItemName="FilesDeleted"/>
+     </Delete>
+  </Target>
   <Import Project="$(SolutionDir)src\xdp.targets" />
 </Project>

--- a/src/xdpruntime/xdpruntime.vcxproj
+++ b/src/xdpruntime/xdpruntime.vcxproj
@@ -28,6 +28,14 @@
   <Target Name="SignBinaries" DependsOnTargets="CopyBinaries" BeforeTargets="Build" Condition="$(SignMode) != 'Off' and $(BuildStage) != 'Package'">
       <Exec Command="powershell.exe /c &quot;&amp; '$(DriverSignToolPath)signtool.exe' sign /sha1 ([system.security.cryptography.x509certificates.x509certificate2]::new([System.IO.File]::ReadAllBytes('$(OutDir)xdp\xdp.sys'))).Thumbprint /fd sha256  $(OutDir)xdp-setup.ps1&quot;" />
   </Target>
+  <Target Name="CleanNuget" BeforeTargets="Clean" Condition="$(BuildStage) == '' OR $(BuildStage) == 'Package'">
+     <ItemGroup>
+       <FilesToDelete Include="$(OutDir)XDP-for-Windows-Runtime.$(Platform).*.nupkg"/>
+     </ItemGroup>
+     <Delete Files="@(FilesToDelete)">
+       <Output TaskParameter="DeletedFiles" ItemName="FilesDeleted"/>
+     </Delete>
+  </Target>
   <Target Name="BuildNuget" AfterTargets="Build" Condition="$(BuildStage) != 'Binary'">
       <Exec Command="powershell.exe /c &quot;$(SolutionDir)tools\update-nuspec.ps1 -InputFile xdp-for-windows-runtime.nuspec.in -OutputFile $(IntDir)xdp-for-windows-runtime.nuspec -Platform $(Platform) -Config $(Configuration)&quot;" />
       <Exec Command="NuGet.exe pack $(IntDir)xdp-for-windows-runtime.nuspec -OutputDirectory $(OutDir) -BasePath $(ProjectDir) -Properties NoWarn=NU5100,NU5110,NU5111" />

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -730,10 +730,17 @@ SetDeviceSddl(
     _In_z_ const CHAR *Sddl
     )
 {
+    CHAR XdpBinaryPath[MAX_PATH];
+    UINT32 XdpBinaryPathLength;
     CHAR CmdBuff[256];
-    RtlZeroMemory(CmdBuff, sizeof(CmdBuff));
 
-    sprintf_s(CmdBuff, "xdpcfg.exe SetDeviceSddl \"%s\"", Sddl);
+    XdpBinaryPathLength =
+        GetEnvironmentVariableA("_XDP_BINARIES_PATH", XdpBinaryPath, sizeof(XdpBinaryPath));
+    TEST_NOT_EQUAL(0, XdpBinaryPathLength);
+    TEST_TRUE(XdpBinaryPathLength <= sizeof(XdpBinaryPath));
+
+    RtlZeroMemory(CmdBuff, sizeof(CmdBuff));
+    sprintf_s(CmdBuff, "%s\\xdpcfg.exe SetDeviceSddl \"%s\"", XdpBinaryPath, Sddl);
     TEST_EQUAL(0, InvokeSystem(CmdBuff));
 }
 

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -96,7 +96,7 @@ function Get-VsTestPath {
 
 # Returns the XDP installation path
 function Get-XdpInstallPath {
-    return "$($env:SystemDrive)\xdpmsi"
+    return "$($env:SystemDrive)\xdpruntime"
 }
 
 # Returns the eBPF installation path

--- a/tools/functional.ps1
+++ b/tools/functional.ps1
@@ -44,7 +44,11 @@ param (
     [string]$TestBinaryPath = "",
 
     [Parameter(Mandatory = $false)]
-    [switch]$NoPrerelease = $false
+    [switch]$NoPrerelease = $false,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("MSI", "INF", "NuGet")]
+    [string]$XdpInstaller = "MSI"
 )
 
 Set-StrictMode -Version 'Latest'
@@ -98,7 +102,7 @@ for ($i = 1; $i -le $Iterations; $i++) {
         }
 
         Write-Verbose "installing xdp..."
-        & "$RootDir\tools\setup.ps1" -Install xdp -Config $Config -Platform $Platform -EnableEbpf
+        & "$RootDir\tools\setup.ps1" -Install xdp -Config $Config -Platform $Platform -EnableEbpf -XdpInstaller $XdpInstaller
         Write-Verbose "installed xdp."
 
         Write-Verbose "installing fnmp..."
@@ -168,7 +172,7 @@ for ($i = 1; $i -le $Iterations; $i++) {
         & "$RootDir\tools\setup.ps1" -Uninstall fnsock -Config $Config -Platform $Platform -ErrorAction 'Continue'
         & "$RootDir\tools\setup.ps1" -Uninstall fnlwf -Config $Config -Platform $Platform -ErrorAction 'Continue'
         & "$RootDir\tools\setup.ps1" -Uninstall fnmp -Config $Config -Platform $Platform -ErrorAction 'Continue'
-        & "$RootDir\tools\setup.ps1" -Uninstall xdp -Config $Config -Platform $Platform -ErrorAction 'Continue'
+        & "$RootDir\tools\setup.ps1" -Uninstall xdp -Config $Config -Platform $Platform -XdpInstaller $XdpInstaller -ErrorAction 'Continue'
         if (!$EbpfPreinstalled) {
             & "$RootDir\tools\setup.ps1" -Uninstall ebpf -Config $Config -Platform $Platform -ErrorAction 'Continue'
         }

--- a/tools/functional.ps1
+++ b/tools/functional.ps1
@@ -157,8 +157,8 @@ for ($i = 1; $i -le $Iterations; $i++) {
         # Sanity test the XDP_PA installer.
 
         Write-Verbose "Reinstalling XDP at PA layer..."
-        & "$RootDir\tools\setup.ps1" -Uninstall xdp -Config $Config -Platform $Platform
-        & "$RootDir\tools\setup.ps1" -Install xdp -Config $Config -Platform $Platform -EnableEbpf -PaLayer
+        & "$RootDir\tools\setup.ps1" -Uninstall xdp -Config $Config -Platform $Platform -XdpInstaller $XdpInstaller
+        & "$RootDir\tools\setup.ps1" -Install xdp -Config $Config -Platform $Platform -EnableEbpf -XdpInstaller $XdpInstaller -PaLayer
         Write-Verbose "Installed XDP PA layer."
 
         if (!(Get-NetAdapterBinding -ComponentID ms_xdp_pa)) {

--- a/tools/spinxsk.ps1
+++ b/tools/spinxsk.ps1
@@ -82,7 +82,11 @@ param (
     [switch]$EnableEbpf = $false,
 
     [Parameter(Mandatory = $false)]
-    [switch]$EbpfPreinstalled = $false
+    [switch]$EbpfPreinstalled = $false,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("MSI", "INF", "NuGet")]
+    [string]$XdpInstaller = "MSI"
 )
 
 Set-StrictMode -Version 'Latest'
@@ -145,7 +149,7 @@ while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes))
         }
 
         Write-Verbose "installing xdp..."
-        & "$RootDir\tools\setup.ps1" -Install xdp -Config $Config -Platform $Platform -EnableEbpf:$EnableEbpf
+        & "$RootDir\tools\setup.ps1" -Install xdp -Config $Config -Platform $Platform -EnableEbpf:$EnableEbpf -XdpInstaller $XdpInstaller
         Write-Verbose "installed xdp."
 
         Write-Verbose "installing xdpmp..."
@@ -189,7 +193,7 @@ while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes))
         }
     } finally {
         & "$RootDir\tools\setup.ps1" -Uninstall xdpmp -Config $Config -Platform $Platform -ErrorAction 'Continue'
-        & "$RootDir\tools\setup.ps1" -Uninstall xdp -Config $Config -Platform $Platform -ErrorAction 'Continue'
+        & "$RootDir\tools\setup.ps1" -Uninstall xdp -Config $Config -Platform $Platform -XdpInstaller $XdpInstaller -ErrorAction 'Continue'
         if (!$EbpfPreinstalled) {
             & "$RootDir\tools\setup.ps1" -Uninstall ebpf -Config $Config -Platform $Platform -ErrorAction 'Continue'
         }


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Resolves #794

Adds support for installing XDP with the runtime nuget package in test automation. Uses this new config in GitHub for stress tests (as a sanity test) and in OneBranch tests.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.