### PR TITLE
Fix loop counter type

### DIFF
--- a/test/spinxsk/spinxsk.c
+++ b/test/spinxsk/spinxsk.c
@@ -2242,7 +2242,7 @@ InjectFnmpRxFrames(
 
     TraceVerbose("FnmpInjectRx: injecting %d frames", NumFrames);
 
-    for (UINT8 i = 0; i < NumFrames; i++) {
+    for (UINT32 i = 0; i < NumFrames; i++) {
         const UINT32 backfill = RandUlong() % (FNMP_FRAME_MAX_BACKFILL + 1);
         UINT32 frameLength = frameBufferSize - backfill;
         UINT32 frameType = 0;


### PR DESCRIPTION
## Description

Fix a loop counter type flagged by code analysis.
The type was UINT8 and compared with a UINT32, potentially causing an infinite loop.
In practice, the value provided was always smaller than UINT8_MAX.

## Testing

C/I

## Documentation

N/A

## Installation

N/A
