### PR TITLE
Fix minor NuGet packaging issues

### DIFF
--- a/src/nuget/nuget.vcxproj
+++ b/src/nuget/nuget.vcxproj
@@ -31,7 +31,7 @@
     <PostBuildEvent>
       <Command>
         powershell -NonInteractive -ExecutionPolicy Unrestricted ..\..\tools\update-nuspec.ps1 -InputFile xdp-for-windows.nuspec.in -OutputFile $(IntDir)xdp-for-windows.nuspec -Platform $(NugetPlatforms) -Config $(Configuration)
-        NuGet.exe pack $(IntDir)xdp-for-windows.nuspec -OutputDirectory $(OutDir) -BasePath $(ProjectDir)
+        NuGet.exe pack $(IntDir)xdp-for-windows.nuspec -OutputDirectory $(OutDir) -BasePath $(ProjectDir) -Properties TreatWarningsAsErrors=true
       </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>

--- a/src/nuget/xdp-for-windows.nuspec.in
+++ b/src/nuget/xdp-for-windows.nuspec.in
@@ -15,7 +15,7 @@
         <repository type="git" url="https://github.com/microsoft/xdp" commit="{commit}" />
     </metadata>
     <files>
-        <file src="xdp-for-windows.props" target="build\native"/>
+        <file src="xdp-for-windows.props" target="build\native\Microsoft.XDP-for-Windows.Sdk.props"/>
         <file src="{rootpath}\published\external\**" target="build\native\include"/>
         <file src="{binpath_anyarch}\xdpbpfexport.exe" target="build\native\bin\{anyarch}"/>
         <file src="{binpath_anyarch}\xdpapi.lib" target="build\native\lib\{anyarch}"/>

--- a/src/xdpruntime/xdp-for-windows-runtime.nuspec.in
+++ b/src/xdpruntime/xdp-for-windows-runtime.nuspec.in
@@ -15,6 +15,7 @@
         <repository type="git" url="https://github.com/microsoft/xdp" commit="{commit}" />
     </metadata>
     <files>
+        <file src="xdp-for-windows-runtime.props" target="build\native\Microsoft.XDP-for-Windows.Runtime.{arch}.props"/>
         <file src="{binpath_anyarch}\xdp-setup.ps1" target="runtime\native"/>
         <file src="{binpath_anyarch}\xdpbpfexport.exe" target="runtime\native"/>
         <file src="{binpath_anyarch}\xdpbpfexport.pdb" target="runtime\native"/>

--- a/src/xdpruntime/xdp-for-windows-runtime.props
+++ b/src/xdpruntime/xdp-for-windows-runtime.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation -->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0">
+    <!-- No definitions currently needed, but this file is included to ensure there is valid content under a recognized
+    directory for the 'native' target framework moniker (TFM). -->
+ </Project>

--- a/src/xdpruntime/xdpruntime.vcxproj
+++ b/src/xdpruntime/xdpruntime.vcxproj
@@ -38,6 +38,6 @@
   </Target>
   <Target Name="BuildNuget" AfterTargets="Build" Condition="$(BuildStage) != 'Binary'">
       <Exec Command="powershell.exe /c &quot;$(SolutionDir)tools\update-nuspec.ps1 -InputFile xdp-for-windows-runtime.nuspec.in -OutputFile $(IntDir)xdp-for-windows-runtime.nuspec -Platform $(Platform) -Config $(Configuration)&quot;" />
-      <Exec Command="NuGet.exe pack $(IntDir)xdp-for-windows-runtime.nuspec -OutputDirectory $(OutDir) -BasePath $(ProjectDir) -Properties NoWarn=NU5100,NU5110,NU5111" />
+      <Exec Command="NuGet.exe pack $(IntDir)xdp-for-windows-runtime.nuspec -OutputDirectory $(OutDir) -BasePath $(ProjectDir) -Properties NoWarn=NU5100,NU5110,NU5111;TreatWarningsAsErrors=true" />
   </Target>
 </Project>


### PR DESCRIPTION
## Description

Fix issue where the redistributable NuGet package isn't restored when listed as a package dependency of another package. Eg.

```XML
<group targetFramework="native0.0">
  <dependency id="XDP-for-Windows-Runtime.x64" version="1.1.0" />
</group>  
```

This is due to the package not containing any content that targets the `native` target framework moniker (TFM). The package must contain at least one item group that specifies the `native` TFM, otherwise the dependency is silently ignored as the tooling doesn't detect any matching content.

Also fix issue where warnings generated during NuGet packing did not fail the build.

Fixes #822 #821

## Testing

* Built new package locally, listed it as a dependency in a test project's `.nuspec` and validated the package was listed as a dependency in the dependent package:

 From NuGet Package Explorer:
<img width="256" alt="image" src="https://github.com/user-attachments/assets/6fba56cc-1e1d-408a-a315-ca0ac30dd087" />

## Documentation

N/A

## Installation

N/A