### PR TITLE
XSK: ensure queues exist before trying to set offloads

### DIFF
--- a/src/xdp/xsk.c
+++ b/src/xdp/xsk.c
@@ -3825,7 +3825,12 @@ XskSetTxOffloadChecksumWorker(
     XSK_BINDING_WORKITEM *WorkItem = (XSK_BINDING_WORKITEM *)Item;
     XSK *Xsk = WorkItem->Xsk;
 
-    WorkItem->CompletionStatus = XdpTxQueueEnableChecksumOffload(Xsk->Tx.Xdp.Queue);
+    if (Xsk->Tx.Xdp.Queue != NULL) {
+        WorkItem->CompletionStatus = XdpTxQueueEnableChecksumOffload(Xsk->Tx.Xdp.Queue);
+    } else {
+        WorkItem->CompletionStatus = STATUS_INVALID_DEVICE_STATE;
+    }
+
     KeSetEvent(&WorkItem->CompletionEvent, 0, FALSE);
 }
 
@@ -3837,7 +3842,13 @@ XskSetRxOffloadChecksumWorker(
 {
     XSK_BINDING_WORKITEM *WorkItem = (XSK_BINDING_WORKITEM *)Item;
     XSK *Xsk = WorkItem->Xsk;
-    WorkItem->CompletionStatus = XdpRxQueueEnableChecksumOffload(Xsk->Rx.Xdp.Queue);
+
+    if (Xsk->Rx.Xdp.Queue != NULL) {
+        WorkItem->CompletionStatus = XdpRxQueueEnableChecksumOffload(Xsk->Rx.Xdp.Queue);
+    } else {
+        WorkItem->CompletionStatus = STATUS_INVALID_DEVICE_STATE;
+    }
+
     KeSetEvent(&WorkItem->CompletionEvent, 0, FALSE);
 }
 


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

XSK was calling `XdpTxQueueEnableChecksumOffload` in the context of a worker that may run _after_ the underlying TX queue becomes detached. This leads to a null pointer access violation, so check within the worker whether the queue exists before trying to make any changes.

For RX, there is currently no code path in XSK that allows the entire RX queue to be set to null while the socket has any IOs outstanding (the RX queue state machine is more complicated) but add a similar defensive check anyways.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Builds locally.

## Documentation

_Is there any documentation impact for this change?_

N/A.

## Installation

_Is there any installer impact for this change?_

N/A.