### PR TITLE
support uplevel nuget runtimes on release/1.1

### DIFF
--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -721,10 +721,33 @@ SetDeviceSddl(
     )
 {
     CHAR CmdBuff[256];
+    CHAR XdpBinaryPath[MAX_PATH];
+    UINT32 XdpBinaryPathLength;
+
     RtlZeroMemory(CmdBuff, sizeof(CmdBuff));
 
-    sprintf_s(CmdBuff, "xdpcfg.exe SetDeviceSddl \"%s\"", Sddl);
-    TEST_EQUAL(0, InvokeSystem(CmdBuff));
+    XdpBinaryPathLength =
+        GetEnvironmentVariableA("_XDP_BINARIES_PATH", XdpBinaryPath, sizeof(XdpBinaryPath));
+
+    if (XdpBinaryPathLength > 0) {
+        //
+        // The XDP runtime was installed via nuget package, which doesn't add
+        // XDP to the system-wide search path; use the path hint provided by
+        // the test setup script, which is currently only set uplevel.
+        //
+        TEST_TRUE(XdpBinaryPathLength <= sizeof(XdpBinaryPath));
+
+        RtlZeroMemory(CmdBuff, sizeof(CmdBuff));
+        sprintf_s(CmdBuff, "%s\\xdpcfg.exe SetDeviceSddl \"%s\"", XdpBinaryPath, Sddl);
+        TEST_EQUAL(0, InvokeSystem(CmdBuff));
+    } else {
+        //
+        // There's no XDP path hint, so fall back to using the system search
+        // path. This works only with the MSI installer.
+        //
+        sprintf_s(CmdBuff, "xdpcfg.exe SetDeviceSddl \"%s\"", Sddl);
+        TEST_EQUAL(0, InvokeSystem(CmdBuff));
+    }
 }
 
 static


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

The MSI cleanup uplevel (#1014) exposed a test dependency on XDP being added to the system path. Since the nuget runtime doesn't modify the system path by design, add the corresponding (but now conditional) `_XDP_BINARIES_PATH` path hint to the functional tests, so they can be run uplevel.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.