### PR TITLE
build arch-specific SDK package in package stage

### DIFF
--- a/src/nuget/nuget.vcxproj
+++ b/src/nuget/nuget.vcxproj
@@ -26,7 +26,7 @@
   <PropertyGroup Condition="'$(NugetPlatforms)' == ''">
     <NugetPlatforms>$(Platform)</NugetPlatforms>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(NugetPlatforms)' != '' AND '$(NugetPlatforms)' != '$(Platform)'">
+  <PropertyGroup Condition="$(BuildStage) == 'AllPackage'">
     <!-- If targetting multiple platforms, use a platform-independent output directory. -->
     <OutDir>$(UndockedOut)bin\$(Configuration)\packages\</OutDir>
   </PropertyGroup>
@@ -38,7 +38,7 @@
       </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
-  <Target Name="CleanNuget" BeforeTargets="Clean" Condition="$(BuildStage) == '' OR $(BuildStage) == 'AllPackage'">
+  <Target Name="CleanNuget" BeforeTargets="Clean" Condition="$(BuildStage) == '' OR $(BuildStage) == 'Package' OR $(BuildStage) == 'AllPackage'">
      <ItemGroup>
        <FilesToDelete Include="$(OutDir)Microsoft.XDP-for-Windows.*.nupkg"/>
      </ItemGroup>


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Build an SDK nuget package in the "package" stage, which is currently the only packaging state supported by our internal OneBranch system. This means we can't build the all-in-one arm64 + x64 SDK package in OneBranch yet, but we will get fully prod-signed arch-specific packages.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Builds locally. CI should verify the build combinations.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.