### PR TITLE
xskperf: set TX rate limit to unlimited by default

### DIFF
--- a/tools/xskperf.ps1
+++ b/tools/xskperf.ps1
@@ -241,19 +241,17 @@ try {
         Wait-NetAdapterUpStatus -Name $AdapterName
 
         $RxSimRate = 1
-        $TxSimRate = 1
+        $TxSimRate = 0xFFFFFFFFl
         if (@("RX", "FWD").Contains($Mode) -and -not $TxInspect) {
             $RxSimRate = 0xFFFFFFFFl
             if ($Pacing) {
                 $RxSimRate = 1000
             }
         }
-        if ((@("TX", "FWD").Contains($Mode) -and -not $RxInject) -or
-            ($Mode -eq "RX" -and $TxInspect)) {
-            $TxSimRate = 0xFFFFFFFFl
-            if ($Pacing) {
-                $TxSimRate = 1000
-            }
+        if ($Pacing -and
+            ((@("TX", "FWD").Contains($Mode) -and -not $RxInject) -or
+             ($Mode -eq "RX" -and $TxInspect))) {
+            $TxSimRate = 1000
         }
 
         Write-Verbose "Setting XDPMP rate simulation to RX:$RxSimRate TX:$TxSimRate"


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

The 64 byte IO size test is returning 0 pps, and it might be caused by the wsario traffic generator saturating XDPMP's rate limit of 1 packet completion per interval. Since we don't need to limit the TX completion unless pacing is enabled (which it isn't, in CI) just simplify the config and run in unlimited mode by default.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Couldn't repro locally. CI.

## Documentation

_Is there any documentation impact for this change?_

N/A.

## Installation

_Is there any installer impact for this change?_

N/A.