### PR TITLE
more nuget nuspec improvements

### DIFF
--- a/src/nuget/xdp-for-windows.nuspec.in
+++ b/src/nuget/xdp-for-windows.nuspec.in
@@ -3,7 +3,7 @@
 <package>
     <metadata>
         <id>Microsoft.XDP-for-Windows.Sdk</id>
-        <title>XDP-for-Windows SDK</title>
+        <title>Microsoft XDP-for-Windows SDK</title>
         <version>{version}</version>
         <authors>Microsoft</authors>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -11,8 +11,8 @@
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <projectUrl>https://github.com/microsoft/xdp-for-windows</projectUrl>
         <readme>README.md</readme>
-        <description>XDP-for-Windows SDK</description>
-        <repository type="git" url="https://github.com/microsoft/xdp" commit="{commit}" />
+        <description>Microsoft XDP-for-Windows SDK</description>
+        <repository type="git" url="https://github.com/microsoft/xdp-for-windows" commit="{commit}" />
     </metadata>
     <files>
         <file src="xdp-for-windows.props" target="build\native\Microsoft.XDP-for-Windows.Sdk.props"/>

--- a/src/xdpruntime/xdp-for-windows-runtime.nuspec.in
+++ b/src/xdpruntime/xdp-for-windows-runtime.nuspec.in
@@ -3,7 +3,7 @@
 <package>
     <metadata>
         <id>Microsoft.XDP-for-Windows.Runtime.{arch}</id>
-        <title>XDP-for-Windows Runtime for {arch}</title>
+        <title>Microsoft XDP-for-Windows Runtime for {arch}</title>
         <version>{version}</version>
         <authors>Microsoft</authors>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -11,8 +11,8 @@
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <projectUrl>https://github.com/microsoft/xdp-for-windows</projectUrl>
         <readme>README.md</readme>
-        <description>XDP-for-Windows Runtime for {arch}</description>
-        <repository type="git" url="https://github.com/microsoft/xdp" commit="{commit}" />
+        <description>Microsoft XDP-for-Windows Runtime for {arch}</description>
+        <repository type="git" url="https://github.com/microsoft/xdp-for-windows" commit="{commit}" />
     </metadata>
     <files>
         <file src="xdp-for-windows-runtime.props" target="build\native\Microsoft.XDP-for-Windows.Runtime.{arch}.props"/>


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

It looks like nuget.org will accept the most recent set of nuget packages from our OneBranch builds, but we have some inconsistencies and a broken GitHub URL. Consistently use "Microsoft XDP-for-Windows" as the package name and fix the URL.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.