### PR TITLE
Bump downlevel release tests to v1.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,7 +491,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        downlevel_release: [1.0.2, 1.1.0]
+        downlevel_release: [1.0.2, 1.1.2]
         windows: [2022, Prerelease]
         configuration: [Release]
         platform: [x64]


### PR DESCRIPTION
## Description

Due to recent build pipeline fixes, we need to update downlevel release to v1.1.2.

## Testing

CI 

## Documentation

No

## Installation

No
