### PR TITLE
Add missing volatile accessors

### DIFF
--- a/src/rtl/inc/xdprtl.h
+++ b/src/rtl/inc/xdprtl.h
@@ -176,22 +176,6 @@ RtlFindLeastSignificantBit(
 
 #endif
 
-#ifndef _RTL_VOL_MEM_ACCESSORS_
-
-__forceinline
-VOID
-RtlCopyVolatileMemory(
-    _Out_writes_bytes_(Size) VOID *Destination,
-    _In_reads_bytes_(Size) volatile const VOID *Source,
-    _In_ SIZE_T Size
-    )
-{
-    RtlCopyMemory(Destination, (const VOID *)Source, Size);
-    _ReadWriteBarrier();
-}
-
-#endif
-
 #if defined(STATUS_SUCCESS) && defined(STATUS_INTEGER_OVERFLOW)
 
 inline

--- a/src/xdp/programinspect.c
+++ b/src/xdp/programinspect.c
@@ -824,7 +824,7 @@ BufferTooSmall:
 
 static
 BOOLEAN
-XdpTestBit(
+XdpTestBitNoFence(
     _In_ const UINT8 *BitMap,
     _In_ UINT32 Index
     )
@@ -1071,7 +1071,7 @@ XdpInspect(
                     &FrameCache, &Program->FrameStorage);
             }
             if (FrameCache.UdpValid &&
-                XdpTestBit(Rule->Pattern.PortSet.PortSet, FrameCache.UdpHdr->uh_dport)) {
+                XdpTestBitNoFence(Rule->Pattern.PortSet.PortSet, FrameCache.UdpHdr->uh_dport)) {
                 Matched = TRUE;
             }
             break;
@@ -1087,7 +1087,7 @@ XdpInspect(
                     &FrameCache.Ip4Hdr->DestinationAddress,
                     &Rule->Pattern.IpPortSet.Address.Ipv4) &&
                 FrameCache.UdpValid &&
-                XdpTestBit(Rule->Pattern.IpPortSet.PortSet.PortSet, FrameCache.UdpHdr->uh_dport)) {
+                XdpTestBitNoFence(Rule->Pattern.IpPortSet.PortSet.PortSet, FrameCache.UdpHdr->uh_dport)) {
                 Matched = TRUE;
             }
             break;
@@ -1103,7 +1103,7 @@ XdpInspect(
                     &FrameCache.Ip6Hdr->DestinationAddress,
                     &Rule->Pattern.IpPortSet.Address.Ipv6) &&
                 FrameCache.UdpValid &&
-                XdpTestBit(Rule->Pattern.IpPortSet.PortSet.PortSet, FrameCache.UdpHdr->uh_dport)) {
+                XdpTestBitNoFence(Rule->Pattern.IpPortSet.PortSet.PortSet, FrameCache.UdpHdr->uh_dport)) {
                 Matched = TRUE;
             }
             break;
@@ -1119,7 +1119,7 @@ XdpInspect(
                     &FrameCache.Ip4Hdr->DestinationAddress,
                     &Rule->Pattern.IpPortSet.Address.Ipv4) &&
                 FrameCache.TcpValid &&
-                XdpTestBit(Rule->Pattern.IpPortSet.PortSet.PortSet, FrameCache.TcpHdr->th_dport)) {
+                XdpTestBitNoFence(Rule->Pattern.IpPortSet.PortSet.PortSet, FrameCache.TcpHdr->th_dport)) {
                 Matched = TRUE;
             }
             break;
@@ -1135,7 +1135,7 @@ XdpInspect(
                     &FrameCache.Ip6Hdr->DestinationAddress,
                     &Rule->Pattern.IpPortSet.Address.Ipv6) &&
                 FrameCache.TcpValid &&
-                XdpTestBit(Rule->Pattern.IpPortSet.PortSet.PortSet, FrameCache.TcpHdr->th_dport)) {
+                XdpTestBitNoFence(Rule->Pattern.IpPortSet.PortSet.PortSet, FrameCache.TcpHdr->th_dport)) {
                 Matched = TRUE;
             }
             break;

--- a/src/xdp/xsk.c
+++ b/src/xdp/xsk.c
@@ -4948,6 +4948,7 @@ XskReceiveSingleFrame(
 
     XSK_FRAME_DESCRIPTOR *XskFrame;
     XSK_BUFFER_DESCRIPTOR *XskBuffer;
+    XSK_BUFFER_ADDRESS XskBufferAddress;
 
     RingIndex =
         (ReadUInt32NoFence(&Xsk->Rx.FillRing.Shared->ConsumerIndex) + FillOffset) &
@@ -5008,10 +5009,12 @@ XskReceiveSingleFrame(
             Xsk->Rx.Ring.Mask;
     XskFrame = XskKernelRingGetElement(&Xsk->Rx.Ring, RingIndex);
     XskBuffer = &XskFrame->Buffer;
-    XskBuffer->Address.BaseAddress = UmemAddress;
+
+    XskBufferAddress.BaseAddress = UmemAddress;
     ASSERT(Xsk->Umem->Reg.Headroom <= MAXUINT16);
-    XskBuffer->Address.Offset = (UINT16)Xsk->Umem->Reg.Headroom;
-    XskBuffer->Length = UmemOffset - Xsk->Umem->Reg.Headroom + CopyLength;
+    XskBufferAddress.Offset = (UINT16)Xsk->Umem->Reg.Headroom;
+    WriteUInt64NoFence(&XskBuffer->Address.AddressAndOffset, XskBufferAddress.AddressAndOffset);
+    WriteUInt32NoFence(&XskBuffer->Length, UmemOffset - Xsk->Umem->Reg.Headroom + CopyLength);
 
     ++*CompletionOffset;
 }

--- a/src/xdp/xsk.c
+++ b/src/xdp/xsk.c
@@ -549,7 +549,7 @@ XskBounceBuffer(
         // behavior is undefined if the buffer is modified while IO is
         // outstanding. Ignore any writes to the buffer once an IO is in flight.
         //
-        RtlCopyMemory(
+        RtlCopyVolatileMemory(
             Bounce->Mapping.SystemAddress + RelativeAddress + Buffer->DataOffset,
             Umem->Mapping.SystemAddress + RelativeAddress + Buffer->DataOffset,
             Buffer->DataLength);
@@ -4968,7 +4968,8 @@ XskReceiveSingleFrame(
     CopyLength = min(Buffer->DataLength, Xsk->Umem->Reg.ChunkSize - UmemOffset);
 
     if (!XskGlobals.RxZeroCopy) {
-        RtlCopyMemory(UmemChunk + UmemOffset, Va->VirtualAddress + Buffer->DataOffset, CopyLength);
+        RtlCopyVolatileMemory(
+            UmemChunk + UmemOffset, Va->VirtualAddress + Buffer->DataOffset, CopyLength);
     }
     if (CopyLength < Buffer->DataLength) {
         //
@@ -4987,7 +4988,7 @@ XskReceiveSingleFrame(
             CopyLength = min(Buffer->DataLength, Xsk->Umem->Reg.ChunkSize - UmemOffset);
 
             if (!XskGlobals.RxZeroCopy) {
-                RtlCopyMemory(
+                RtlCopyVolatileMemory(
                     UmemChunk + UmemOffset, Va->VirtualAddress + Buffer->DataOffset, CopyLength);
             }
 


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Add a few missing volatile accessors, including UMEM copies and XSK writes. Also, clarify the program inspection routine uses a volatile read of the mapped port bit set.

N.B. The standin RtlCopyVolatileMemory in XDP looks suspicious, and we should be compiling and linking against the real WDK version in official builds (we removed support for VS2019) so I removed it.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Compiles locally.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.