### PR TITLE
Fix a race condition in xdp receive path in low resources scenario

### DIFF
--- a/src/xdpetw/xdpetw.man
+++ b/src/xdpetw/xdpetw.man
@@ -315,6 +315,43 @@
                 outType="win:HexInt32"
                 />
           </template>
+          <template tid="tid_GenericRxInspectRing">
+            <data
+                inType="win:Pointer"
+                name="RxQueue"
+                outType="win:HexInt64"
+                />
+            <data
+                inType="win:UInt8"
+                name="LowResources"
+                outType="xs:boolean"
+                />
+            <data
+                inType="win:UInt32"
+                name="RingProducerIndex"
+                outType="win:HexInt32"
+                />
+            <data
+                inType="win:UInt32"
+                name="RingConsumerIndex"
+                outType="win:HexInt32"
+                />
+            <data
+                inType="win:UInt32"
+                name="RingResultIndex"
+                outType="win:HexInt32"
+                />
+            <data
+                inType="win:Pointer"
+                name="NetBufferHead"
+                outType="win:HexInt64"
+                />
+            <data
+                inType="win:Pointer"
+                name="NetBufferTail"
+                outType="win:HexInt64"
+                />
+          </template>
         </templates>
         <events>
           <event
@@ -516,6 +553,26 @@
               template="tid_EbpfProgramFailure"
               value="20"
               />
+          <event
+              channel="CHID_XDP"
+              keywords="Generic Rx"
+              level="XdpPerFrame"
+              message="$(string.GenericRxInspectRingStart.EventMessage)"
+              opcode="GenericRxFilter"
+              symbol="GenericRxInspectRingStart"
+              template="tid_GenericRxInspectRing"
+              value="21"
+              />
+          <event
+              channel="CHID_XDP"
+              keywords="Generic Rx"
+              level="XdpPerFrame"
+              message="$(string.GenericRxInspectRingStop.EventMessage)"
+              opcode="GenericRxFilter"
+              symbol="GenericRxInspectRingStop"
+              template="tid_GenericRxInspectRing"
+              value="22"
+              />
         </events>
       </provider>
     </events>
@@ -602,6 +659,14 @@
         <string
             id="EbpfProgramFailure.EventMessage"
             value="[ebpf][%1] program failed EbpfResult=%2"
+            />
+        <string
+            id="GenericRxInspectRingStart.EventMessage"
+            value="[gxrf][%1] Rx ring submitted for inspection LowResources=%2 RingProducerIndex=%3 RingConsumerIndex=%4 RingResultIndex=%5 NetBufferHead=%6 NetBufferTail=%7"
+            />
+        <string
+            id="GenericRxInspectRingStop.EventMessage"
+            value="[gxrf][%1] Rx ring inspection complete LowResources=%2 RingProducerIndex=%3 RingConsumerIndex=%4 RingResultIndex=%5 NetBufferHead=%6 NetBufferTail=%7"
             />
       </stringTable>
     </resources>

--- a/src/xdplwf/recv.c
+++ b/src/xdplwf/recv.c
@@ -1679,7 +1679,7 @@ XdpGenericReceivePostInspectNbs(
             // NB at a time in low resources scenario.
             //
             ASSERT(!RxQueue->Flags.TxInspect);
-            ASSERT(FrameRing->ConsumerIndex == FrameRing->InterfaceReserved);
+            ASSERT(FrameRing->InterfaceReserved == FrameRing->ProducerIndex);
             XdpGenericReceiveLowResources(
                 RxQueue->Generic->NdisFilterHandle, &RxQueue->EcLock, PassList, DropList,
                 LowResourcesList, PortNumber, (NbHead == NULL));

--- a/src/xdplwf/recv.c
+++ b/src/xdplwf/recv.c
@@ -1640,7 +1640,7 @@ XdpGenericReceivePostInspectNbs(
         //
         // In low resource scenarios, only one NB should be processed at a time.
         //
-		ASSERT(CanPend || NbHead == NbTail);
+        ASSERT(CanPend || NbHead == NbTail);
 
         //
         // Now that we've finished dereferencing ActionNbl, apply the RX action.

--- a/src/xdplwf/recv.c
+++ b/src/xdplwf/recv.c
@@ -1515,7 +1515,7 @@ XdpGenericReceivePreInspectNbs(
     ASSERT(RxQueue->FrameRing->ConsumerIndex == RxQueue->FrameRing->InterfaceReserved);
     ASSERT(RxQueue->FrameRing->ConsumerIndex == RxQueue->FrameRing->ProducerIndex);
 
-    InspectionNeeded = FALSE;
+    *InspectionNeeded = FALSE;
 
     //
     // For low resources indications (CanPend == FALSE), ensure only one NBL
@@ -1530,7 +1530,7 @@ XdpGenericReceivePreInspectNbs(
         ASSERT(XdpRingFree(RxQueue->FrameRing) > 0);
 
         XdpGenericReceivePreinspectNb(RxQueue, *Nbl, *Nb, &NbAddedToRing, &FlushNeeded);
-        InspectionNeeded |= NbAddedToRing;
+        *InspectionNeeded |= NbAddedToRing;
         if (FlushNeeded) {
             return;
         }

--- a/src/xdplwf/recv.c
+++ b/src/xdplwf/recv.c
@@ -1633,7 +1633,7 @@ XdpGenericReceivePostInspectNbs(
             ASSERT(!RxQueue->Flags.TxInspect);
             XdpGenericReceiveLowResources(
                 RxQueue->Generic->NdisFilterHandle, &RxQueue->EcLock, PassList, DropList,
-                LowResourcesList, PortNumber, (NbHead == NULL));
+                LowResourcesList, PortNumber, (NbHead == NbTail));
         }
     }
 

--- a/src/xdplwf/recv.c
+++ b/src/xdplwf/recv.c
@@ -1496,7 +1496,6 @@ XdpGenericReceivePreinspectNb(
     FrameRing->ProducerIndex++;
 
     *NbAddedToRing = TRUE;
-    return;
 }
 
 static

--- a/src/xdplwf/recv.c
+++ b/src/xdplwf/recv.c
@@ -1400,7 +1400,7 @@ XdpGenericReceivePreinspectNb(
     // on the receive path. Skip inspection of these packets.
     //
     if (NdisTestNblFlag(Nbl, NDIS_NBL_FLAGS_IS_LOOPBACK_PACKET)) {
-        STAT_INC(&RxQueue->PcwStats, NdisLoopbackPackets);
+        STAT_INC(&RxQueue->PcwStats, LoopbackNblsSkipped);
         return;
     }
 

--- a/src/xdppcw/inc/xdppcw.h
+++ b/src/xdppcw/inc/xdppcw.h
@@ -31,7 +31,7 @@ typedef struct _XDP_PCW_LWF_RX_QUEUE {
     UINT64 ForwardingFailuresRscInvalidHeaders;
     UINT64 ForwardingNbsRequested;
     UINT64 ForwardingNbsSent;
-    UINT64 NdisLoopbackPackets;
+    UINT64 LoopbackNblsSkipped;
 } XDP_PCW_LWF_RX_QUEUE;
 
 typedef struct _XDP_PCW_TX_QUEUE {

--- a/src/xdppcw/inc/xdppcw.h
+++ b/src/xdppcw/inc/xdppcw.h
@@ -31,6 +31,7 @@ typedef struct _XDP_PCW_LWF_RX_QUEUE {
     UINT64 ForwardingFailuresRscInvalidHeaders;
     UINT64 ForwardingNbsRequested;
     UINT64 ForwardingNbsSent;
+    UINT64 NdisLoopbackPackets;
 } XDP_PCW_LWF_RX_QUEUE;
 
 typedef struct _XDP_PCW_TX_QUEUE {

--- a/src/xdppcw/xdppcw.man
+++ b/src/xdppcw/xdppcw.man
@@ -267,7 +267,7 @@
           <counter
             id="8"
             uri="Microsoft.Xdp.LwfRxQueue.LoopbackNblsSkipped"
-            name="Ndis Loopback NBLs Skipped"
+            name="NDIS Loopback NBLs Skipped"
             nameID="3032"
             field="LoopbackNblsSkipped"
             description="Ndis Loopback NBLs, which skip XDP inspection."

--- a/src/xdppcw/xdppcw.man
+++ b/src/xdppcw/xdppcw.man
@@ -266,11 +266,11 @@
             />
           <counter
             id="8"
-            uri="Microsoft.Xdp.LwfRxQueue.NdisLoopbackPackets"
-            name="Ndis Loopback Packets"
+            uri="Microsoft.Xdp.LwfRxQueue.LoopbackNblsSkipped"
+            name="Ndis Loopback Nbls Slipped"
             nameID="3032"
-            field="NdisLoopbackPackets"
-            description="Ndis Loopback Frames, which are not submitted to XDP for inspection."
+            field="LoopbackNblsSkipped"
+            description="Ndis Loopback Nbls, which skip XDP inspection."
             descriptionID="3034"
             type="perf_counter_rawcount"
             aggregate="sum"

--- a/src/xdppcw/xdppcw.man
+++ b/src/xdppcw/xdppcw.man
@@ -264,6 +264,19 @@
             detailLevel="standard"
             defaultScale="1"
             />
+          <counter
+            id="8"
+            uri="Microsoft.Xdp.LwfRxQueue.NdisLoopbackPackets"
+            name="Ndis Loopback Packets"
+            nameID="3032"
+            field="NdisLoopbackPackets"
+            description="Ndis Loopback Frames, which are not submitted to XDP for inspection."
+            descriptionID="3034"
+            type="perf_counter_rawcount"
+            aggregate="sum"
+            detailLevel="standard"
+            defaultScale="1"
+            />
         </counterSet>
         <counterSet
           guid="{05947256-79cd-4393-b54c-a65be0963294}"

--- a/src/xdppcw/xdppcw.man
+++ b/src/xdppcw/xdppcw.man
@@ -267,10 +267,10 @@
           <counter
             id="8"
             uri="Microsoft.Xdp.LwfRxQueue.LoopbackNblsSkipped"
-            name="Ndis Loopback Nbls Slipped"
+            name="Ndis Loopback NBLs Skipped"
             nameID="3032"
             field="LoopbackNblsSkipped"
-            description="Ndis Loopback Nbls, which skip XDP inspection."
+            description="Ndis Loopback NBLs, which skip XDP inspection."
             descriptionID="3034"
             type="perf_counter_rawcount"
             aggregate="sum"


### PR DESCRIPTION
## Description

Fix a race condition in xdp receive path in low resources scenario.

## Background

In low resource scenario, XDP must return the NBL chain unchanged to NDIS.

To do so, in `XdpGenericReceivePostInspectNbs`, it flushes NetBuffers that need to be passed to the next driver in `XdpGenericReceiveLowResources`, so it can re-assemble the NBL chain in order (if waiting as in the non-low resource path, in-order reassembly would become complex, since NBLs would be split between a "drop" and "pass" lists).

To optimize this logic, the code tries to indicate batches of NBLs when possible, by indicating a sequence of packets only when a packet needs to be dropped. The batch of NBLs is easy to put back in order: first all the indicated "PASS" NBLs, then the DROP NBL.
The following sequence of action should result in two indications: one when a packet is dropped, one at the end of the sequence.

> PASS -> PASS -> PASS -> DROP [indicate] -> PASS -> PASS [indicate]

`XdpGenericReceiveLowResources` must releas and re-acquire the execution context lock when indicating packets:
another thread can start queuing packets for inspection at that point, so the state of the ring buffer must be consistent when releasing the lock.

To ensure that, in low resource mode, `XdpGenericReceivePreInspectNbs` add a single NBL at a time in XDP ring buffer. This packet can be grouped with NBL that are skipping the inspection and are not added to the ring buffer (loopback, failure to map the VA...)

> SKIP -> ADD_TO_RING [inspect] -> ADD_TO_RING [inspect] || SKIP -> SKIP -> ADD_TO_RING [inspect]

The reasoning likely being that this way, when indicating NBLs, the NBL from the ring would have already been retrieved and the ring be in a clean state for another thread. 

This is wrong on several scenarios.

## What is wrong

### First issue: A flush is done only after processing the full chain

For this sequence:

> ADD_TO_RING+PASS -> SKIP+DROP -> ADD_TO_RING+PASS

(NBL skipped because of fault injection or mapping failure)

- After the first inspection, the pass list contains the first NBL.
- The second pre-inspection will skip one NBL and add one to the ring
- The second post-inspection sees the DROP for the skipped NBL first, with an NBL present in the PASS list
    - it indicates the first PASS NBL, with the second PASS NBL still in the ring => ERROR

### Second issue: Loopback packets default to PASS

For this sequence:

> SKIP+PASS -> SKIP+DROP -> ADD_TO_RING+PASS

(first NBL skipped because of loopback, second because of fault injection or mapping failure)

- The SKIP+DROP NBL will cause the SKIP+PASS NBL to be indicated with an NBL still on the ring ==> ERROR

## Solution

First attempt: -- Flush at the end of every call to `XdpGenericReceivePostInspectNbs` --

Actually, this was a bad solution:
- almost zero batching will be done for indications since NBLs are inspected one by one
- doesn't solve the second issue

Better solution:
No longer group NBL skipping inspection with NBL skipping inspection: only consider a single NBL per "pre / inspect / post" loop. This preserve the batching of the indication up the stack and remove all risk of invalid ring buffer state.

## Testing

C/I + local run using spinxsk with FNMP

## Documentation

N/A

## Installation

N/A
