### PR TITLE
Remove invalid assertion in XDPLWF in low resource scenario

### DIFF
--- a/src/xdplwf/recv.c
+++ b/src/xdplwf/recv.c
@@ -1631,7 +1631,6 @@ XdpGenericReceivePostInspectNbs(
             // N.B. This releases and reacquires the EC spinlock.
             //
             ASSERT(!RxQueue->Flags.TxInspect);
-            ASSERT(FrameRing->InterfaceReserved == FrameRing->ProducerIndex);
             XdpGenericReceiveLowResources(
                 RxQueue->Generic->NdisFilterHandle, &RxQueue->EcLock, PassList, DropList,
                 LowResourcesList, PortNumber, (NbHead == NULL));


### PR DESCRIPTION
## Description

Remove an invalid assertion in XDPLWF for low resource scenario.
The assertion was triggered through a run of SpinXsk with added support for FNMP.

The assertion assumed that it could be reached only when a single NB would be processed by the function.
This is incorrect: in low resource scenario, XDPLWF ensures that a single frame is submitted to XDP for inspection, but it can skip multiple NB (loopback, failure to map the MDL).
When this is the case, the pose-inspection will need to process multiple NB and the assertion can be incorrect if an NB was skipped then another NB was submitted for inspection.

## Testing

C/I, no logic change.

## Documentation

N/A

## Installation

N/A