### PR TITLE
Fix Stress CI false negatives

### DIFF
--- a/tools/spinxsk.ps1
+++ b/tools/spinxsk.ps1
@@ -25,7 +25,7 @@ more coverage for setup and cleanup.
     Number of fuzzer threads per queue.
 
 .Parameter GlobalConcurrentWorkerCount
-    Number of concurrent threads 
+    Number of concurrent threads
 
 .Parameter SuccessThresholdPercent
     Minimum socket success rate, percent.
@@ -221,6 +221,9 @@ while (($Minutes -eq 0) -or (((Get-Date)-$StartTime).TotalMinutes -lt $Minutes))
         if ($LastExitCode -ne 0) {
             throw "SpinXsk failed with $LastExitCode"
         }
+    } catch {
+        Write-Error "Something went wrong: $_"
+        exit 1
     } finally {
         if ($Driver -eq "XDPMP") {
             & "$RootDir\tools\setup.ps1" -Uninstall xdpmp -Config $Config -Platform $Platform -ErrorAction 'Continue'


### PR DESCRIPTION
## Description

Issue https://github.com/microsoft/xdp-for-windows/issues/810 points out how the Stress CI succeeds even though one of it's intermediary steps failed.

This PR aims to ensure the entire job fails if any intermediary step fails.

## Testing

CI

## Documentation

n/a

## Installation

n/a
