### PR TITLE
Add workflow_dispatch to build_matrix

### DIFF
--- a/.github/workflows/build_matrix.yml
+++ b/.github/workflows/build_matrix.yml
@@ -17,6 +17,20 @@ on:
         required: false
         default: true
         type: boolean
+  workflow_dispatch:
+    inputs:
+      ref:
+        required: false
+        default: ''
+        type: string
+      id:
+        required: false
+        default: ''
+        type: string
+      codeql:
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   build_matrix:


### PR DESCRIPTION
## Description

Getting local builds of XDP has been a massive pain recently.
It would be great if there was a way to leverage just the build step in the CI and avoid triggering all the tests.

Also, it would be great to be able to supply a ref so we can build any version, not just the latest.


## Testing

CI 

## Documentation

N/A

## Installation

N/A