### PR TITLE
Improve tracing of NDIS status indications

### DIFF
--- a/src/xdplwf/offload.c
+++ b/src/xdplwf/offload.c
@@ -342,7 +342,10 @@ XdpOffloadFilterStatusWorker(
         CONTAINING_RECORD(WorkItem, XDP_LWF_OFFLOAD_INSPECT_STATUS, WorkItem);
     XDP_LWF_FILTER *Filter = WorkItem->Filter;
 
-    TraceEnter(TRACE_LWF, "Filter=%p StatusIndication=%u", Filter, InspectRequest->StatusCode);
+    TraceEnter(
+        TRACE_LWF, "Filter=%p StatusCode=%u StatusBuffer=%!HEXDUMP!",
+        Filter, InspectRequest->StatusCode,
+        WppHexDump(InspectRequest->StatusBuffer, InspectRequest->StatusBufferSize));
 
     switch (InspectRequest->StatusCode) {
     case NDIS_STATUS_TASK_OFFLOAD_CURRENT_CONFIG:
@@ -366,7 +369,7 @@ XdpOffloadFilterStatus(
     XDP_LWF_OFFLOAD_INSPECT_STATUS *InspectRequest = NULL;
     NTSTATUS Status;
 
-    TraceEnter(TRACE_LWF, "Filter=%p StatusIndication=%u", Filter, StatusIndication->StatusCode);
+    TraceEnter(TRACE_LWF, "Filter=%p StatusCode=%u", Filter, StatusIndication->StatusCode);
 
     InspectRequest = ExAllocatePoolZero(NonPagedPoolNx, sizeof(*InspectRequest), POOLTAG_OFFLOAD);
     if (InspectRequest == NULL) {


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

When investigating failure to checksum offload in netperf for MsQuic, the XDP traces were missing some useful information about the NIC's actual advertised capabilities and configuration. This adds a backstop of logging the contents of all NDIS status indications handled by XDP.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.