### PR TITLE
update test signed driver docs

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,11 +23,15 @@ xdp-setup.ps1 -Install xdp
 
 ### Install a Test Version
 
-If xdp.sys is not production-signed:
+If xdp.sys is not an official production-signed release, its test sigining certificate must be installed and test signing must be enabled before installing XDP. Secure boot must be [disabled](https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/disabling-secure-boot) before test signing can be enabled.
 
-```bat
-CertUtil.exe -addstore Root CoreNetSignRoot.cer
-CertUtil.exe -addstore TrustedPublisher CoreNetSignRoot.cer
+Here's an example set of commands to extract the test signing certificate from an MSI, install it as a trusted certificate, and enable test signing:
+
+```PowerShell
+$CertFileName = 'xdp.cer'
+Get-AuthenticodeSignature 'xdp-for-windows.msi' | Select-Object -ExpandProperty SignerCertificate | Export-Certificate -Type CERT -FilePath $CertFileName
+Import-Certificate -FilePath $CertFileName -CertStoreLocation 'cert:\localmachine\root'
+Import-Certificate -FilePath $CertFileName -CertStoreLocation 'cert:\localmachine\trustedpublisher'
 bcdedit.exe /set testsigning on
 [reboot]
 ```


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

PRs #589 and #623 changed our test-signing steps to use ephemeral certificates instead of the CoreNet certificate, but while the PR description for #623 provided sample steps to install the test-signed binaries, documentation was not updated.

Resolves #831 

## Testing

_Do any existing tests cover this change? Are new tests needed?_

N/A.

## Documentation

_Is there any documentation impact for this change?_

Yes.

## Installation

_Is there any installer impact for this change?_

No.