### PR TITLE
Prevent rebuilding artifacts in package stage

### DIFF
--- a/src/nuget/nuget.vcxproj
+++ b/src/nuget/nuget.vcxproj
@@ -6,7 +6,7 @@
     <UndockedType>none</UndockedType>
   </PropertyGroup>
   <Import Project="$(SolutionDir)src\xdp.cpp.props" />
- <ItemGroup Condition="'$(BuildStage)' != 'AllPackage'">
+ <ItemGroup Condition="'$(BuildStage)' != 'Package' AND '$(BuildStage)' != 'AllPackage'">
     <ProjectReference Include="$(SolutionDir)src\bpfexport\bpfexport.vcxproj">
       <Project>{8f8830ff-1648-4772-87ed-f5da091fc931}</Project>
       <Private>false</Private>


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

While reading logs to debug another packaging issue, I realized #910 introduced a regression where binaries are rebuilt in the package stage.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Locally verified the package stage only builds the expected packages.

## Documentation

_Is there any documentation impact for this change?_

N/A.

## Installation

_Is there any installer impact for this change?_

N/A.