### PR TITLE
remove v1.0 from downlevel test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,7 +491,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        downlevel_release: [1.0.2, 1.1.2]
+        downlevel_release: [1.1.2]
         windows: [2022, Prerelease]
         configuration: [Release]
         platform: [x64]


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

The XDP v1.0 release has been out of support for months, so finally remember to remove it from our CI.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Yes.

## Documentation

_Is there any documentation impact for this change?_

Already updated with EOL date.

## Installation

_Is there any installer impact for this change?_

No.