### PR TITLE
Add conditional requirements just for release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -629,7 +629,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {} # No need for any permissions.
     steps:
-    - name: Decide whether the needed jobs succeeded or failed
+    - name: Decide whether the needed jobs succeeded or failed (Release)
+      if: ${{ startsWith(github.ref, 'refs/heads/release/') || startsWith(github.base_ref, 'refs/heads/release/') }}
+      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
+      with:
+        jobs: ${{ toJSON(needs) }}
+        allowed-failures: xskperf_tests, ring_perf_tests, rxfilter_perf_tests
+    - name: Decide whether the needed jobs succeeded or failed (Non Release)
+      if: ${{ !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.base_ref, 'refs/heads/release/') }}
       uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
       with:
         jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -630,13 +630,13 @@ jobs:
     permissions: {} # No need for any permissions.
     steps:
     - name: Decide whether the needed jobs succeeded or failed (Release)
-      if: ${{ startsWith(github.ref, 'refs/heads/release/') || startsWith(github.base_ref, 'refs/heads/release/') }}
+      if: ${{ contains(github.ref, 'release') || contains(github.base_ref, 'release') || contains(github.head_ref, 'release') }}
       uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
       with:
         jobs: ${{ toJSON(needs) }}
         allowed-failures: xskperf_tests, ring_perf_tests, rxfilter_perf_tests
     - name: Decide whether the needed jobs succeeded or failed (Non Release)
-      if: ${{ !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.base_ref, 'refs/heads/release/') }}
+      if: ${{ !contains(github.ref, 'release') && !contains(github.base_ref, 'release') && !contains(github.head_ref, 'release') }}
       uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
       with:
         jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Description

Release branches sometime have a different set of requirements that differ from non-release branches.

We don't want to block PRs on release branches due to some requirement in non-release branches that is irrelevant. 

Let's add logic to have a different set of dependencies depending on whether the branch is release or not.

## Testing

CI

## Documentation

No.

## Installation

No.
