### PR TITLE
Apply ADO timeout to jobs

### DIFF
--- a/.azure/templates/tests.yml
+++ b/.azure/templates/tests.yml
@@ -29,6 +29,7 @@ jobs:
   variables:
     runCodesignValidationInjection: false
     platconfig: ${{ parameters.platform }}_${{ parameters.config }}
+  timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
   steps:
   - checkout: self
 


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

#796 bumped the timeout value, but the ADO job was still using the default 60 minutes. Plumb it properly.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Verified on internal CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.