### PR TITLE
Output NuGet packages to a packages subdirectory

### DIFF
--- a/src/nuget/nuget.vcxproj
+++ b/src/nuget/nuget.vcxproj
@@ -20,12 +20,15 @@
       <Private>false</Private>
     </ProjectReference>
   </ItemGroup>
+  <PropertyGroup>
+    <OutDir>$(OutDir)packages\</OutDir>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(NugetPlatforms)' == ''">
     <NugetPlatforms>$(Platform)</NugetPlatforms>
   </PropertyGroup>
   <PropertyGroup Condition="'$(NugetPlatforms)' != '' AND '$(NugetPlatforms)' != '$(Platform)'">
     <!-- If targetting multiple platforms, use a platform-independent output directory. -->
-    <OutDir>$(UndockedOut)bin\$(Configuration)\</OutDir>
+    <OutDir>$(UndockedOut)bin\$(Configuration)\packages\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <PostBuildEvent>
@@ -37,7 +40,7 @@
   </ItemDefinitionGroup>
   <Target Name="CleanNuget" BeforeTargets="Clean" Condition="$(BuildStage) == '' OR $(BuildStage) == 'AllPackage'">
      <ItemGroup>
-       <FilesToDelete Include="$(OutDir)XDP-for-Windows.*.nupkg"/>
+       <FilesToDelete Include="$(OutDir)Microsoft.XDP-for-Windows.*.nupkg"/>
      </ItemGroup>
      <Delete Files="@(FilesToDelete)">
        <Output TaskParameter="DeletedFiles" ItemName="FilesDeleted"/>

--- a/src/xdpruntime/xdpruntime.vcxproj
+++ b/src/xdpruntime/xdpruntime.vcxproj
@@ -22,14 +22,15 @@
     </ProjectReference>
   </ItemGroup>
   <PropertyGroup>
+    <OutRootDir>$(OutDir)</OutRootDir>
     <OutDir>$(OutDir)packages\</OutDir>
   </PropertyGroup>
   <Import Project="$(SolutionDir)src\xdp.targets" />
-  <Target Name="CopyBinaries" BeforeTargets="Build" Condition="$(BuildStage) != 'Package'">
-      <Copy SourceFiles="xdp-setup.ps1" DestinationFolder="$(OutDir)" />
+  <Target Name="CopyBinaries" BeforeTargets="BuildNuget" Condition="$(BuildStage) != 'Package'">
+      <Copy SourceFiles="xdp-setup.ps1" DestinationFolder="$(OutRootDir)" />
   </Target>
-  <Target Name="SignBinaries" DependsOnTargets="CopyBinaries" BeforeTargets="Build" Condition="$(SignMode) != 'Off' and $(BuildStage) != 'Package'">
-      <Exec Command="powershell.exe /c &quot;&amp; '$(DriverSignToolPath)signtool.exe' sign /sha1 ([system.security.cryptography.x509certificates.x509certificate2]::new([System.IO.File]::ReadAllBytes('$(OutDir)xdp\xdp.sys'))).Thumbprint /fd sha256  $(OutDir)xdp-setup.ps1&quot;" />
+  <Target Name="SignBinaries" DependsOnTargets="CopyBinaries" BeforeTargets="BuildNuget" Condition="$(SignMode) != 'Off' and $(BuildStage) != 'Package'">
+      <Exec Command="powershell.exe /c &quot;&amp; '$(DriverSignToolPath)signtool.exe' sign /sha1 ([system.security.cryptography.x509certificates.x509certificate2]::new([System.IO.File]::ReadAllBytes('$(OutRootDir)xdp\xdp.sys'))).Thumbprint /fd sha256  $(OutRootDir)xdp-setup.ps1&quot;" />
   </Target>
   <Target Name="CleanNuget" BeforeTargets="Clean" Condition="$(BuildStage) == '' OR $(BuildStage) == 'Package'">
      <ItemGroup>

--- a/src/xdpruntime/xdpruntime.vcxproj
+++ b/src/xdpruntime/xdpruntime.vcxproj
@@ -21,6 +21,9 @@
       <Project>{e64ccf9c-9d27-4aac-8119-197faba5e8c2}</Project>
     </ProjectReference>
   </ItemGroup>
+  <PropertyGroup>
+    <OutDir>$(OutDir)packages\</OutDir>
+  </PropertyGroup>
   <Import Project="$(SolutionDir)src\xdp.targets" />
   <Target Name="CopyBinaries" BeforeTargets="Build" Condition="$(BuildStage) != 'Package'">
       <Copy SourceFiles="xdp-setup.ps1" DestinationFolder="$(OutDir)" />

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -310,7 +310,7 @@ function Install-Xdp {
         $XdpPath = Get-XdpInstallPath
         $XdpBinariesPath = "$XdpPath/$XdpRuntimeNupkgNativePath"
         $XdpSetupPath = "$XdpPath/$XdpRuntimeNupkgSetupPath"
-        $XdpRuntimeNupkgFullPath = Find-Nupkg "$ArtifactsDir\Microsoft.XDP-for-Windows.Runtime.$Platform.$XdpFileVersion*.nupkg"
+        $XdpRuntimeNupkgFullPath = Find-Nupkg "$ArtifactsDir\packages\Microsoft.XDP-for-Windows.Runtime.$Platform.$XdpFileVersion*.nupkg"
 
         Expand-Nupkg $XdpRuntimeNupkgFullPath $XdpPath | Write-Verbose
 


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Our internal build system requires NuGet packages be output to a `packages` subdirectory. Do that everywhere.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Builds locally. CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.