### PR TITLE
onboard ws2025 arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,8 +174,6 @@ jobs:
         exclude:
         - windows: 2022
           platform: arm64
-        - windows: 2025
-          platform: arm64
     runs-on:
      - self-hosted
      - "1ES.Pool=xdp-ci-functional${{ matrix.platform != 'x64' && format('-{0}', matrix.platform) || '' }}-gh"
@@ -243,8 +241,6 @@ jobs:
         enableTxInspect: [enableTxInspect, disableTxInspect]
         exclude:
         - windows: 2022
-          platform: arm64
-        - windows: 2025
           platform: arm64
         - testDriver: FNMP
           enableTxInspect: enableTxInspect
@@ -355,8 +351,6 @@ jobs:
         platform: [x64, arm64]
         exclude:
         - windows: 2022
-          platform: arm64
-        - windows: 2025
           platform: arm64
     runs-on:
      - self-hosted
@@ -586,8 +580,6 @@ jobs:
         exclude:
         - windows: 2022
           platform: arm64
-        - windows: 2025
-          platform: arm64
     runs-on:
      - self-hosted
      - "1ES.Pool=xdp-ci-functional${{ matrix.platform != 'x64' && format('-{0}', matrix.platform) || '' }}-gh"
@@ -639,8 +631,6 @@ jobs:
         platform: [x64, arm64]
         exclude:
         - windows: 2022
-          platform: arm64
-        - windows: 2025
           platform: arm64
     runs-on:
      - self-hosted


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Resolves #987 by adding arm64 ws2025 runners, too. (#1000 was blocked on missing arm64 builds.)

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

N/A.

## Installation

_Is there any installer impact for this change?_

N/A.