### PR TITLE
tighten conditions for a release (non- "-prerelease-xxx") build

### DIFF
--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -74,7 +74,7 @@ function Get-BuildBranch {
 }
 
 function Is-ReleaseBuild {
-    return ((Get-BuildBranch) -match '^release/|^tags/')
+    return ((Get-BuildBranch) -match '^tags/v\d+\.\d+\.\d+$')
 }
 
 function Get-VsTestPath {


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

We've settled on producing a release build only for tags "vX.Y.Z" where X, Y, and Z are major, minor, and patch digits, as defined in semver.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Builds locally. Need to run through CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.