### PR TITLE
use same case for nuget readme files

### DIFF
--- a/src/nuget/xdp-for-windows.nuspec.in
+++ b/src/nuget/xdp-for-windows.nuspec.in
@@ -20,6 +20,6 @@
         <file src="{binpath_anyarch}\xdpbpfexport.exe" target="build\native\bin\{anyarch}"/>
         <file src="{binpath_anyarch}\xdpapi.lib" target="build\native\lib\{anyarch}"/>
         <file src="{binpath_anyarch}\xdpnmr.lib" target="build\native\lib\{anyarch}"/>
-        <file src="{rootpath}\readme.md" target="."/>
+        <file src="{rootpath}\readme.md" target="README.md"/>
     </files>
 </package>

--- a/src/xdpruntime/xdp-for-windows-runtime.nuspec.in
+++ b/src/xdpruntime/xdp-for-windows-runtime.nuspec.in
@@ -29,6 +29,6 @@
         <file src="{binpath_anyarch}\xdp\xdpapi.dll" target="runtime\native"/>
         <file src="{binpath_anyarch}\xdpapi.pdb" target="runtime\native"/>
         <file src="{rootpath}\tools\xdptrace.wprp" target="runtime\native"/>
-        <file src="{rootpath}\readme.md" target="."/>
+        <file src="{rootpath}\readme.md" target="README.md"/>
     </files>
 </package>


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

The `<readme>` element mismatched the actual filename, which was all lower case. The common practice on nuget.org seems to be `README.md`, so be consistent and make that the filename, too. 

It's not clear if this will resolve our upload errors.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.