### PR TITLE
Use FNMP to inject interesting frames on the Rx path of spinxsk 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,7 @@ jobs:
         windows: [2019, 2022, Prerelease]
         configuration: [Release, Debug]
         platform: [x64, arm64]
+        testDriver: [XDPMP, FNMP]
         exclude:
         - windows: 2019
           platform: arm64
@@ -267,12 +268,12 @@ jobs:
       if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
       shell: PowerShell
       timeout-minutes: 20
-      run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Minutes ${{ env.prRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf -XdpInstaller NuGet
+      run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Driver ${{ matrix.testDriver}} -Minutes ${{ env.prRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf -XdpInstaller NuGet
     - name: Run spinxsk (main)
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch'}}
       shell: PowerShell
       timeout-minutes: 70
-      run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Minutes ${{ env.fullRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf -XdpInstaller NuGet
+      run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Driver ${{ matrix.testDriver}} -Minutes ${{ env.fullRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf -XdpInstaller NuGet
     - name: Convert Logs
       if: ${{ always() }}
       timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,12 +278,12 @@ jobs:
       if: ${{ always() }}
       timeout-minutes: 15
       shell: PowerShell
-      run: tools/log.ps1 -Convert -Name spinxsk -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
+      run: tools/log.ps1 -Convert -Name spinxsk_${{ matrix.testDriver }} -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }}
     - name: Upload Logs
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       if: ${{ always() }}
       with:
-        name: logs_stress_win${{ matrix.windows }}_${{ matrix.configuration }}_${{ matrix.platform }}
+        name: logs_stress_win${{ matrix.windows }}_${{ matrix.configuration }}_${{ matrix.platform }}_${{ matrix.testDriver }}
         path: artifacts/logs
     - name: Check Drivers
       if: ${{ always() }}

--- a/src/xdp.props
+++ b/src/xdp.props
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageReference Include="Microsoft.Windows.WDK.$(Platform)" Version="$(XdpWdkVersion)" Condition="'$(ImportWdk)' != 'false'" />
     <PackageReference Include="Microsoft.Windows.WDK.$(HostPlatform)" Version="$(XdpWdkVersion)" Condition="'$(ImportWdk)' != 'false' AND '$(HostPlatform)' != '$(Platform)'" />
-    <PackageReference Include="win-net-test" Version="1.2.0" GeneratePathProperty="true" Condition="'$(ImportWnt)' == 'true'"/>
+    <PackageReference Include="win-net-test" Version="1.3.0" GeneratePathProperty="true" Condition="'$(ImportWnt)' == 'true'"/>
   </ItemGroup>
   <Import Project="$(UndockedDir)vs\windows.undocked.props" Condition="'$(ImportUndocked)' != 'false'" />
   <PropertyGroup>

--- a/test/spinxsk/spinxsk.c
+++ b/test/spinxsk/spinxsk.c
@@ -2074,7 +2074,7 @@ BuildRandomQuicPacket(
     _Inout_ UINT32* PacketBufferSize,
     _In_reads_bytes_(PayloadBufferSize) UCHAR* Payload,
     _In_ const UINT32 PayloadBufferSize
-)
+    )
 {
     UINT16 quicPayloadLength =
         (UINT16)(RandUlong() % (min(PayloadBufferSize, *PacketBufferSize - QUIC_MAX_HEADER_LEN) + 1));
@@ -2098,7 +2098,7 @@ void BuildRandomUdpFrame(
     _In_ UINT32* FrameLength,
     _In_reads_bytes_(PayloadLength) UCHAR* Payload,
     _In_ const UINT16 PayloadLength
-)
+    )
 {
     const ETHERNET_ADDRESS localMac = FNMP_LOCAL_ETHERNET_ADDRESS_INIT;
     const ETHERNET_ADDRESS remoteMac = FNMP_NEIGHBOR_ETHERNET_ADDRESS_INIT;
@@ -2121,7 +2121,7 @@ BuildRandomTcpFrame(
     _In_ UINT32* FrameLength,
     _In_reads_bytes_(PayloadLength) UCHAR* Payload,
     _In_ const UINT16 PayloadLength
-)
+    )
 {
     const ETHERNET_ADDRESS localMac = FNMP_LOCAL_ETHERNET_ADDRESS_INIT;
     const ETHERNET_ADDRESS remoteMac = FNMP_NEIGHBOR_ETHERNET_ADDRESS_INIT;
@@ -2158,7 +2158,7 @@ BuildRandomFnmpDataBuffers(
     _In_ const UINT32 FrameLength,
     _In_ const UINT32 FrameBufferSize,
     _In_ const UINT32 Backfill
-)
+    )
 {
     //
     // Split the frame into up to 3 MDLs.
@@ -2183,6 +2183,7 @@ BuildRandomFnmpDataBuffers(
         Buffers[1].BufferLength = FrameBufferSize - Buffers[0].BufferLength;
         Buffers[1].VirtualAddress = Buffers[0].VirtualAddress + Buffers[0].BufferLength;;
     } else { // *NumBuffers == 3
+        ASSERT_FRE(*NumBuffers == 3);
         const UINT32 bufferSplitOffset = RandUlong() % (FrameLength + 1);
         const UINT32 bufferSplitOffset2 =
             bufferSplitOffset + RandUlong() % (FrameLength - bufferSplitOffset + 1);
@@ -2209,7 +2210,7 @@ VOID
 InjectFnmpRxFrames(
     _In_ FNMP_HANDLE Fnmp,
     _In_ const UINT32 NumFrames
-)
+    )
 {
     UINT32 payloadBufferSize = 0;
     DATA_FLUSH_OPTIONS flushOptions = {0};

--- a/test/spinxsk/spinxsk.c
+++ b/test/spinxsk/spinxsk.c
@@ -2225,8 +2225,7 @@ InjectFnmpRxFrames(
     // but keep it smaller most of the time to iterate faster:
     // most of the interesting logic has to do with the headers.
     //
-    if (RandUlong() % 10 == 0)
-    {
+    if (RandUlong() % 10 == 0) {
         payloadBufferSize = 64'000;
     } else {
         payloadBufferSize = 500;
@@ -2238,9 +2237,7 @@ InjectFnmpRxFrames(
 
     if (frame == NULL || payload == NULL) {
         TraceWarn("Allocation failure, frame: %p, payload: %p", frame, payload);
-        free(frame);
-        free(payload);
-        return;
+        goto Exit;
     }
 
     TraceVerbose("FnmpInjectRx: injecting %d frames", NumFrames);
@@ -2309,7 +2306,9 @@ InjectFnmpRxFrames(
         fnmpFrame.BufferCount = numBuffers;
 
         status = FnMpRxEnqueue(Fnmp, &fnmpFrame);
-        TraceVerbose("FnmpInjectRx: FnMpRxEnqueue failed with %x", status);
+        if (FAILED(status)) {
+            TraceWarn("FnmpInjectRx: FnMpRxEnqueue failed with %x", status);
+        }
     }
 
     flushOptions.Flags.DpcLevel = RandUlong() & 1;
@@ -2320,6 +2319,7 @@ InjectFnmpRxFrames(
     status = FnMpRxFlush(Fnmp, &flushOptions);
     TraceVerbose("FnmpInjectRx: done injecting %d frames, status %x", NumFrames, status);
 
+Exit:
     //
     // Cleanup
     //

--- a/test/spinxsk/spinxsk.c
+++ b/test/spinxsk/spinxsk.c
@@ -2701,15 +2701,13 @@ GlobalConcurrentWorkerFn(
         //
         // Use a random delay to simulate bursts of traffic
         //
-        // TODO guhetier: Reduce the delay to 10ms / increase the number of frames
-        //
-        DWORD timeoutMs = RandUlong() % 100;
+        DWORD timeoutMs = RandUlong() % 10;
         DWORD status = WaitForSingleObject(workersDoneEvent, timeoutMs);
         if (status == WAIT_OBJECT_0) {
             break;
         }
 
-        const UINT32 numFrames = RandUlong() % 256;
+        const UINT32 numFrames = RandUlong() % 4000;
         InjectFnmpRxFrames(fnmp, numFrames);
     }
 

--- a/test/spinxsk/spinxsk.c
+++ b/test/spinxsk/spinxsk.c
@@ -2218,7 +2218,7 @@ InjectFnmpRxFrames(
     ULONG frameBufferSize = 0;
     UCHAR* payload = NULL;
     UCHAR* frame = NULL;
-    int status = 0;
+    HRESULT status = S_OK;
 
     //
     // Use a very large payload buffer from time to time
@@ -2309,7 +2309,7 @@ InjectFnmpRxFrames(
         fnmpFrame.BufferCount = numBuffers;
 
         status = FnMpRxEnqueue(Fnmp, &fnmpFrame);
-        TraceVerbose("FnmpInjectRx: FnMpRxEnqueue failed with %d", status);
+        TraceVerbose("FnmpInjectRx: FnMpRxEnqueue failed with %x", status);
     }
 
     flushOptions.Flags.DpcLevel = RandUlong() & 1;
@@ -2318,7 +2318,7 @@ InjectFnmpRxFrames(
     flushOptions.RssCpuQueueId = RandUlong() % queueCount;
 
     status = FnMpRxFlush(Fnmp, &flushOptions);
-    TraceVerbose("FnmpInjectRx: done injecting %d frames, status %d", NumFrames, status);
+    TraceVerbose("FnmpInjectRx: done injecting %d frames, status %x", NumFrames, status);
 
     //
     // Cleanup

--- a/test/spinxsk/spinxsk.c
+++ b/test/spinxsk/spinxsk.c
@@ -310,7 +310,7 @@ FillRandomBuffer(
     _In_ const ULONG Size
     )
 {
-    ASSERT_FRE(NT_SUCCESS(BCryptGenRandom(NULL, Buffer, Size, BCRYPT_USE_SYSTEM_PREFERRED_RNG)));
+    (void)BCryptGenRandom(NULL, Buffer, Size, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
 }
 
 ULONG

--- a/test/spinxsk/spinxsk.c
+++ b/test/spinxsk/spinxsk.c
@@ -2916,7 +2916,7 @@ ParseArgs(
             }
             fuzzerCount = atoi(argv[i]);
             TraceVerbose("fuzzerCount=%u", fuzzerCount);
-        } else if (!strcmp(argv[i], "-GloabalConcurrentWorkerCount")) {
+        } else if (!strcmp(argv[i], "-GlobalConcurrentWorkers")) {
             if (++i >= argc) {
                 Usage();
             }

--- a/test/spinxsk/spinxsk.c
+++ b/test/spinxsk/spinxsk.c
@@ -2156,7 +2156,7 @@ InjectFnmpRxPacket(_In_ FNMP_HANDLE Fnmp) {
     flushOptions.Flags.DpcLevel = RandUlong() & 1;
     flushOptions.Flags.LowResources = RandUlong() & 1;
     flushOptions.Flags.RssCpu = RandUlong() & 1;
-    flushOptions.RssCpuQueueId = RandUlong() & 1;
+    flushOptions.RssCpuQueueId = RandUlong() % queueCount;
 
     FnMpRxFlush(Fnmp, &flushOptions);
 

--- a/test/spinxsk/spinxsk.c
+++ b/test/spinxsk/spinxsk.c
@@ -2060,7 +2060,7 @@ InjectFnmpRxPacket(_In_ FNMP_HANDLE Fnmp) {
         return;
     }
 
-    const UINT32 numFrames = RandUlong() % 4000;
+    const UINT32 numFrames = (UINT8)(RandUlong() % 4000);
     TraceVerbose("FnmpInjectRx: injecting %d frames", numFrames);
 
     for (UINT8 i = 0; i < numFrames; i++) {
@@ -2634,7 +2634,7 @@ GlobalConcurrentWorkerFn(
         //
         // Use a random delay to simulate bursts of traffic
         //
-        DWORD timeoutMs = RandUlong() % 10;
+        DWORD timeoutMs = RandUlong() % 100;
         DWORD status = WaitForSingleObject(workersDoneEvent, timeoutMs);
         if (status == WAIT_OBJECT_0) {
             break;

--- a/test/spinxsk/spinxsk.c
+++ b/test/spinxsk/spinxsk.c
@@ -2306,7 +2306,7 @@ InjectFnmpRxFrames(
         fnmpFrame.Input.Checksum.Value = (PVOID)(ULONG_PTR)RandUlong();
         fnmpFrame.Input.Rsc.Value = (PVOID)(ULONG_PTR)RandUlong();
         fnmpFrame.Buffers = buffers;
-        fnmpFrame.BufferCount = numBuffers + 1;
+        fnmpFrame.BufferCount = numBuffers;
 
         status = FnMpRxEnqueue(Fnmp, &fnmpFrame);
         TraceVerbose("FnmpInjectRx: FnMpRxEnqueue failed with %d", status);

--- a/test/spinxsk/spinxsk.c
+++ b/test/spinxsk/spinxsk.c
@@ -2163,7 +2163,7 @@ BuildRandomFnmpDataBuffers(
     //
     // Split the frame into up to 3 MDLs.
     //
-	ASSERT_FRE(*NumBuffers > 0);
+    ASSERT_FRE(*NumBuffers > 0);
     *NumBuffers = (RandUlong() % min(*NumBuffers, 3)) + 1;
 
     if (*NumBuffers == 1) {
@@ -2215,7 +2215,7 @@ InjectFnmpRxFrames(
     DATA_FLUSH_OPTIONS flushOptions = {0};
     ULONG frameBufferSize = 0;
     UCHAR* payload = NULL;
-	UCHAR* frame = NULL;
+    UCHAR* frame = NULL;
 
     //
     // Use a very large payload buffer from time to time
@@ -2224,15 +2224,15 @@ InjectFnmpRxFrames(
     //
     if (RandUlong() % 10 == 0)
     {
-		payloadBufferSize = 64'000;
-	}
-	else {
-		payloadBufferSize = 500;
+        payloadBufferSize = 64'000;
+    }
+    else {
+        payloadBufferSize = 500;
     }
     frameBufferSize = FNMP_FRAME_MAX_BACKFILL + TCP_HEADER_STORAGE + payloadBufferSize;
 
     payload = calloc(payloadBufferSize, sizeof(UCHAR));
-	frame = calloc(frameBufferSize, sizeof(UCHAR));
+    frame = calloc(frameBufferSize, sizeof(UCHAR));
 
     if (frame == NULL || payload == NULL) {
         TraceWarn("Allocation failure, frame: %p, payload: %p", frame, payload);
@@ -2709,7 +2709,7 @@ GlobalConcurrentWorkerFn(
     )
 {
     FNMP_HANDLE fnmp;
-	HRESULT res = S_OK;
+    HRESULT res = S_OK;
 
     UNREFERENCED_PARAMETER(ThreadParameter);
 
@@ -2727,7 +2727,7 @@ GlobalConcurrentWorkerFn(
     ASSERT_FRE(SUCCEEDED(res));
 
     while (TRUE) {
-		DWORD status = ERROR_SUCCESS;
+        DWORD status = ERROR_SUCCESS;
         UINT32 burstSize = 0;
         DWORD timeoutMs = 0;
 
@@ -2745,28 +2745,19 @@ GlobalConcurrentWorkerFn(
         //
         // Split the burst into smaller batches
         //
-		while (burstSize > 0) {
+        while (burstSize > 0) {
             //
             // NDIS recommands to not exceed 255 packets in a single operation.
             //
-			UINT32 batchSize = min(burstSize, UINT8_MAX);
-
-            if (RandUlong() % 100 == 0) {
-                //
-                // Small chance to send a very large burst.
-                // Drivers should avoid this, but XDP should handle it.
-                //
-                batchSize = burstSize;
-            }
-
+            UINT32 batchSize = min(burstSize, UINT8_MAX);
             InjectFnmpRxFrames(fnmp, batchSize);
-			burstSize -= batchSize;
+            burstSize -= batchSize;
 
             status = WaitForSingleObject(workersDoneEvent, 0);
-	        if (status == WAIT_OBJECT_0) {
-	            break;
-	        }
-		}
+            if (status == WAIT_OBJECT_0) {
+                break;
+            }
+        }
     }
 
     FnMpClose(fnmp);

--- a/test/spinxsk/spinxsk.c
+++ b/test/spinxsk/spinxsk.c
@@ -2026,11 +2026,11 @@ ProcessPkts(
 }
 
 //
-// Add some "corrupted" bytes to a buffer.
+// Add some "randomized" bytes to a buffer.
 // Each byte of the buffer has a 1/20 chance to be replaced by a random value.
 //
 VOID
-CorruptBuffer(
+PartiallyRandomizeBuffer(
     _Inout_updates_bytes_(BufferSize) UINT8* Buffer,
     _In_ const UINT32 BufferSize
     )
@@ -2287,10 +2287,10 @@ InjectFnmpRxFrames(
         }
 
         //
-        // Consider corrupting a well built frame a little.
+        // Consider randomizing some bytes in a well built frame.
         //
         if (RandUlong() % 2) {
-            CorruptBuffer(&frame[backfill], TCP_HEADER_STORAGE + QUIC_MAX_HEADER_LEN);
+            PartiallyRandomizeBuffer(&frame[backfill], TCP_HEADER_STORAGE + QUIC_MAX_HEADER_LEN);
         }
 
         //

--- a/test/spinxsk/spinxsk.c
+++ b/test/spinxsk/spinxsk.c
@@ -2211,11 +2211,28 @@ InjectFnmpRxFrames(
     _In_ const UINT32 NumFrames
 )
 {
-    const UINT32 payloadBufferSize = 64'000;
+    UINT32 payloadBufferSize = 0;
     DATA_FLUSH_OPTIONS flushOptions = {0};
-    UCHAR* payload = calloc(payloadBufferSize, sizeof(UCHAR));
-    const ULONG frameBufferSize = FNMP_FRAME_MAX_BACKFILL + TCP_HEADER_STORAGE + payloadBufferSize;
-    UCHAR* frame = calloc(frameBufferSize, sizeof(UCHAR));
+    ULONG frameBufferSize = 0;
+    UCHAR* payload = NULL;
+	UCHAR* frame = NULL;
+
+    //
+    // Use a very large payload buffer from time to time
+    // but keep it smaller most of the time to iterate faster:
+    // most of the interesting logic has to do with the headers.
+    //
+    if (RandUlong() % 10 == 0)
+    {
+		payloadBufferSize = 64'000;
+	}
+	else {
+		payloadBufferSize = 500;
+    }
+    frameBufferSize = FNMP_FRAME_MAX_BACKFILL + TCP_HEADER_STORAGE + payloadBufferSize;
+
+    payload = calloc(payloadBufferSize, sizeof(UCHAR));
+	frame = calloc(frameBufferSize, sizeof(UCHAR));
 
     if (frame == NULL || payload == NULL) {
         TraceWarn("Allocation failure, frame: %p, payload: %p", frame, payload);

--- a/test/spinxsk/spinxsk.vcxproj
+++ b/test/spinxsk/spinxsk.vcxproj
@@ -13,6 +13,7 @@
     <TargetName>spinxsk</TargetName>
     <UndockedType>exe</UndockedType>
     <ImportEbpf>true</ImportEbpf>
+    <ImportWnt>true</ImportWnt>
   </PropertyGroup>
   <Import Project="$(SolutionDir)src\xdp.cpp.props" />
   <ItemDefinitionGroup>

--- a/test/xdpmp/xdpmp.md
+++ b/test/xdpmp/xdpmp.md
@@ -26,4 +26,4 @@ and/or registry keys.
 
 Additionally, XDPMP supports a load generator and rate limiter. RX load
 generation and TX rate limiting  can be dynamically configured with
-`xdpmppace.ps1`.
+`xdpmpratesim.ps1`.

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -133,7 +133,7 @@ function Get-EbpfMsiUrl {
 }
 
 function Get-FnVersion {
-    return "1.2.0"
+    return "1.3.0"
 }
 
 function Get-FnRuntimeUrl {

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -351,6 +351,7 @@ if ($Cleanup) {
 if ($Reboot) {
     if ($RequireNoReboot) {
         Write-Error "Reboot required but disallowed"
+        Write-Info "If running in CI, it likely means the OS image used has a non-matching configuration."
     } elseif ($NoReboot) {
         Write-Verbose "Reboot required"
         return @{"RebootRequired" = $true}

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -310,7 +310,7 @@ if ($Cleanup) {
         # 1   - Delay (in minutes) after boot until simulation engages
         #       This is the lowest value configurable via verifier.exe.
         # WARNING: xdp.sys itself may fail to load due to low resources simulation.
-        Write-Verbose "verifier.exe /standard /faults 599 `"`" `"`" 1  /driver xdp.sys fnmp.sys ebpfcore.sys"
+        Write-Verbose "verifier.exe /standard /faults 599 `"`" `"`" 1  /driver xdp.sys ebpfcore.sys"
         verifier.exe /standard /faults 599 `"`" `"`" 1  /driver xdp.sys fnmp.sys ebpfcore.sys | Write-Verbose
         if (!$?) {
             $Reboot = $true

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -311,7 +311,7 @@ if ($Cleanup) {
         #       This is the lowest value configurable via verifier.exe.
         # WARNING: xdp.sys itself may fail to load due to low resources simulation.
         Write-Verbose "verifier.exe /standard /faults 599 `"`" `"`" 1  /driver xdp.sys ebpfcore.sys"
-        verifier.exe /standard /faults 599 `"`" `"`" 1  /driver xdp.sys fnmp.sys ebpfcore.sys | Write-Verbose
+        verifier.exe /standard /faults 599 `"`" `"`" 1  /driver xdp.sys ebpfcore.sys | Write-Verbose
         if (!$?) {
             $Reboot = $true
         }

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -310,13 +310,19 @@ if ($Cleanup) {
         # 1   - Delay (in minutes) after boot until simulation engages
         #       This is the lowest value configurable via verifier.exe.
         # WARNING: xdp.sys itself may fail to load due to low resources simulation.
-        Write-Verbose "verifier.exe /standard /faults 599 `"`" `"`" 1  /driver xdp.sys ebpfcore.sys"
-        verifier.exe /standard /faults 599 `"`" `"`" 1  /driver xdp.sys ebpfcore.sys | Write-Verbose
+        Write-Verbose "verifier.exe /standard /faults 599 `"`" `"`" 1  /driver xdp.sys fnmp.sys ebpfcore.sys"
+        verifier.exe /standard /faults 599 `"`" `"`" 1  /driver xdp.sys fnmp.sys ebpfcore.sys | Write-Verbose
         if (!$?) {
             $Reboot = $true
         }
 
         Enable-CrashDumps
+        Download-Fn-Runtime
+        Write-Verbose "$(Get-FnRuntimeDir)/tools/prepare-machine.ps1 -ForTest -NoReboot"
+        $FnResult = & "$(Get-FnRuntimeDir)/tools/prepare-machine.ps1" -ForTest -NoReboot
+        if ($null -ne $FnResult -and $FnResult -contains "RebootRequired" -and $FnResult["RebootRequired"]) {
+            $Reboot = $true
+        }
     }
 
     if ($ForPerfTest) {

--- a/tools/spinxsk.ps1
+++ b/tools/spinxsk.ps1
@@ -192,7 +192,7 @@ while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes))
             "-IfIndex", (Get-NetAdapter $AdapterName).ifIndex, `
             "-QueueCount", $QueueCount, `
             "-Minutes", $ThisIterationMinutes, `
-            "-GlobalConcurrentWorkerCount", $GlobalConcurrentWorkerCount
+            "-GlobalConcurrentWorkers", $GlobalConcurrentWorkerCount
         if ($Stats) {
             $Args += "-Stats"
         }

--- a/tools/spinxsk.ps1
+++ b/tools/spinxsk.ps1
@@ -82,7 +82,9 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("XDPMP", "FNMP")]
-    [string]$Driver = "XDPMP",
+    [string]$Driver = "FNMP",
+    # TODO guhetier: XDPMP by default, but using FNMP to test CI easily
+    # [string]$Driver = "XDPMP",
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("NDIS", "FNDIS")]

--- a/tools/spinxsk.ps1
+++ b/tools/spinxsk.ps1
@@ -24,8 +24,8 @@ more coverage for setup and cleanup.
 .Parameter FuzzerCount
     Number of fuzzer threads per queue.
 
-.Parameter RxInjecterCount
-    Number of threads injecting frames (with FNMP only).
+.Parameter GlobalConcurrentWorkerCount
+    Number of concurrent threads 
 
 .Parameter SuccessThresholdPercent
     Minimum socket success rate, percent.
@@ -72,7 +72,7 @@ param (
     [Int32]$FuzzerCount = 0,
 
     [Parameter(Mandatory = $false)]
-    [Int32]$RxInjecterCount = 2,
+    [Int32]$GlobalConcurrentWorkerCount = 2,
 
     [Parameter(Mandatory = $false)]
     [Int32]$SuccessThresholdPercent = -1,
@@ -191,7 +191,8 @@ while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes))
         $Args = `
             "-IfIndex", (Get-NetAdapter $AdapterName).ifIndex, `
             "-QueueCount", $QueueCount, `
-            "-Minutes", $ThisIterationMinutes
+            "-Minutes", $ThisIterationMinutes, `
+            "-GlobalConcurrentWorkerCount", $GlobalConcurrentWorkerCount
         if ($Stats) {
             $Args += "-Stats"
         }
@@ -214,7 +215,6 @@ while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes))
         }
         if ($Driver -eq "FNMP") {
             $Args += "-UseFnmp"
-            $Args += "-RxInjecterCount", $RxInjecterCount
         }
         Write-Verbose "$SpinXsk $Args"
         & $SpinXsk $Args

--- a/tools/spinxsk.ps1
+++ b/tools/spinxsk.ps1
@@ -143,7 +143,7 @@ while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes))
             & "$RootDir\tools\log.ps1" -Start -Name spinxskebpf_$Driver -Profile SpinXskEbpf.Verbose -LogMode Memory -Config $Config -Platform $Platform
             if ($Platform -ne "arm64") {
                 # Our spinxsk pool does not yet support Gen6 VMs, so skip the profile.
-                & "$RootDir\tools\log.ps1" -Start -Name spinxskcpu -Profile CpuCswitchSample.Verbose -Config $Config -Platform $Platform
+                & "$RootDir\tools\log.ps1" -Start -Name spinxskcpu_$Driver -Profile CpuCswitchSample.Verbose -Config $Config -Platform $Platform
             }
         }
         if ($XdpmpPollProvider -eq "FNDIS") {
@@ -230,7 +230,7 @@ while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes))
         if (!$NoLogs) {
             if ($Platform -ne "arm64") {
                 # Our spinxsk pool does not yet support Gen6 VMs, so skip the profile.
-                & "$RootDir\tools\log.ps1" -Stop -Name spinxskcpu -Config $Config -Platform $Platform -ErrorAction 'Continue'
+                & "$RootDir\tools\log.ps1" -Stop -Name spinxskcpu_$Driver -Config $Config -Platform $Platform -ErrorAction 'Continue'
             }
             & "$RootDir\tools\log.ps1" -Stop -Name spinxskebpf_$Driver -Config $Config -Platform $Platform -ErrorAction 'Continue'
             & "$RootDir\tools\log.ps1" -Stop -Name spinxsk_$Driver -Config $Config -Platform $Platform -ErrorAction 'Continue'

--- a/tools/spinxsk.ps1
+++ b/tools/spinxsk.ps1
@@ -24,6 +24,9 @@ more coverage for setup and cleanup.
 .Parameter FuzzerCount
     Number of fuzzer threads per queue.
 
+.Parameter RxInjecterCount
+    Number of threads injecting frames (with FNMP only).
+
 .Parameter SuccessThresholdPercent
     Minimum socket success rate, percent.
 
@@ -67,6 +70,9 @@ param (
 
     [Parameter(Mandatory = $false)]
     [Int32]$FuzzerCount = 0,
+
+    [Parameter(Mandatory = $false)]
+    [Int32]$RxInjecterCount = 2,
 
     [Parameter(Mandatory = $false)]
     [Int32]$SuccessThresholdPercent = -1,
@@ -208,6 +214,7 @@ while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes))
         }
         if ($Driver -eq "FNMP") {
             $Args += "-UseFnmp"
+            $Args += "-RxInjecterCount", $RxInjecterCount
         }
         Write-Verbose "$SpinXsk $Args"
         & $SpinXsk $Args

--- a/tools/spinxsk.ps1
+++ b/tools/spinxsk.ps1
@@ -172,7 +172,7 @@ while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes))
             $AdapterName = "XDPMP"
         } else {
             Write-Verbose "installing fnmp..."
-            & "$RootDir\scripts\setup.ps1" -Install fnmp -Config $Config -Arch $Arch
+            & "$RootDir\tools\setup.ps1" -Install fnmp -Config $Config -Platform $Platform
             Write-Verbose "installed fnmp."
 
             $AdapterName = "XDPFNMP"

--- a/tools/spinxsk.ps1
+++ b/tools/spinxsk.ps1
@@ -208,6 +208,9 @@ while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes))
         if ($EnableEbpf) {
             $Args += "-EnableEbpf"
         }
+        if ($Driver -eq "FNMP") {
+            $Args += "-UseFnmp"
+        }
         Write-Verbose "$SpinXsk $Args"
         & $SpinXsk $Args
         if ($LastExitCode -ne 0) {

--- a/tools/spinxsk.ps1
+++ b/tools/spinxsk.ps1
@@ -82,9 +82,7 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("XDPMP", "FNMP")]
-    [string]$Driver = "FNMP",
-    # TODO guhetier: XDPMP by default, but using FNMP to test CI easily
-    # [string]$Driver = "XDPMP",
+    [string]$Driver = "XDPMP",
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("NDIS", "FNDIS")]
@@ -141,8 +139,8 @@ while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes))
 
     try {
         if (!$NoLogs) {
-            & "$RootDir\tools\log.ps1" -Start -Name spinxsk -Profile SpinXsk.Verbose -Config $Config -Platform $Platform
-            & "$RootDir\tools\log.ps1" -Start -Name spinxskebpf -Profile SpinXskEbpf.Verbose -LogMode Memory -Config $Config -Platform $Platform
+            & "$RootDir\tools\log.ps1" -Start -Name spinxsk_$Driver -Profile SpinXsk.Verbose -Config $Config -Platform $Platform
+            & "$RootDir\tools\log.ps1" -Start -Name spinxskebpf_$Driver -Profile SpinXskEbpf.Verbose -LogMode Memory -Config $Config -Platform $Platform
             if ($Platform -ne "arm64") {
                 # Our spinxsk pool does not yet support Gen6 VMs, so skip the profile.
                 & "$RootDir\tools\log.ps1" -Start -Name spinxskcpu -Profile CpuCswitchSample.Verbose -Config $Config -Platform $Platform
@@ -234,8 +232,8 @@ while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes))
                 # Our spinxsk pool does not yet support Gen6 VMs, so skip the profile.
                 & "$RootDir\tools\log.ps1" -Stop -Name spinxskcpu -Config $Config -Platform $Platform -ErrorAction 'Continue'
             }
-            & "$RootDir\tools\log.ps1" -Stop -Name spinxskebpf -Config $Config -Platform $Platform -ErrorAction 'Continue'
-            & "$RootDir\tools\log.ps1" -Stop -Name spinxsk -Config $Config -Platform $Platform -ErrorAction 'Continue'
+            & "$RootDir\tools\log.ps1" -Stop -Name spinxskebpf_$Driver -Config $Config -Platform $Platform -ErrorAction 'Continue'
+            & "$RootDir\tools\log.ps1" -Stop -Name spinxsk_$Driver -Config $Config -Platform $Platform -ErrorAction 'Continue'
         }
     }
 }


### PR DESCRIPTION
## Description

Add FNMP support for spinxsk.
When using FNMP, spinxsk will inject randomized UDP frames on the receive path.

The following parameters are randomized:
- Address family: IPv4 / IPv6
- Data offset in NB
- Number of MBL (1 to 3)
- Local and remote port
- Whether to generate a QUIC header or not 
- Whether to use a TCP or UDP header
- Size of the UDP / TCP / QUIC payload

## Testing

N/A

## Documentation

N/A

## Installation

N/A
