### PR TITLE
Fix TCP offload test to use TCP socket

### DIFF
--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -6494,14 +6494,15 @@ GenericTxChecksumOffloadTcp(
 {
     const BOOLEAN Rx = FALSE, Tx = TRUE;
     auto If = FnMpIf;
-    UINT16 LocalPort, RemotePort;
+    UINT16 LocalPort;
+    UINT16 RemotePort = htons(1234);
     ETHERNET_ADDRESS LocalHw, RemoteHw;
     INET_ADDR LocalIp, RemoteIp;
+    UINT32 AckNum;
     auto Xsk = CreateAndBindSocket(If.GetIfIndex(), If.GetQueueId(), Rx, Tx, XDP_GENERIC);
-    auto UdpSocket = CreateUdpSocket(Af, NULL, &LocalPort);
+    auto TcpSocket = CreateTcpSocket(Af, &If, &LocalPort, RemotePort, &AckNum);
     auto GenericMp = MpOpenGeneric(If.GetIfIndex());
 
-    RemotePort = htons(1234);
     If.GetHwAddress(&LocalHw);
     If.GetRemoteHwAddress(&RemoteHw);
     if (Af == AF_INET) {
@@ -6521,7 +6522,7 @@ GenericTxChecksumOffloadTcp(
     UINT32 UdpFrameLength = Xsk.Umem.Reg.ChunkSize;
     TEST_TRUE(
         PktBuildTcpFrame(
-            TxFrame, &UdpFrameLength, TcpPayload, sizeof(TcpPayload), NULL, 0, 0, 0, TH_SYN, 0,
+            TxFrame, &UdpFrameLength, TcpPayload, sizeof(TcpPayload), NULL, 0, 0, AckNum, TH_SYN, 0,
             &LocalHw, &RemoteHw, Af, &LocalIp, &RemoteIp, LocalPort, RemotePort));
 
     CxPlatVector<UCHAR> Mask(UdpFrameLength, 0xFF);


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

@ProjectsByJackHe noticed `GenericTxChecksumOffloadTcp` was using a UDP socket in a TCP test, which was a mistake. The socket is only used to grab a local port number, which is why the protocol mismatch wasn't causing failures.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.