### PR TITLE
Disable node reuse in all GitHub builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,8 @@ jobs:
     - name: Prepare for compiling eBPF programs
       run: tools/prepare-machine.ps1 -ForEbpfBuild -Verbose -Platform ${{ inputs.platform }}
     - name: Build
-      run: msbuild xdp.sln /m /p:configuration=${{ inputs.config }} /p:platform=${{ inputs.platform }} /p:SignMode=TestSign /p:IsAdmin=true
+      # See /tools/build.ps1 for /nodeReuse:false discussion.
+      run: msbuild xdp.sln /m /p:configuration=${{ inputs.config }} /p:platform=${{ inputs.platform }} /p:SignMode=TestSign /p:IsAdmin=true /nodeReuse:false
     - name: Upload Artifacts
       if: inputs.artifact_path != ''
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

The global and nuget WDKs can race against each other in builds. The `/nodeReuse:false` is already used in build.ps1 for reliable but slightly slower builds.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.