### PR TITLE
set XSK offload change flag only for enabled offloads

### DIFF
--- a/src/xdp/xsk.c
+++ b/src/xdp/xsk.c
@@ -164,6 +164,12 @@ typedef struct _XSK_TX {
     //
     DMA_ADAPTER *DmaAdapter;
     XDP_EXTENSION_SET *FrameExtensionSet;
+    union {
+        struct {
+            UINT8 CurrentConfig : 1;
+        };
+        UINT8 Value;
+    } OffloadChangeFlags;
 } XSK_TX;
 
 typedef struct _XSK {
@@ -2225,8 +2231,13 @@ XskNotifyTxQueue(
 
         KeAcquireSpinLock(&Xsk->Lock, &OldIrql);
 
+        //
+        // Set the offload changed flag if any offloads sensitive to current
+        // config changes are enabled.
+        //
         Shared = Xsk->Tx.Ring.Shared;
-        if (Shared != NULL) {
+        if (Shared != NULL && Xsk->Tx.OffloadFlags.Checksum) {
+            Xsk->Tx.OffloadChangeFlags.CurrentConfig = TRUE;
             InterlockedOrNoFence((LONG *)&Shared->Flags, XSK_RING_FLAG_OFFLOAD_CHANGED);
         }
 
@@ -4024,6 +4035,7 @@ XskSockoptGetOffload(
     VOID *OutputBuffer = Irp->AssociatedIrp.SystemBuffer;
     UINT32 OutputBufferLength = IrpSp->Parameters.DeviceIoControl.OutputBufferLength;
     SIZE_T *BytesReturned = &Irp->IoStatus.Information;
+    BOOLEAN ResetChangeFlag = FALSE;
 
     TraceEnter(TRACE_XSK, "Xsk=%p", Xsk);
 
@@ -4040,6 +4052,8 @@ XskSockoptGetOffload(
         WorkItem.GetIfOffloadHandle = XskSockoptGetTxOffloadHandle;
         WorkItem.OffloadType = XdpOffloadChecksum;
         Ring = Xsk->Tx.Ring.Shared;
+        Xsk->Tx.OffloadChangeFlags.CurrentConfig = FALSE;
+        ResetChangeFlag = Xsk->Tx.OffloadChangeFlags.Value == 0;
         break;
 
     default:
@@ -4050,7 +4064,7 @@ XskSockoptGetOffload(
     ASSERT(WorkItem.IfWorkItem.BindingHandle != NULL);
     ASSERT(WorkItem.GetIfOffloadHandle != NULL);
 
-    if (Ring != NULL) {
+    if (Ring != NULL && ResetChangeFlag) {
         InterlockedAndNoFence((LONG *)&Ring->Flags, ~XSK_RING_FLAG_OFFLOAD_CHANGED);
     }
 

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -6653,10 +6653,6 @@ GenericTxChecksumOffloadConfig()
     auto GenericMp = MpOpenGeneric(If.GetIfIndex());
     const BOOLEAN Rx = FALSE, Tx = TRUE;
 
-    //
-    // Enable the TX checksum offload on the socket, and then indicate another
-    // NIC config change. This time the offload change flag should be set.
-    //
     auto Xsk = CreateAndBindSocket(If.GetIfIndex(), If.GetQueueId(), Rx, Tx, XDP_GENERIC);
     EnableTxChecksumOffload(&Xsk);
     ActivateSocket(&Xsk, Rx, Tx);

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -6652,12 +6652,22 @@ GenericTxChecksumOffloadConfig()
     const auto &If = FnMpIf;
     auto GenericMp = MpOpenGeneric(If.GetIfIndex());
     const BOOLEAN Rx = FALSE, Tx = TRUE;
-    auto Xsk = CreateAndActivateSocket(If.GetIfIndex(), If.GetQueueId(), Rx, Tx, XDP_GENERIC);
+
+    //
+    // Enable the TX checksum offload on the socket, and then indicate another
+    // NIC config change. This time the offload change flag should be set.
+    //
+    auto Xsk = CreateAndBindSocket(If.GetIfIndex(), If.GetQueueId(), Rx, Tx, XDP_GENERIC);
+    EnableTxChecksumOffload(&Xsk);
+    ActivateSocket(&Xsk, Rx, Tx);
+
+    auto PlainXsk = CreateAndActivateSocket(If.GetIfIndex(), If.GetQueueId(), Rx, Tx, XDP_GENERIC);
 
     XDP_CHECKSUM_CONFIGURATION ChecksumConfig;
     UINT32 OptionLength;
 
     TEST_FALSE(XskRingOffloadChanged(&Xsk.Rings.Tx));
+    TEST_FALSE(XskRingOffloadChanged(&PlainXsk.Rings.Tx));
 
     OptionLength = 0;
     TEST_EQUAL(
@@ -6693,15 +6703,19 @@ GenericTxChecksumOffloadConfig()
 
     auto OffloadReset = MpUpdateTaskOffload(GenericMp, FnOffloadCurrentConfig, &OffloadParams);
 
-    Stopwatch Watchdog(TEST_TIMEOUT_ASYNC_MS);
-    while (!Watchdog.IsExpired()) {
-        if (XskRingOffloadChanged(&Xsk.Rings.Tx)) {
-            break;
-        }
-    }
+    CxPlatSleep(TEST_TIMEOUT_ASYNC_MS); // Give time for the offload change notification to occur.
 
+    //
+    // The offload bit should not be set unless the offload is enabled on the
+    // socket.
+    //
     TEST_TRUE(XskRingOffloadChanged(&Xsk.Rings.Tx));
+    TEST_FALSE(XskRingOffloadChanged(&PlainXsk.Rings.Tx));
 
+    //
+    // Verify the current config is updated and the offload change flag has been
+    // cleared.
+    //
     OptionLength = sizeof(ChecksumConfig);
     GetSockopt(
         Xsk.Handle.get(), XSK_SOCKOPT_TX_OFFLOAD_CURRENT_CONFIG_CHECKSUM, &ChecksumConfig,
@@ -6713,6 +6727,7 @@ GenericTxChecksumOffloadConfig()
     TEST_TRUE(ChecksumConfig.TcpOptions);
 
     TEST_FALSE(XskRingOffloadChanged(&Xsk.Rings.Tx));
+    TEST_FALSE(XskRingOffloadChanged(&PlainXsk.Rings.Tx));
 }
 
 static


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Resolves #848 by setting the offload change flag on an XSK only if an associated offload has been enabled. This allows the app to reliably clear the flag by querying the config of all enabled offloads even as new (and implicitly disabled) offloads are added.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Tests added and pass locally.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.