### PR TITLE
Enable NuGet Transitive Pinning

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="eBPF-for-Windows.arm64" Version="$(XdpEbpfVersion)" />


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Copied from [internal PR](https://microsoft.visualstudio.com/undock/_git/xdp-for-windows/pullrequest/14056827).

Enable NuGet’s Transitive Pinning to effectively promote a transitive dependency to a top-level dependency implicitly on your behalf when necessary.
Result: Ensures central management of transitive dependencies and a fixed graph that makes Component Governance (security) findings easier to triage and remediate.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.