### PR TITLE
Enable ebpf in spinxsk helper script by default

### DIFF
--- a/tools/spinxsk.ps1
+++ b/tools/spinxsk.ps1
@@ -95,7 +95,7 @@ param (
     [string]$XdpmpPollProvider = "NDIS",
 
     [Parameter(Mandatory = $false)]
-    [switch]$EnableEbpf = $false,
+    [switch]$EnableEbpf = $true,
 
     [Parameter(Mandatory = $false)]
     [switch]$EbpfPreinstalled = $false,


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

eBPF is stable enough and important enough that the spinxsk helper script should enable it by default.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

N/A.

## Documentation

_Is there any documentation impact for this change?_

N/A. The default behavior of the underlying tool remains the same.

## Installation

_Is there any installer impact for this change?_

N/A.