### PR TITLE
test and fix getsockopt behavior with zero-size output buffer

### DIFF
--- a/docs/api/XskGetSockopt.md
+++ b/docs/api/XskGetSockopt.md
@@ -9,18 +9,21 @@ XDP_STATUS
 XskGetSockopt(
     _In_ HANDLE Socket,
     _In_ UINT32 OptionName,
-    _Out_writes_bytes_(*OptionLength) VOID *OptionValue,
+    _Out_opt_writes_bytes_(*OptionLength) VOID *OptionValue,
     _Inout_ UINT32 *OptionLength
     );
 ```
 
 ## Parameters
 
-TODO
+- Socket - An AF_XDP socket handle.
+- OptionName - A [socket option](xsk-sockopts.md).
+- OptionValue - An optional buffer of size `OptionLength`. If `OptionLength` is nonzero, the buffer must not be `NULL`.
+- OptionLength - The size of the `OptionValue` output buffer. If the input value is `0` and `XskGetSockopt` returns `HRESULT_FROM_WIN32(ERROR_MORE_DATA)`, the output value is the required buffer size. If `XskGetSockopt` succeeds, the output value is the number of bytes written to the output buffer.
 
 ## Remarks
 
-TODO
+None.
 
 ## See Also
 

--- a/published/external/afxdp.h
+++ b/published/external/afxdp.h
@@ -199,7 +199,7 @@ XDP_STATUS
 XskGetSockopt(
     _In_ HANDLE Socket,
     _In_ UINT32 OptionName,
-    _Out_writes_bytes_(*OptionLength) VOID *OptionValue,
+    _Out_writes_bytes_opt_(*OptionLength) VOID *OptionValue,
     _Inout_ UINT32 *OptionLength
     );
 
@@ -209,7 +209,7 @@ XskIoctl(
     _In_ UINT32 OptionName,
     _In_reads_bytes_opt_(InputLength) const VOID *InputValue,
     _In_ UINT32 InputLength,
-    _Out_writes_bytes_(*OutputLength) VOID *OutputValue,
+    _Out_writes_bytes_opt_(*OutputLength) VOID *OutputValue,
     _Inout_ UINT32 *OutputLength
     );
 

--- a/published/external/xdp/afxdp_v1.h
+++ b/published/external/xdp/afxdp_v1.h
@@ -88,7 +88,7 @@ HRESULT
 XSK_GET_SOCKOPT_FN(
     _In_ HANDLE Socket,
     _In_ UINT32 OptionName,
-    _Out_writes_bytes_(*OptionLength) VOID *OptionValue,
+    _Out_writes_bytes_opt_(*OptionLength) VOID *OptionValue,
     _Inout_ UINT32 *OptionLength
     );
 
@@ -99,7 +99,7 @@ XSK_IOCTL_FN(
     _In_ UINT32 OptionName,
     _In_reads_bytes_opt_(InputLength) const VOID *InputValue,
     _In_ UINT32 InputLength,
-    _Out_writes_bytes_(*OutputLength) VOID *OutputValue,
+    _Out_writes_bytes_opt_(*OutputLength) VOID *OutputValue,
     _Inout_ UINT32 *OutputLength
     );
 

--- a/published/external/xdp/details/afxdp.h
+++ b/published/external/xdp/details/afxdp.h
@@ -184,6 +184,7 @@ XskGetSockopt(
     _Inout_ UINT32 *OptionLength
     )
 {
+#if defined(XDP_API_VERSION) && (XDP_API_VERSION >= XDP_API_VERSION_3)
     return
         _XdpIoctl(
             Socket,
@@ -195,6 +196,29 @@ XskGetSockopt(
             (ULONG *)OptionLength,
             NULL,
             FALSE);
+#else
+    XDP_STATUS Res;
+    DWORD BytesReturned;
+
+    Res =
+        _XdpIoctl(
+            Socket,
+            IOCTL_XSK_GET_SOCKOPT,
+            &OptionName,
+            sizeof(OptionName),
+            OptionValue,
+            *OptionLength,
+            &BytesReturned,
+            NULL,
+            FALSE);
+    if (XDP_FAILED(Res)) {
+        return Res;
+    }
+
+    *OptionLength = BytesReturned;
+
+    return Res;
+#endif
 }
 
 inline

--- a/published/external/xdp/details/afxdp.h
+++ b/published/external/xdp/details/afxdp.h
@@ -180,7 +180,7 @@ XDP_STATUS
 XskGetSockopt(
     _In_ HANDLE Socket,
     _In_ UINT32 OptionName,
-    _Out_writes_bytes_(*OptionLength) VOID *OptionValue,
+    _Out_writes_bytes_opt_(*OptionLength) VOID *OptionValue,
     _Inout_ UINT32 *OptionLength
     )
 {
@@ -204,7 +204,7 @@ XskIoctl(
     _In_ UINT32 OptionName,
     _In_reads_bytes_opt_(InputLength) const VOID *InputValue,
     _In_ UINT32 InputLength,
-    _Out_writes_bytes_(*OutputLength) VOID *OutputValue,
+    _Out_writes_bytes_opt_(*OutputLength) VOID *OutputValue,
     _Inout_ UINT32 *OutputLength
     )
 {

--- a/published/external/xdp/details/afxdp.h
+++ b/published/external/xdp/details/afxdp.h
@@ -184,10 +184,7 @@ XskGetSockopt(
     _Inout_ UINT32 *OptionLength
     )
 {
-    XDP_STATUS Res;
-    DWORD BytesReturned;
-
-    Res =
+    return
         _XdpIoctl(
             Socket,
             IOCTL_XSK_GET_SOCKOPT,
@@ -195,16 +192,9 @@ XskGetSockopt(
             sizeof(OptionName),
             OptionValue,
             *OptionLength,
-            &BytesReturned,
+            (ULONG *)OptionLength,
             NULL,
             FALSE);
-    if (XDP_FAILED(Res)) {
-        return Res;
-    }
-
-    *OptionLength = BytesReturned;
-
-    return Res;
 }
 
 inline

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -6658,6 +6658,21 @@ GenericTxChecksumOffloadConfig()
 
     TEST_FALSE(XskRingOffloadChanged(&Xsk.Rings.Tx));
 
+    OptionLength = 0;
+    TEST_EQUAL(
+        HRESULT_FROM_WIN32(ERROR_MORE_DATA),
+        TryGetSockopt(
+            Xsk.Handle.get(), XSK_SOCKOPT_TX_OFFLOAD_CURRENT_CONFIG_CHECKSUM, NULL, &OptionLength));
+    TEST_TRUE(OptionLength >= XDP_SIZEOF_CHECKSUM_CONFIGURATION_REVISION_1);
+
+    OptionLength = 1;
+    TEST_EQUAL(
+        HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER),
+        TryGetSockopt(
+            Xsk.Handle.get(), XSK_SOCKOPT_TX_OFFLOAD_CURRENT_CONFIG_CHECKSUM, &ChecksumConfig,
+            &OptionLength));
+    TEST_TRUE(OptionLength == 0);
+
     OptionLength = sizeof(ChecksumConfig);
     GetSockopt(
         Xsk.Handle.get(), XSK_SOCKOPT_TX_OFFLOAD_CURRENT_CONFIG_CHECKSUM, &ChecksumConfig,

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -8434,6 +8434,7 @@ GenericXskQueryAffinity()
                 XskRingConsumerRelease(&Socket.Rings.Rx, 1);
                 TEST_TRUE(XskRingAffinityChanged(&Socket.Rings.Rx));
 
+                ProcNumberSize = sizeof(ProcNumber);
                 GetSockopt(
                     Socket.Handle.get(), XSK_SOCKOPT_RX_PROCESSOR_AFFINITY, &ProcNumber,
                     &ProcNumberSize);
@@ -8464,6 +8465,7 @@ GenericXskQueryAffinity()
 
                 TEST_TRUE(XskRingAffinityChanged(&Socket.Rings.Tx));
 
+                ProcNumberSize = sizeof(ProcNumber);
                 GetSockopt(
                     Socket.Handle.get(), XSK_SOCKOPT_TX_PROCESSOR_AFFINITY, &ProcNumber,
                     &ProcNumberSize);


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

While investigating our stress test failures in CI, I started code reviewing recent changes. I spotted a bug with how we handle zero-sized output buffers in getsockopt, which was intended to return the necessary output buffer size, but returned zero.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Tests added.

## Documentation

_Is there any documentation impact for this change?_

Yes, added.

## Installation

_Is there any installer impact for this change?_

No.