### PR TITLE
Fix WDK build break

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,8 @@
     <PackageVersion Include="Microsoft.SourceLink.AzureRepos.Git" Version="1.0.0" />
     <PackageVersion Include="Microsoft.SourceLink.Common" Version="1.0.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageVersion Include="Microsoft.Windows.SDK.cpp.$(HostPlatform)" Version="$(XdpWdkVersion)" Condition="'$(Platform)' != '$(HostPlatform)'"/>
+    <PackageVersion Include="Microsoft.Windows.SDK.cpp.$(Platform)" Version="$(XdpWdkVersion)" />
     <PackageVersion Include="Microsoft.Windows.WDK.$(HostPlatform)" Version="$(XdpWdkVersion)" Condition="'$(Platform)' != '$(HostPlatform)'"/>
     <PackageVersion Include="Microsoft.Windows.WDK.$(Platform)" Version="$(XdpWdkVersion)" />
     <PackageVersion Include="win-net-test" Version="1.3.0" />

--- a/src/xdp.props
+++ b/src/xdp.props
@@ -17,7 +17,7 @@
     <HostPlatform>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</HostPlatform>
     <!-- eBPF-for-windows version -->
     <XdpEbpfVersion>0.21.0</XdpEbpfVersion>
-    <XdpWdkVersion>10.0.26100.2454</XdpWdkVersion>
+    <XdpWdkVersion>10.0.26100.4204</XdpWdkVersion>
     <XdpWixVer>5.0.1</XdpWixVer>
   </PropertyGroup>
   <ItemGroup>
@@ -28,6 +28,8 @@
     <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.SourceLink.Common" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" />
+    <PackageReference Include="Microsoft.Windows.SDK.cpp.$(Platform)" Condition="'$(ImportWdk)' != 'false'" />
+    <PackageReference Include="Microsoft.Windows.SDK.cpp.$(HostPlatform)" Condition="'$(ImportWdk)' != 'false' AND '$(HostPlatform)' != '$(Platform)'" />
     <PackageReference Include="Microsoft.Windows.WDK.$(Platform)" Condition="'$(ImportWdk)' != 'false'" />
     <PackageReference Include="Microsoft.Windows.WDK.$(HostPlatform)" Condition="'$(ImportWdk)' != 'false' AND '$(HostPlatform)' != '$(Platform)'" />
     <PackageReference Include="win-net-test" GeneratePathProperty="true" Condition="'$(ImportWnt)' == 'true'"/>

--- a/src/xdpinstaller/xdpinstaller.wixproj
+++ b/src/xdpinstaller/xdpinstaller.wixproj
@@ -4,6 +4,8 @@
     <ProjectGuid>{93635a7b-565e-4b41-af67-5b375756b227}</ProjectGuid>
     <ImportUndocked>false</ImportUndocked>
     <ImportWdk>false</ImportWdk>
+    <!-- Try to prevent the system-wide WDK from being used. -->
+    <WDKKitVersion>0</WDKKitVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)src\xdp.props" />
   <PropertyGroup>

--- a/src/xdpinstaller/xdpinstaller.wixproj
+++ b/src/xdpinstaller/xdpinstaller.wixproj
@@ -4,8 +4,6 @@
     <ProjectGuid>{93635a7b-565e-4b41-af67-5b375756b227}</ProjectGuid>
     <ImportUndocked>false</ImportUndocked>
     <ImportWdk>false</ImportWdk>
-    <!-- Try to prevent the system-wide WDK from being used. -->
-    <WDKKitVersion>0</WDKKitVersion>
   </PropertyGroup>
   <Import Project="$(SolutionDir)src\xdp.props" />
   <PropertyGroup>


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Our CI suddenly started failing to build the XDP installer project, which is known to be incompatible with the WDK. In the CI machines, because the WDK happens to be globally installed, it gets included whether or not we intentionally include the nuget version of the WDK. This global WDK also started breaking.

It seems like updating the WDK nuget to be at least as new as the WDK globally installed works around the problem, though I'm not sure it has been directly addressed.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.