### PR TITLE
use tag version string for tagged builds

### DIFF
--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -73,8 +73,16 @@ function Get-BuildBranch {
     }
 }
 
+function Get-BuildTag {
+    if (((Get-BuildBranch) -match '^tags/v(\d+\.\d+\.\d+.*)$')) {
+        return $Matches[1]
+    }
+
+    return $null
+}
+
 function Is-ReleaseBuild {
-    return ((Get-BuildBranch) -match '^tags/v\d+\.\d+\.\d+$')
+    return Get-BuildTag -ne $null
 }
 
 function Get-VsTestPath {
@@ -200,7 +208,13 @@ function Get-XdpBuildVersionString {
     $XdpVersion = Get-XdpBuildVersion
     $VersionString = "$($XdpVersion.Major).$($XdpVersion.Minor).$($XdpVersion.Patch)"
 
-    if (!(Is-ReleaseBuild)) {
+    if (Is-ReleaseBuild) {
+        $TagVersion = Get-BuildTag
+        if (!($TagVersion.StartsWith($VersionString))) {
+            Write-Error "Tag version $TagVersion mismatches expected version $VersionString"
+        }
+        $VersionString = $TagVersion
+    } else {
         $VersionString += "-prerelease-" + (git.exe describe --long --always --dirty --exclude=* --abbrev=8)
     }
 


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Pass the tag version string (expected to be a semantic version such as `v1.2.3-alpha3`) through to the package names instead of always producing a hash. With the previous git hash name, package sorting will be unreliable/nondeterministic if multiple packages are available.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Builds locally with a pseudo-tag.

## Documentation

_Is there any documentation impact for this change?_

N/A.

## Installation

_Is there any installer impact for this change?_

N/A.