### PR TITLE
make tcp options optional in checksum offload

### DIFF
--- a/published/external/afxdp_experimental.h
+++ b/published/external/afxdp_experimental.h
@@ -98,7 +98,7 @@ typedef enum _XSK_POLL_MODE {
 // XSK_SOCKOPT_TX_OFFLOAD_CURRENT_CONFIG_CHECKSUM
 //
 // Supports: get
-// Optval type: UINT32
+// Optval type: XDP_CHECKSUM_CONFIGURATION
 // Description: Returns the TX queue's current checksum offload configuration.
 //
 #define XSK_SOCKOPT_TX_OFFLOAD_CURRENT_CONFIG_CHECKSUM 1004

--- a/published/external/xdpapi_experimental.h
+++ b/published/external/xdpapi_experimental.h
@@ -178,14 +178,20 @@ typedef struct _XDP_CHECKSUM_CONFIGURATION {
     XDP_OBJECT_HEADER Header;
 
     //
-    // Indicates whether checksum offload is enabled.
+    // Indicates whether basic checksum offloads are enabled.
+    // Includes RX and TX (as appropriate for a queue) IPv4,
+    // UDP, and TCP checksums.
     //
     BOOLEAN Enabled;
+    //
+    // Indicates whether TCP header options are enabled.
+    //
+    BOOLEAN TcpOptions;
 } XDP_CHECKSUM_CONFIGURATION;
 
 #define XDP_CHECKSUM_CONFIGURATION_REVISION_1 1
 #define XDP_SIZEOF_CHECKSUM_CONFIGURATION_REVISION_1 \
-    RTL_SIZEOF_THROUGH_FIELD(XDP_CHECKSUM_CONFIGURATION, Enabled)
+    RTL_SIZEOF_THROUGH_FIELD(XDP_CHECKSUM_CONFIGURATION, TcpOptions)
 
 typedef enum _XDP_QUIC_OPERATION {
     XDP_QUIC_OPERATION_ADD,     // Add (or modify) a QUIC connection offload

--- a/src/xdplwf/offload.h
+++ b/src/xdplwf/offload.h
@@ -16,6 +16,7 @@ typedef struct _XDP_LWF_OFFLOAD_SETTING_RSS {
 typedef struct _XDP_LWF_OFFLOAD_SETTING_TASK_OFFLOAD {
     struct {
         BOOLEAN Enabled : 1;
+        BOOLEAN TcpOptions : 1;
     } Checksum;
     struct {
         UINT32 MaxOffloadSize;

--- a/src/xdplwf/offloadtask.c
+++ b/src/xdplwf/offloadtask.c
@@ -282,7 +282,7 @@ XdpOffloadUpdateTaskOffloadConfig(
     TraceInfo(
         TRACE_LWF,
         "Filter=%p updated task offload. "
-        "Checksum.Enabled=%!BOOLEAN! Checksum.TcpOptions=%!BOOLEAN"
+        "Checksum.Enabled=%!BOOLEAN! Checksum.TcpOptions=%!BOOLEAN!"
         "Lso.MaxOffloadSize=%u Lso.MinSegments=%u",
         Filter, NewOffload->Checksum.Enabled, NewOffload->Checksum.TcpOptions,
         NewOffload->Lso.MaxOffloadSize, NewOffload->Lso.MinSegments);

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -6510,6 +6510,7 @@ GenericTxChecksumOffloadConfig()
     TEST_EQUAL(XDP_CHECKSUM_CONFIGURATION_REVISION_1, ChecksumConfig.Header.Revision);
     TEST_EQUAL(XDP_SIZEOF_CHECKSUM_CONFIGURATION_REVISION_1, ChecksumConfig.Header.Size);
     TEST_TRUE(ChecksumConfig.Enabled);
+    TEST_TRUE(ChecksumConfig.TcpOptions);
 
     TEST_FALSE(XskRingOffloadChanged(&Xsk.Rings.Tx));
 }


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Resolves #847. This is a breaking change and are intentionally not backward-compatible with previous iterations of this experimental/preview feature.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Minimal test case added.

## Documentation

_Is there any documentation impact for this change?_

Updated, within the headers.

## Installation

_Is there any installer impact for this change?_

No.