### PR TITLE
fix azure functional test timeout

### DIFF
--- a/.azure/onebranch.test.yml
+++ b/.azure/onebranch.test.yml
@@ -31,7 +31,7 @@ variables:
   spinxskRuntime: 60
   spinxskTimeout: 65
   spinxskJobTimeout: 75
-  functionalRuntime: 180
+  functionalRuntime: 360
   functionalIterations: 10
 
 stages:


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Our functional tests have become larger and slower, so bump the newly re-onboarded ADO tests to use the same timeout as GitHub.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.