### PR TITLE
Fix bogus assert in XskPoke

### DIFF
--- a/src/xdp/xsk.c
+++ b/src/xdp/xsk.c
@@ -114,6 +114,9 @@ typedef struct _XSK_RX {
         };
         UINT8 Value;
     } ExtensionFlags;
+    struct {
+        BOOLEAN Activated : 1;
+    } Flags;
     UINT16 LayoutExtensionOffset;
     UINT16 ChecksumExtensionOffset;
     UINT16 OriginalLengthExtensionOffset;
@@ -181,6 +184,9 @@ typedef struct _XSK_TX {
         };
         UINT8 Value;
     } OffloadFlags;
+    struct {
+        BOOLEAN Activated : 1;
+    } Flags;
     UINT16 LayoutExtensionOffset;
     UINT16 ChecksumExtensionOffset;
     UINT16 TimestampCompletionExtensionOffset;
@@ -2507,6 +2513,7 @@ XskActivateCommitRxIf(
     XdpRxQueueInvokeAttachmentNotification(
         Xsk->Rx.Xdp.Queue, &Xsk->Rx.Xdp.QueueNotificationEntry,
         XskNotifyRxQueue);
+    Xsk->Rx.Flags.Activated = TRUE;
 
     Status = STATUS_SUCCESS;
 
@@ -2727,6 +2734,8 @@ XskActivateCommitTxIf(
     RtlAcquirePushLockExclusive(&Xsk->PollLock);
     Xsk->Tx.Xdp.Flags.QueueActive = TRUE;
     RtlReleasePushLockExclusive(&Xsk->PollLock);
+
+    Xsk->Tx.Flags.Activated = TRUE;
 
     Status = STATUS_SUCCESS;
 
@@ -3074,21 +3083,14 @@ XskIrpActivateSocket(
         KeReleaseSpinLock(&Xsk->Lock, OldIrql);
         goto Exit;
     }
-    //
-    // For each datapath direction, require all rings be set if the path is
-    // bound. If the direction was not bound, only require the RX/TX rings
-    // themselves not be set: many examples of binding the fill/completion rings
-    // accumulated before a stricter API could be enforced.
-    if ((Xsk->Rx.Xdp.Queue == NULL && Xsk->Rx.Ring.Size > 0) ||
-        (Xsk->Rx.Xdp.Queue != NULL &&
-        (Xsk->Rx.Ring.Size == 0 || Xsk->Rx.FillRing.Size == 0))) {
+    if (Xsk->Rx.Xdp.Queue != NULL &&
+        (Xsk->Rx.Ring.Size == 0 || Xsk->Rx.FillRing.Size == 0)) {
         Status = STATUS_INVALID_DEVICE_STATE;
         KeReleaseSpinLock(&Xsk->Lock, OldIrql);
         goto Exit;
     }
-    if ((Xsk->Tx.Xdp.Queue == NULL && Xsk->Tx.Ring.Size > 0) ||
-        (Xsk->Tx.Xdp.Queue != NULL &&
-        (Xsk->Tx.Ring.Size == 0 || Xsk->Tx.CompletionRing.Size == 0))) {
+    if (Xsk->Tx.Xdp.Queue != NULL &&
+        (Xsk->Tx.Ring.Size == 0 || Xsk->Tx.CompletionRing.Size == 0)) {
         Status = STATUS_INVALID_DEVICE_STATE;
         KeReleaseSpinLock(&Xsk->Lock, OldIrql);
         goto Exit;
@@ -5398,8 +5400,8 @@ XskNotifyValidateParams(
         return STATUS_INVALID_PARAMETER;
     }
 
-    if ((*InFlags & (XSK_NOTIFY_FLAG_POKE_RX | XSK_NOTIFY_FLAG_WAIT_RX) && Xsk->Rx.Ring.Size == 0) ||
-        (*InFlags & (XSK_NOTIFY_FLAG_POKE_TX | XSK_NOTIFY_FLAG_WAIT_TX) && Xsk->Tx.Ring.Size == 0)) {
+    if ((*InFlags & (XSK_NOTIFY_FLAG_POKE_RX | XSK_NOTIFY_FLAG_WAIT_RX) && !Xsk->Rx.Flags.Activated) ||
+        (*InFlags & (XSK_NOTIFY_FLAG_POKE_TX | XSK_NOTIFY_FLAG_WAIT_TX) && !Xsk->Tx.Flags.Activated)) {
         return STATUS_INVALID_DEVICE_STATE;
     }
 
@@ -5433,6 +5435,7 @@ XskPoke(
 
         if (Flags & XSK_NOTIFY_FLAG_POKE_RX) {
             ASSERT(Xsk->Rx.Ring.Size > 0);
+            ASSERT(Xsk->Rx.FillRing.Size > 0);
             //
             // TODO: Driver poke routine for zero copy RX.
             //

--- a/src/xdp/xsk.c
+++ b/src/xdp/xsk.c
@@ -197,7 +197,6 @@ typedef struct _XSK_TX {
         };
         UINT8 Value;
     } OffloadChangeFlags;
-    BOOLEAN Activated;
 } XSK_TX;
 
 typedef struct _XSK {
@@ -3075,14 +3074,14 @@ XskIrpActivateSocket(
         KeReleaseSpinLock(&Xsk->Lock, OldIrql);
         goto Exit;
     }
-    if (Xsk->Rx.Xdp.Queue != NULL &&
-        (Xsk->Rx.Ring.Size == 0 || Xsk->Rx.FillRing.Size == 0)) {
+    if ((Xsk->Rx.Xdp.Queue == NULL) != (Xsk->Rx.Ring.Size == 0) ||
+        (Xsk->Rx.Xdp.Queue == NULL) != (Xsk->Rx.FillRing.Size == 0)) {
         Status = STATUS_INVALID_DEVICE_STATE;
         KeReleaseSpinLock(&Xsk->Lock, OldIrql);
         goto Exit;
     }
-    if (Xsk->Tx.Xdp.Queue != NULL &&
-        (Xsk->Tx.Ring.Size == 0 || Xsk->Tx.CompletionRing.Size == 0)) {
+    if ((Xsk->Tx.Xdp.Queue == NULL) != (Xsk->Tx.Ring.Size == 0) ||
+        (Xsk->Tx.Xdp.Queue == NULL) != (Xsk->Tx.CompletionRing.Size == 0)) {
         Status = STATUS_INVALID_DEVICE_STATE;
         KeReleaseSpinLock(&Xsk->Lock, OldIrql);
         goto Exit;

--- a/src/xdp/xsk.c
+++ b/src/xdp/xsk.c
@@ -3074,14 +3074,21 @@ XskIrpActivateSocket(
         KeReleaseSpinLock(&Xsk->Lock, OldIrql);
         goto Exit;
     }
-    if ((Xsk->Rx.Xdp.Queue == NULL) != (Xsk->Rx.Ring.Size == 0) ||
-        (Xsk->Rx.Xdp.Queue == NULL) != (Xsk->Rx.FillRing.Size == 0)) {
+    //
+    // For each datapath direction, require all rings be set if the path is
+    // bound. If the direction was not bound, only require the RX/TX rings
+    // themselves not be set: many examples of binding the fill/completion rings
+    // accumulated before a stricter API could be enforced.
+    if ((Xsk->Rx.Xdp.Queue == NULL && Xsk->Rx.Ring.Size > 0) ||
+        (Xsk->Rx.Xdp.Queue != NULL &&
+        (Xsk->Rx.Ring.Size == 0 || Xsk->Rx.FillRing.Size == 0))) {
         Status = STATUS_INVALID_DEVICE_STATE;
         KeReleaseSpinLock(&Xsk->Lock, OldIrql);
         goto Exit;
     }
-    if ((Xsk->Tx.Xdp.Queue == NULL) != (Xsk->Tx.Ring.Size == 0) ||
-        (Xsk->Tx.Xdp.Queue == NULL) != (Xsk->Tx.CompletionRing.Size == 0)) {
+    if ((Xsk->Tx.Xdp.Queue == NULL && Xsk->Tx.Ring.Size > 0) ||
+        (Xsk->Tx.Xdp.Queue != NULL &&
+        (Xsk->Tx.Ring.Size == 0 || Xsk->Tx.CompletionRing.Size == 0))) {
         Status = STATUS_INVALID_DEVICE_STATE;
         KeReleaseSpinLock(&Xsk->Lock, OldIrql);
         goto Exit;
@@ -5426,7 +5433,6 @@ XskPoke(
 
         if (Flags & XSK_NOTIFY_FLAG_POKE_RX) {
             ASSERT(Xsk->Rx.Ring.Size > 0);
-            ASSERT(Xsk->Rx.FillRing.Size > 0);
             //
             // TODO: Driver poke routine for zero copy RX.
             //


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

I hit an [assert](https://github.com/microsoft/xdp-for-windows/blob/06b0e15c69764e171648e4c4103aba3f09a51760/src/xdp/xsk.c#L5430) while onboarding multi-if spin tests. It looks benign in and of itself, but exposes a potentially contradictory state.

Update the notify validation routine to check whether the datapath direction was activated, rather than checking whether a ring size was set.

I originally tried to tighten up the activation logic to require each ring size be non-zero if and only if the encompassing datapath direction is bound, but we have tons of historical examples of gratuitously setting the RX fill and TX completion rings.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

N/A.

## Installation

_Is there any installer impact for this change?_

N/A.