### PR TITLE
Add empty check to let nugget parse the prop file

### DIFF
--- a/src/xdp/xdp.vcxproj
+++ b/src/xdp/xdp.vcxproj
@@ -137,7 +137,8 @@
       </AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(LatestWdkPlatformVersion)' &gt;= '10.0.26100.0'">
+  <ItemDefinitionGroup Condition="'$(LatestWdkPlatformVersion)' != '' And '$(LatestWdkPlatformVersion)' &gt;= '10.0.26100.0'">
+    <!-- a null check is needed to let nuget parse this before LatestWdkPlatformVersion is defined when packages are initially restored -->
     <!-- volatileaccessk.lib is introduced in WDK version 10.0.22621.0, i.e., ge_release. -->
     <Link>
       <AdditionalDependencies>


### PR DESCRIPTION
## Description

On a clean device, nuget would fail to restore packages because LatestWdkPlatformVersion == ''.

## Testing

After clearing the nuget cache, a build to restore nuget packages.

## Documentation

N/A

## Installation

N/A
