### PR TITLE
Document eBPF build requirements

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -28,6 +28,9 @@ git submodule update --init --recursive
     - C++ Clang Compiler for Windows
 - [NuGet Windows x86 Commandline](https://www.nuget.org/downloads)
   - Version 6.3.1 or higher is required by the eBPF-for-Windows project.
+- [Windows WDK and matching SDK](https://learn.microsoft.com/en-us/windows-hardware/drivers/download-the-wdk)
+  - Version 10.0.26100.3323 is required to build eBPF programs, including tests. This prerequisite will eventually be [removed](https://github.com/microsoft/ebpf-for-windows/issues/4379) by the eBPF project.
+  - The standalone SDK and WDK are not required to build the XDP runtime.
 
 ### Building
 


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Our existing documented prerequisites are missing a global WDK dependency. There is an eBPF [task ](https://github.com/microsoft/ebpf-for-windows/issues/4379) to fix this dependency (they're not supposed to require a global WDK either) but for now, documented what's needed.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

This built in CI, which happens to have a compatible WDK preinstalled.

## Documentation

_Is there any documentation impact for this change?_

Yup.

## Installation

_Is there any installer impact for this change?_

No.