### PR TITLE
Add remote test execution and AI integration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -146,6 +146,50 @@ Guidelines for agents:
 * If kd reports "Cannot connect to server" or exits immediately, inform
   the user that no kd head is currently attached to that machine and
   continue without kd.
+* **Keep kd attached across reboots.** After issuing `.reboot`, leave
+  the kd terminal running — secondary breaks (early-boot Driver Verifier
+  hits, watchdog timeouts, follow-on bugchecks from corrupted state)
+  often happen during the next boot and you'll want to see them.
+* **Bugchecks can leave the test machine's disk in a damaged state.**
+  Files written to disk in the seconds before the crash may be
+  truncated, partially written, or filled with NUL bytes. Driver
+  registry keys, INF / catalog files, and PnP metadata are common
+  victims. If `check-drivers.ps1` fails to recover the machine and the
+  failure looks like file/state corruption, try to improve
+  `check-drivers.ps1` (and the helpers it calls) to detect and repair
+  that specific class of corruption explicitly. Avoid adding broad
+  ignore-everything error handling; recovery should be targeted and
+  understandable.
+* **Reinstall-over-corrupt is often the simplest recovery.** When an
+  installer/MSI/INF reports the product is missing from its database
+  but the on-disk binaries and loaded driver are still present, the
+  cleanest fix is to *reinstall* on top of the existing layout (which
+  reseeds the database) and then run the normal uninstall. Prefer this
+  over hand-rolled service/driver teardown when feasible.
+* **Recovery flags must be opt-in.** Behaviors that downgrade errors,
+  reinstall over partial state, or otherwise paper over corruption
+  belong behind a `-Force` (or similarly named) switch on the recovery
+  script (e.g. `tools\check-drivers.ps1 -Force`). Don't change default
+  install/uninstall behavior.
+* **Persist until `check-drivers.ps1` succeeds.** The development loop
+  cannot move on to the next build/test cycle while the test machine is
+  in a broken state. Each bugcheck tends to expose a *slightly
+  different* corruption (NUL-filled scripts last time, a wedged eBPF
+  service this time, something else next time). When `check-drivers.ps1`
+  fails:
+  1. Read the actual error and identify which component / step is
+     stuck.
+  2. Improve `tools\setup.ps1` (or `tools\check-drivers.ps1`) with a
+     **targeted** fix for that specific failure mode — e.g. add a
+     stuck service to the cleanup list, detect a specific MSI exit
+     code, or add a NUL-byte check for a specific file path.
+  3. Re-run `check-drivers.ps1 -Force` and repeat until it reports
+     "No loaded XDP drivers found!".
+  4. Only then return to the build/test/deploy loop.
+
+  Do not stop at "the recovery is partially working" — partial
+  recovery means the next test run will hit the residual broken state
+  and waste another iteration.
 * When the chat session ends or the user moves on, kill the kd
   terminal.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,212 +59,27 @@ XDP for Windows is a high-performance Windows packet processing framework inspir
 
 ## Testing
 
-All testing must occur on a separate test machine. Do not try to run tests locally.
+All testing must occur on a separate test machine. Do not try to run
+tests locally. **Always pass `-ComputerName <machine>` explicitly on
+every test command** — see the `xdp-testing` skill below.
 
-> [!IMPORTANT]
-> **Always pass `-ComputerName <machine>` explicitly on every test
-> command.** Do not rely on `Set-XdpRemoteDefault` /
-> `remote-set-default.ps1` alone — the session default lives in the
-> PowerShell global scope and is silently lost when a new terminal is
-> spawned (which happens any time a previous command spawned its own
-> shell, e.g. after `Start-Process`, after a kd session, or whenever the
-> tool host opens a fresh terminal). A test script invoked without
-> `-ComputerName` and without an active session default will run
-> **against the dev machine**, which can damage local state.
-> The session default is a convenience for the human at the keyboard;
-> for AI-driven runs treat `-ComputerName` as required.
+For everything else about test execution and bugcheck recovery
+(remote PowerShell setup, kd attach over named pipe, the
+inject/build/bugcheck/`.reboot`/`check-drivers -Force` recovery loop,
+how to derive default test parameters from CI, the persist-until-clean
+recovery doctrine, opt-in `-Force` recovery flags), use the
+[`xdp-testing`](./skills/xdp-testing/SKILL.md) skill. The skill is
+auto-loaded whenever an agent runs any `tools\*.ps1` test or recovery
+command, attaches kd, or analyzes a bugcheck.
 
-### Running tests against a remote test machine (PREFERRED for AI agents)
-
-The repo's test scripts (`tools\functional.ps1`, `tools\spinxsk.ps1`,
-`tools\prepare-machine.ps1` for non-build scenarios, `tools\check-drivers.ps1`,
-`tools\rxfilter.ps1`, `tools\rxfilterperf.ps1`, `tools\ringperf.ps1`,
-`tools\xskmaprx.ps1`, `tools\xskfwdkm.ps1`, `tools\pktfuzz.ps1`) all
-support a `-ComputerName` parameter that transparently runs the script on
-a remote test machine via PowerShell remoting. See [docs/remote-testing.md](../docs/remote-testing.md).
-
-**Workflow for AI agents:**
-
-1. **Ask the user for the test machine name once per chat session.** Use a
-   clarifying question. Example prompt: *"Which test machine should I run
-   tests on?"*. Accept hostname, FQDN, or IP. Remember the value and
-   pass it as `-ComputerName <machine>` on **every** test-script
-   invocation for the rest of the session.
-
-2. **Optionally set the session default for the human's convenience:**
-   ```powershell
-   .\tools\remote-set-default.ps1 <machine>
-   ```
-   This is *not* a substitute for `-ComputerName` in agent-driven
-   commands (see the IMPORTANT note above). Continue to pass
-   `-ComputerName` explicitly.
-
-3. **Run any test script with `-ComputerName`** — it auto-forwards to
-   the remote and streams output back:
-   ```powershell
-   .\tools\functional.ps1 -ComputerName <machine> -ListTestCases
-   .\tools\functional.ps1 -ComputerName <machine> -TestCaseFilter "Name=GenericBinding"
-   .\tools\spinxsk.ps1 -ComputerName <machine> -Minutes 5
-   ```
-
-4. **Credentials.** On first connect the script auto-adds the host to
-   WSMan TrustedHosts (UAC prompt) and, if WinRM rejects with auth error,
-   prompts at the **console** (`Read-Host`, no GUI) for username and
-   password. Credentials are then cached in
-   `$global:XdpRemoteCredentialCache` for the rest of the session. Do
-   **not** generate `Get-Credential` calls or store passwords in scripts.
-
-5. **One-time setup on the test machine itself** (must be done by the
-   user, requires elevation):
-   ```powershell
-   .\tools\remote.ps1 -EnableRemoting
-   ```
-   If the user has not done this, the connection will fail with
-   "WinRM client cannot process the request" or similar. Tell them to
-   run `tools\remote.ps1 -EnableRemoting` on the test machine.
-
-6. **Build first.** Remote scripts deploy `artifacts\bin\<plat>_<cfg>\`
-   from the dev machine. Always run `.\tools\build.ps1` (or rely on a
-   recent build) before remote test commands.
-
-**Build-only scripts always run locally and ignore `-ComputerName`:**
-`build.ps1`, `merge-artifacts.ps1`, `publish-nuget.ps1`,
-`prepare-machine.ps1 -ForBuild` / `-ForEbpfBuild`,
-`create-test-archive.ps1`, `update-nuspec.ps1`.
-
-### Monitoring the test machine kernel debugger
-
-Test machines typically have a kd "head" already attached and exposing a
-debug server over a named pipe (started on the head with `.server
-npipe:pipe=<name>`). To watch for breaks/bugchecks during a test run,
-attach a passive **remote** kd client from the dev machine **in a
-separate background terminal**:
+Quick reference for the most common scripts:
 
 ```powershell
-# Run in a background terminal (mode=async) before kicking off the test.
-# Replace <pipe-name> with the kd pipe name; defaults to the same value
-# as -ComputerName / Set-XdpRemoteDefault.
-kd.exe -remote npipe:server=localhost,pipe=<pipe-name>
+.\tools\functional.ps1 -ComputerName <machine> -ListTestCases
+.\tools\functional.ps1 -ComputerName <machine> -TestCaseFilter "Name=GenericBinding"
+.\tools\spinxsk.ps1   -ComputerName <machine> -Minutes 5
+.\tools\check-drivers.ps1 -ComputerName <machine> -Force
 ```
-
-Guidelines for agents:
-
-* Use `-remote npipe:server=localhost,pipe=<name>` — **never**
-  `-k com:pipe,port=...` (that is the serial-pipe transport for VMs and
-  will not connect to a kd debug server).
-* Default `pipe` to the value of `-ComputerName` / `Set-XdpRemoteDefault`.
-  If that fails to connect, ask the user for the correct pipe name once.
-* Run kd as `mode=async` so the test invocation can stream output in
-  parallel.
-* Periodically check the kd terminal for break-in prompts (`kd>` after
-  a break) or bugcheck banners and surface them to the user; otherwise
-  let kd run idle in the background.
-* If kd reports "Cannot connect to server" or exits immediately, inform
-  the user that no kd head is currently attached to that machine and
-  continue without kd.
-* **Keep kd attached across reboots.** After issuing `.reboot`, leave
-  the kd terminal running — secondary breaks (early-boot Driver Verifier
-  hits, watchdog timeouts, follow-on bugchecks from corrupted state)
-  often happen during the next boot and you'll want to see them.
-* **Bugchecks can leave the test machine's disk in a damaged state.**
-  Files written to disk in the seconds before the crash may be
-  truncated, partially written, or filled with NUL bytes. Driver
-  registry keys, INF / catalog files, and PnP metadata are common
-  victims. If `check-drivers.ps1` fails to recover the machine and the
-  failure looks like file/state corruption, try to improve
-  `check-drivers.ps1` (and the helpers it calls) to detect and repair
-  that specific class of corruption explicitly. Avoid adding broad
-  ignore-everything error handling; recovery should be targeted and
-  understandable.
-* **Reinstall-over-corrupt is often the simplest recovery.** When an
-  installer/MSI/INF reports the product is missing from its database
-  but the on-disk binaries and loaded driver are still present, the
-  cleanest fix is to *reinstall* on top of the existing layout (which
-  reseeds the database) and then run the normal uninstall. Prefer this
-  over hand-rolled service/driver teardown when feasible.
-* **Recovery flags must be opt-in.** Behaviors that downgrade errors,
-  reinstall over partial state, or otherwise paper over corruption
-  belong behind a `-Force` (or similarly named) switch on the recovery
-  script (e.g. `tools\check-drivers.ps1 -Force`). Don't change default
-  install/uninstall behavior.
-* **Persist until `check-drivers.ps1` succeeds.** The development loop
-  cannot move on to the next build/test cycle while the test machine is
-  in a broken state. Each bugcheck tends to expose a *slightly
-  different* corruption (NUL-filled scripts last time, a wedged eBPF
-  service this time, something else next time). When `check-drivers.ps1`
-  fails:
-  1. Read the actual error and identify which component / step is
-     stuck.
-  2. Improve `tools\setup.ps1` (or `tools\check-drivers.ps1`) with a
-     **targeted** fix for that specific failure mode — e.g. add a
-     stuck service to the cleanup list, detect a specific MSI exit
-     code, or add a NUL-byte check for a specific file path.
-  3. Re-run `check-drivers.ps1 -Force` and repeat until it reports
-     "No loaded XDP drivers found!".
-  4. Only then return to the build/test/deploy loop.
-
-  Do not stop at "the recovery is partially working" — partial
-  recovery means the next test run will hit the residual broken state
-  and waste another iteration.
-* When the chat session ends or the user moves on, kill the kd
-  terminal.
-
-### Functional Tests
-
-1. Prepare test machine (requires admin, enables test signing, may require reboot):
-   ```powershell
-   .\tools\prepare-machine.ps1 -ForFunctionalTest
-   ```
-
-2. Run tests:
-   ```powershell
-   .\tools\functional.ps1 -Config Debug -Platform x64
-   ```
-
-3. Run specific test:
-   ```powershell
-   .\tools\functional.ps1 -TestCaseFilter "Name=GenericBinding"
-   ```
-
-4. List test cases:
-   ```powershell
-   .\tools\functional.ps1 -ListTestCases
-   ```
-
-5. Convert logs after test:
-   ```powershell
-   .\tools\log.ps1 -Convert -Name xdpfunc
-   ```
-
-### Stress Tests (spinxsk)
-
-```powershell
-.\tools\prepare-machine.ps1 -ForSpinxskTest
-.\tools\spinxsk.ps1 -XdpmpPollProvider FNDIS -QueueCount 2 -Minutes 10
-.\tools\log.ps1 -Convert -Name spinxsk
-```
-
-### Deriving test parameters from CI
-
-When the user asks to run a test (functional, spinxsk, perf, fuzz, etc.)
-without specifying parameters, **derive sensible defaults from the
-matching job in `.github/workflows/ci.yml`** rather than guessing. That
-file is the source of truth for which switches each test is exercised
-with in CI. Examples:
-
-* For spinxsk, CI invokes
-  `tools/spinxsk.ps1 -Verbose -Stats -Driver <XDPMP|FNMP> -Minutes <N>
-  -XdpmpPollProvider <NDIS|FNDIS> -SuccessThresholdPercent <pct>
-  -EnableEbpf [-TxInspect]`. Use those flags (scaling `-Minutes` down for
-  smoke runs as the user requests).
-* For functional tests, mirror the `-Config`, `-Platform`, and any
-  `-TestCaseFilter` / `-XdpInstaller` flags the CI job uses.
-* For perf and fuzz, copy the CI invocation verbatim, only adjusting
-  duration/iteration counts when the user explicitly asks for a shorter
-  run.
-
-If the user explicitly overrides a parameter, respect that and leave
-unspecified parameters at the CI defaults.
 
 ## Project Layout
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -116,6 +116,39 @@ a remote test machine via PowerShell remoting. See [docs/remote-testing.md](../d
 `prepare-machine.ps1 -ForBuild` / `-ForEbpfBuild`,
 `create-test-archive.ps1`, `update-nuspec.ps1`.
 
+### Monitoring the test machine kernel debugger
+
+Test machines typically have a kd "head" already attached and exposing a
+debug server over a named pipe (started on the head with `.server
+npipe:pipe=<name>`). To watch for breaks/bugchecks during a test run,
+attach a passive **remote** kd client from the dev machine **in a
+separate background terminal**:
+
+```powershell
+# Run in a background terminal (mode=async) before kicking off the test.
+# Replace <pipe-name> with the kd pipe name; defaults to the same value
+# as -ComputerName / Set-XdpRemoteDefault.
+kd.exe -remote npipe:server=localhost,pipe=<pipe-name>
+```
+
+Guidelines for agents:
+
+* Use `-remote npipe:server=localhost,pipe=<name>` — **never**
+  `-k com:pipe,port=...` (that is the serial-pipe transport for VMs and
+  will not connect to a kd debug server).
+* Default `pipe` to the value of `-ComputerName` / `Set-XdpRemoteDefault`.
+  If that fails to connect, ask the user for the correct pipe name once.
+* Run kd as `mode=async` so the test invocation can stream output in
+  parallel.
+* Periodically check the kd terminal for break-in prompts (`kd>` after
+  a break) or bugcheck banners and surface them to the user; otherwise
+  let kd run idle in the background.
+* If kd reports "Cannot connect to server" or exits immediately, inform
+  the user that no kd head is currently attached to that machine and
+  continue without kd.
+* When the chat session ends or the user moves on, kill the kd
+  terminal.
+
 ### Functional Tests
 
 1. Prepare test machine (requires admin, enables test signing, may require reboot):

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -61,6 +61,19 @@ XDP for Windows is a high-performance Windows packet processing framework inspir
 
 All testing must occur on a separate test machine. Do not try to run tests locally.
 
+> [!IMPORTANT]
+> **Always pass `-ComputerName <machine>` explicitly on every test
+> command.** Do not rely on `Set-XdpRemoteDefault` /
+> `remote-set-default.ps1` alone — the session default lives in the
+> PowerShell global scope and is silently lost when a new terminal is
+> spawned (which happens any time a previous command spawned its own
+> shell, e.g. after `Start-Process`, after a kd session, or whenever the
+> tool host opens a fresh terminal). A test script invoked without
+> `-ComputerName` and without an active session default will run
+> **against the dev machine**, which can damage local state.
+> The session default is a convenience for the human at the keyboard;
+> for AI-driven runs treat `-ComputerName` as required.
+
 ### Running tests against a remote test machine (PREFERRED for AI agents)
 
 The repo's test scripts (`tools\functional.ps1`, `tools\spinxsk.ps1`,
@@ -74,21 +87,24 @@ a remote test machine via PowerShell remoting. See [docs/remote-testing.md](../d
 
 1. **Ask the user for the test machine name once per chat session.** Use a
    clarifying question. Example prompt: *"Which test machine should I run
-   tests on?"*. Accept hostname, FQDN, or IP.
+   tests on?"*. Accept hostname, FQDN, or IP. Remember the value and
+   pass it as `-ComputerName <machine>` on **every** test-script
+   invocation for the rest of the session.
 
-2. **Set the session default so subsequent commands don't need
-   `-ComputerName`:**
+2. **Optionally set the session default for the human's convenience:**
    ```powershell
    .\tools\remote-set-default.ps1 <machine>
    ```
-   This persists for the current PowerShell session.
+   This is *not* a substitute for `-ComputerName` in agent-driven
+   commands (see the IMPORTANT note above). Continue to pass
+   `-ComputerName` explicitly.
 
-3. **Run any test script normally** — it auto-forwards to the remote and
-   streams output back:
+3. **Run any test script with `-ComputerName`** — it auto-forwards to
+   the remote and streams output back:
    ```powershell
-   .\tools\functional.ps1 -ListTestCases
-   .\tools\functional.ps1 -TestCaseFilter "Name=GenericBinding"
-   .\tools\spinxsk.ps1 -Minutes 5
+   .\tools\functional.ps1 -ComputerName <machine> -ListTestCases
+   .\tools\functional.ps1 -ComputerName <machine> -TestCaseFilter "Name=GenericBinding"
+   .\tools\spinxsk.ps1 -ComputerName <machine> -Minutes 5
    ```
 
 4. **Credentials.** On first connect the script auto-adds the host to

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -151,6 +151,28 @@ a remote test machine via PowerShell remoting. See [docs/remote-testing.md](../d
 .\tools\log.ps1 -Convert -Name spinxsk
 ```
 
+### Deriving test parameters from CI
+
+When the user asks to run a test (functional, spinxsk, perf, fuzz, etc.)
+without specifying parameters, **derive sensible defaults from the
+matching job in `.github/workflows/ci.yml`** rather than guessing. That
+file is the source of truth for which switches each test is exercised
+with in CI. Examples:
+
+* For spinxsk, CI invokes
+  `tools/spinxsk.ps1 -Verbose -Stats -Driver <XDPMP|FNMP> -Minutes <N>
+  -XdpmpPollProvider <NDIS|FNDIS> -SuccessThresholdPercent <pct>
+  -EnableEbpf [-TxInspect]`. Use those flags (scaling `-Minutes` down for
+  smoke runs as the user requests).
+* For functional tests, mirror the `-Config`, `-Platform`, and any
+  `-TestCaseFilter` / `-XdpInstaller` flags the CI job uses.
+* For perf and fuzz, copy the CI invocation verbatim, only adjusting
+  duration/iteration counts when the user explicitly asks for a shorter
+  run.
+
+If the user explicitly overrides a parameter, respect that and leave
+unspecified parameters at the CI defaults.
+
 ## Project Layout
 
 ```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -61,6 +61,61 @@ XDP for Windows is a high-performance Windows packet processing framework inspir
 
 All testing must occur on a separate test machine. Do not try to run tests locally.
 
+### Running tests against a remote test machine (PREFERRED for AI agents)
+
+The repo's test scripts (`tools\functional.ps1`, `tools\spinxsk.ps1`,
+`tools\prepare-machine.ps1` for non-build scenarios, `tools\check-drivers.ps1`,
+`tools\rxfilter.ps1`, `tools\rxfilterperf.ps1`, `tools\ringperf.ps1`,
+`tools\xskmaprx.ps1`, `tools\xskfwdkm.ps1`, `tools\pktfuzz.ps1`) all
+support a `-ComputerName` parameter that transparently runs the script on
+a remote test machine via PowerShell remoting. See [docs/remote-testing.md](../docs/remote-testing.md).
+
+**Workflow for AI agents:**
+
+1. **Ask the user for the test machine name once per chat session.** Use a
+   clarifying question. Example prompt: *"Which test machine should I run
+   tests on?"*. Accept hostname, FQDN, or IP.
+
+2. **Set the session default so subsequent commands don't need
+   `-ComputerName`:**
+   ```powershell
+   .\tools\remote-set-default.ps1 <machine>
+   ```
+   This persists for the current PowerShell session.
+
+3. **Run any test script normally** — it auto-forwards to the remote and
+   streams output back:
+   ```powershell
+   .\tools\functional.ps1 -ListTestCases
+   .\tools\functional.ps1 -TestCaseFilter "Name=GenericBinding"
+   .\tools\spinxsk.ps1 -Minutes 5
+   ```
+
+4. **Credentials.** On first connect the script auto-adds the host to
+   WSMan TrustedHosts (UAC prompt) and, if WinRM rejects with auth error,
+   prompts at the **console** (`Read-Host`, no GUI) for username and
+   password. Credentials are then cached in
+   `$global:XdpRemoteCredentialCache` for the rest of the session. Do
+   **not** generate `Get-Credential` calls or store passwords in scripts.
+
+5. **One-time setup on the test machine itself** (must be done by the
+   user, requires elevation):
+   ```powershell
+   .\tools\remote.ps1 -EnableRemoting
+   ```
+   If the user has not done this, the connection will fail with
+   "WinRM client cannot process the request" or similar. Tell them to
+   run `tools\remote.ps1 -EnableRemoting` on the test machine.
+
+6. **Build first.** Remote scripts deploy `artifacts\bin\<plat>_<cfg>\`
+   from the dev machine. Always run `.\tools\build.ps1` (or rely on a
+   recent build) before remote test commands.
+
+**Build-only scripts always run locally and ignore `-ComputerName`:**
+`build.ps1`, `merge-artifacts.ps1`, `publish-nuget.ps1`,
+`prepare-machine.ps1 -ForBuild` / `-ForEbpfBuild`,
+`create-test-archive.ps1`, `update-nuspec.ps1`.
+
 ### Functional Tests
 
 1. Prepare test machine (requires admin, enables test signing, may require reboot):

--- a/.github/skills/xdp-testing/SKILL.md
+++ b/.github/skills/xdp-testing/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: xdp-testing
+description: 'XDP-for-Windows test execution and debugging workflow. Use when running tests (functional, spinxsk, pktfuzz, ringperf, rxfilter, xskmaprx, xskfwdkm), debugging bugchecks, attaching kd, recovering test machines after crashes, or invoking any tools/*.ps1 script that runs on hardware. Covers PowerShell remoting via -ComputerName, kd remote pipe debugging, and the inject/build/bugcheck/.reboot/check-drivers recovery loop.'
+user-invocable: false
+---
+
+# XDP for Windows: Testing & Debugging
+
+This skill covers everything an agent needs to execute tests on the
+required separate test machine, attach kd for crash analysis, and
+recover the machine to a known-good state after a bugcheck.
+
+> [!IMPORTANT]
+> All XDP testing must occur on a separate Windows test machine — never
+> the dev machine. Always pass `-ComputerName <machine>` explicitly on
+> every test command. Do **not** rely on
+> `tools\remote-set-default.ps1` alone — the session default lives in
+> the PowerShell global scope and is silently lost when a new terminal
+> spawns (after `Start-Process`, kd sessions, or whenever the tool host
+> opens a fresh shell). A test script invoked without `-ComputerName`
+> and without an active session default will run **against the dev
+> machine** and may damage local state. Treat `-ComputerName` as
+> required.
+
+## When to Use
+
+- Running any of: `functional.ps1`, `spinxsk.ps1`, `prepare-machine.ps1`
+  (non-build scenarios), `check-drivers.ps1`, `rxfilter.ps1`,
+  `rxfilterperf.ps1`, `ringperf.ps1`, `xskmaprx.ps1`, `xskfwdkm.ps1`,
+  `pktfuzz.ps1`.
+- Triggering, observing, or analyzing a kernel bugcheck.
+- Recovering a test machine that's stuck after a crash.
+- Choosing default parameters for a test invocation.
+
+## Build-only scripts (always local, ignore -ComputerName)
+
+`build.ps1`, `merge-artifacts.ps1`, `publish-nuget.ps1`,
+`prepare-machine.ps1 -ForBuild` / `-ForEbpfBuild`,
+`create-test-archive.ps1`, `update-nuspec.ps1`.
+
+## Remote-test workflow
+
+1. **Ask the user once per chat session** which test machine to use:
+   *"Which test machine should I run tests on?"*. Accept hostname,
+   FQDN, or IP. Remember the value for the rest of the session and
+   pass it as `-ComputerName <machine>` on every test invocation.
+
+2. *(Optional, human convenience only)* set the session default. Does
+   **not** replace `-ComputerName` for agent-driven runs:
+   ```powershell
+   .\tools\remote-set-default.ps1 <machine>
+   ```
+
+3. **Run any test script with `-ComputerName`** — it auto-deploys
+   `artifacts\bin\<plat>_<cfg>\` and streams output back:
+   ```powershell
+   .\tools\functional.ps1 -ComputerName <machine> -ListTestCases
+   .\tools\functional.ps1 -ComputerName <machine> -TestCaseFilter "Name=GenericBinding"
+   .\tools\spinxsk.ps1   -ComputerName <machine> -Minutes 5
+   ```
+
+4. **Credentials.** First connect auto-adds the host to WSMan
+   TrustedHosts (UAC prompt) and, if WinRM rejects with auth error,
+   prompts at the **console** (`Read-Host`, no GUI) for username and
+   password. Credentials are cached in
+   `$global:XdpRemoteCredentialCache` for the rest of the session. Do
+   **not** generate `Get-Credential` calls or store passwords in
+   scripts.
+
+5. **One-time test-machine setup** (the user must run, requires
+   elevation):
+   ```powershell
+   .\tools\remote.ps1 -EnableRemoting
+   ```
+   If the user hasn't done this, the connection fails with "WinRM
+   client cannot process the request" — surface this and ask them to
+   run it.
+
+6. **Build first.** Always run `.\tools\build.ps1` (or rely on a
+   recent build) before remote test commands, since deploy pulls from
+   `artifacts\bin\<plat>_<cfg>\`.
+
+## Choosing test parameters
+
+When the user doesn't specify parameters, **derive sensible defaults
+from the matching job in [.github/workflows/ci.yml](../../workflows/ci.yml)**.
+That file is the source of truth for which switches each test exercises
+in CI.
+
+* spinxsk: `tools/spinxsk.ps1 -Verbose -Stats -Driver <XDPMP|FNMP>
+  -Minutes <N> -XdpmpPollProvider <NDIS|FNDIS>
+  -SuccessThresholdPercent <pct> -EnableEbpf [-TxInspect]`. Scale
+  `-Minutes` down for smoke runs as requested.
+* functional: mirror `-Config`, `-Platform`, and any
+  `-TestCaseFilter` / `-XdpInstaller` flags from the CI job.
+* perf/fuzz: copy the CI invocation verbatim, adjusting only
+  duration/iteration counts when the user asks for a shorter run.
+
+Respect explicit user overrides; leave everything else at CI defaults.
+
+## Kernel debugger (kd) attach for bugcheck monitoring
+
+Test machines typically have a kd "head" already attached and exposing
+a debug server over a named pipe (started on the head with
+`.server npipe:pipe=<name>`). To watch for breaks during a test run,
+attach a passive **remote** kd client from the dev machine in a
+**separate background terminal** before kicking off the test:
+
+```powershell
+# Run with mode=async; <pipe-name> defaults to the same value as
+# -ComputerName / Set-XdpRemoteDefault.
+kd.exe -remote npipe:server=localhost,pipe=<pipe-name>
+```
+
+### kd usage rules
+
+* **Always** `-remote npipe:server=localhost,pipe=<name>` — never
+  `-k com:pipe,port=...` (that's the serial-pipe transport for VMs and
+  will not connect to a kd debug server).
+* Default `pipe` to the value of `-ComputerName` /
+  `Set-XdpRemoteDefault`. If that fails to connect, ask the user once
+  for the correct pipe name.
+* Run kd `mode=async` so test invocations stream output in parallel.
+* Periodically check the kd terminal for break-in prompts (`kd>` after
+  a break) or bugcheck banners; surface them to the user, otherwise
+  let kd run idle.
+* If kd reports "Cannot connect to server" or exits immediately, no kd
+  head is currently attached. Inform the user and continue without kd.
+* **Keep kd attached across reboots.** After `.reboot`, leave the kd
+  terminal running — secondary breaks (early-boot Driver Verifier hits,
+  watchdog timeouts, follow-on bugchecks from corrupted state) often
+  happen during the next boot.
+* **Issuing `.reboot` non-interactively from the dev machine.** Use
+  `kd.exe -cf <scriptfile>` with a hidden window:
+  ```powershell
+  $cmd = New-TemporaryFile
+  Set-Content -Path $cmd -Value ".reboot`r`nqd"
+  Start-Process kd.exe -ArgumentList @(
+      "-remote","npipe:server=localhost,pipe=<machine>",
+      "-cf",$cmd.FullName) -PassThru -WindowStyle Hidden |
+      ForEach-Object { $_.WaitForExit(60000) | Out-Null }
+  Remove-Item $cmd.FullName -Force
+  ```
+  Do not try to drive an interactive `kd>` prompt via PowerShell's
+  terminal stdin — that connects you to the *host* shell, not kd.
+  Then poll `Test-WSMan -ComputerName <machine>` until it succeeds.
+* When the chat session ends or the user moves on, kill the kd
+  terminal.
+
+## Bugcheck recovery loop
+
+Bugchecks frequently leave the test machine in a partially-corrupted
+state that prevents the next iteration from running. The recovery
+script is `tools\check-drivers.ps1 -Force`. **The dev loop cannot move
+on until that command reports "No loaded XDP drivers found!".**
+
+### Recovery doctrine
+
+* **Bugchecks can corrupt on-disk and registry state.** Files written
+  in the seconds before the crash may be truncated, partially written,
+  or filled with NUL bytes. Driver registry keys, INF/catalog files,
+  PnP metadata, and Windows Installer product databases are common
+  victims.
+* **Reinstall over partial state when feasible.** When an
+  installer/MSI/INF reports the product is missing from its database
+  but the on-disk binaries are still present, *reinstall* on top of
+  the existing layout (which reseeds the database) and then run the
+  normal uninstall. Prefer this over hand-rolled service/driver
+  teardown.
+* **Recovery flags MUST be opt-in.** Behaviors that downgrade errors,
+  reinstall over corruption, or paper over partial state belong
+  behind a `-Force` switch on the recovery script (e.g.
+  `tools\check-drivers.ps1 -Force`). Don't change default
+  install/uninstall behavior — that would silently mask real bugs.
+* **Persist until clean.** Each bugcheck tends to expose a *slightly
+  different* corruption (NUL-filled scripts last time, wedged eBPF
+  service this time, something else next time). When
+  `check-drivers.ps1` fails:
+  1. Read the actual error and identify which component / step is
+     stuck.
+  2. Improve `tools\setup.ps1` (or `tools\check-drivers.ps1`) with a
+     **targeted** fix for that specific failure mode — add a stuck
+     service to the cleanup list, detect a specific MSI exit code,
+     add a NUL-byte check for a specific file path, etc.
+  3. Re-run `check-drivers.ps1 -Force` and repeat until it succeeds.
+  4. Only then return to the build/test/deploy loop.
+
+  Do not stop at "the recovery is partially working" — partial
+  recovery means the next test run will hit the residual broken
+  state and waste an iteration. Avoid broad ignore-everything error
+  handling; recovery should be targeted and understandable.
+
+## Common test commands
+
+```powershell
+# Functional tests
+.\tools\prepare-machine.ps1 -ComputerName <machine> -ForFunctionalTest
+.\tools\functional.ps1 -ComputerName <machine> -Config Debug -Platform x64
+.\tools\functional.ps1 -ComputerName <machine> -TestCaseFilter "Name=GenericBinding"
+.\tools\functional.ps1 -ComputerName <machine> -ListTestCases
+.\tools\log.ps1 -Convert -Name xdpfunc
+
+# Stress tests (spinxsk)
+.\tools\prepare-machine.ps1 -ComputerName <machine> -ForSpinxskTest
+.\tools\spinxsk.ps1 -ComputerName <machine> -XdpmpPollProvider FNDIS -QueueCount 2 -Minutes 10
+.\tools\log.ps1 -Convert -Name spinxsk
+
+# Recovery
+.\tools\check-drivers.ps1 -ComputerName <machine> -Force
+```
+
+See [docs/remote-testing.md](../../../docs/remote-testing.md) for the
+human-facing reference.

--- a/docs/development.md
+++ b/docs/development.md
@@ -50,6 +50,10 @@ The test machine must have the "artifacts" and "tools" directories from the repo
 by cloning the repo and building the code or by copying them from another system. The
 file layout is assumed to be identical to that of the repo.
 
+For a streamlined dev-machine -> test-machine workflow over PowerShell remoting,
+see [Remote testing](./remote-testing.md). The same test scripts described
+below accept a `-ComputerName` parameter to run against a remote test machine.
+
 ### Running functional tests
 
 One-time setup:

--- a/docs/remote-testing.md
+++ b/docs/remote-testing.md
@@ -16,7 +16,7 @@ Run this once on the test machine in an **elevated** PowerShell:
 
 This is equivalent to `Enable-PSRemoting -Force -SkipNetworkProfileCheck`,
 plus a few WinRM tweaks (larger envelope, longer idle timeout) so that
-deployment and long test runs complete cleanly.
+deployment and long test runs complete cleanly. If the script is not readily available, the `Enable-PSRemoting` command is sufficient to boostrap the machine.
 
 If the dev box is not in the same domain as the test machine, the dev script
 will automatically add the test machine to the local WSMan TrustedHosts list

--- a/docs/remote-testing.md
+++ b/docs/remote-testing.md
@@ -1,0 +1,99 @@
+# Running XDP tests on a remote machine
+
+The XDP test scripts (`tools/functional.ps1`, `tools/spinxsk.ps1`, ...) cannot
+run on a developer machine because they require test-signed drivers and a
+clean networking state. To make iterating against a separate test machine
+seamless, the scripts integrate with `tools/remote.ps1`, which uses
+PowerShell remoting (WinRM) to deploy and execute.
+
+## One-time setup on the test machine
+
+Run this once on the test machine in an **elevated** PowerShell:
+
+```powershell
+.\tools\remote.ps1 -EnableRemoting
+```
+
+This is equivalent to `Enable-PSRemoting -Force -SkipNetworkProfileCheck`,
+plus a few WinRM tweaks (larger envelope, longer idle timeout) so that
+deployment and long test runs complete cleanly.
+
+If the dev box is not in the same domain as the test machine, the dev script
+will automatically add the test machine to the local WSMan TrustedHosts list
+on first use. This requires the dev-machine PowerShell to be elevated. If
+you cannot run elevated, do this manually once per test machine:
+
+```powershell
+Set-Item WSMan:\localhost\Client\TrustedHosts -Value '<TestMachineNameOrIp>' -Concatenate -Force
+```
+
+## Day-to-day workflow
+
+From the dev machine, after a normal `tools\build.ps1`:
+
+```powershell
+# Push tools + artifacts to the remote (one-time after each build):
+.\tools\remote.ps1 -Deploy -ComputerName test-vm-1
+
+# Run any test script as you would locally; it auto-forwards to the remote:
+.\tools\functional.ps1 -ComputerName test-vm-1
+.\tools\functional.ps1 -ComputerName test-vm-1 -TestCaseFilter "Name=GenericBinding"
+.\tools\spinxsk.ps1   -ComputerName test-vm-1 -Minutes 5
+```
+
+Output, verbose, warning, and error streams stream back to the dev console
+and `$LASTEXITCODE` is propagated.
+
+### Common options
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `-ComputerName` | (none) | Hostname / FQDN / IP of the test machine. When unset, the script runs locally as before. |
+| `-Credential` | current user | Optional `PSCredential`. |
+| `-RemoteRoot` | `C:\xdp` | Workspace root on the remote machine. |
+| `-SkipDeploy` | off | Skip the file deploy step (re-use whatever is already on the remote). Faster when iterating. |
+
+### Iterating quickly
+
+For script-only changes (no rebuild) you can deploy just the scripts:
+
+```powershell
+.\tools\remote.ps1 -Deploy -ComputerName test-vm-1 -SkipArtifacts
+```
+
+For test reruns where you know the remote already has the right binaries:
+
+```powershell
+.\tools\functional.ps1 -ComputerName test-vm-1 -SkipDeploy
+```
+
+### Running arbitrary scripts remotely
+
+`remote.ps1 -Invoke` runs any repo script on the remote and forwards
+output:
+
+```powershell
+.\tools\remote.ps1 -Invoke -ComputerName test-vm-1 `
+    -ScriptPath tools\functional.ps1 `
+    -ArgumentList @{ TestCaseFilter = 'Name=GenericBinding' }
+```
+
+## How it works
+
+`tools\remote.ps1`:
+
+* `-EnableRemoting` configures WinRM on the test machine.
+* `-Deploy` copies `tools\`, `src\xdp.props`, and the relevant
+  `artifacts\bin\<plat>_<cfg>\` plus dependency directories
+  (`corenet-ci-*`, `nuget`, `fn`, `Microsoft.TestPlatform`, `ebpfmsi`)
+  to the remote via `Copy-Item -ToSession`. The remote layout mirrors
+  the local repo layout so all existing scripts work unchanged.
+* `-Invoke` runs the requested script under `$RemoteRoot`. Streams flow
+  back to the dev console, and `$LASTEXITCODE` propagates.
+
+The forwarding from `functional.ps1` / `spinxsk.ps1` is implemented in
+`Invoke-XdpRemoteIfRequested` in `tools\common.ps1`; adding remote
+support to another script is a one-liner: declare `-ComputerName /
+-Credential / -RemoteRoot / -SkipDeploy` parameters and call
+`Invoke-XdpRemoteIfRequested` immediately after dot-sourcing
+`common.ps1`.

--- a/src/xdpruntime/xdp-setup.ps1
+++ b/src/xdpruntime/xdp-setup.ps1
@@ -26,7 +26,12 @@ param (
     [string]$Uninstall = "",
 
     [Parameter(Mandatory = $false)]
-    [string]$BinaryDirectory = ""
+    [string]$BinaryDirectory = "",
+
+    # When set, treat normally-fatal cleanup errors during -Uninstall as
+    # recoverable warnings.
+    [Parameter(Mandatory = $false)]
+    [switch]$Force = $false
 )
 
 Set-StrictMode -Version 'Latest'
@@ -216,7 +221,12 @@ if ($Uninstall -eq "xdpebpf") {
     Write-Verbose "$XdpBpfExport --clear"
     & $XdpBpfExport --clear
     if ($LastExitCode) {
-        Write-Error "$XdpBpfExport exit code: $LastExitCode"
+        if ($Force) {
+            Write-Warning "$XdpBpfExport --clear exit code: $LastExitCode (ignored due to -Force)"
+            $global:LASTEXITCODE = 0
+        } else {
+            Write-Error "$XdpBpfExport exit code: $LastExitCode"
+        }
     }
 
     Write-Verbose "reg.exe delete HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters /v XdpEbpfEnabled /f"

--- a/src/xdpruntime/xdp-setup.ps1
+++ b/src/xdpruntime/xdp-setup.ps1
@@ -219,7 +219,10 @@ if ($Install -eq "xdpebpf") {
 # Uninstalls the XDP eBPF feature.
 if ($Uninstall -eq "xdpebpf") {
     Write-Verbose "$XdpBpfExport --clear"
-    & $XdpBpfExport --clear
+    # Use cmd.exe to insulate from PowerShell 7+ converting native-command
+    # stderr into terminating errors (which would bypass the explicit
+    # -Force exit-code check below).
+    cmd.exe /c "`"$XdpBpfExport`" --clear 2>&1" | Write-Verbose
     if ($LastExitCode) {
         if ($Force) {
             Write-Warning "$XdpBpfExport --clear exit code: $LastExitCode (ignored due to -Force)"

--- a/tools/check-drivers.ps1
+++ b/tools/check-drivers.ps1
@@ -15,7 +15,19 @@ This checks for the presence of any XDP drivers currently loaded.
     [string]$Platform = "x64",
 
     [Parameter(Mandatory = $false)]
-    [switch]$IgnoreEbpf = $false
+    [switch]$IgnoreEbpf = $false,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ComputerName = "",
+
+    [Parameter(Mandatory = $false)]
+    [System.Management.Automation.PSCredential]$Credential,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RemoteRoot = "",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipDeploy
 )
 
 Set-StrictMode -Version 'Latest'
@@ -23,6 +35,12 @@ $ErrorActionPreference = 'Stop'
 
 # Important paths.
 $RootDir = Split-Path $PSScriptRoot -Parent
+. $RootDir\tools\common.ps1
+
+$Forwarded = Invoke-XdpRemoteIfRequested -InvocationCommand $MyInvocation.MyCommand `
+    -BoundParameters $PSBoundParameters -Config $Config -Platform $Platform -DeployArtifacts $false
+if ($Forwarded -is [array]) { $Forwarded = $Forwarded[-1] }
+if ($Forwarded) { return }
 
 # Cache driverquery output.
 $AllDrivers = driverquery /v /fo list

--- a/tools/check-drivers.ps1
+++ b/tools/check-drivers.ps1
@@ -143,6 +143,20 @@ function Check-And-Remove-Driver($Driver, $Component) {
         $script:AllDrivers = driverquery /v /fo list
     }
 
+    if ($Force) {
+        # Components installed via raw `sc.exe create` (fndis, xskfwdkm) leave
+        # behind a service registration after surprise reboots. The Check-Driver
+        # path only sees currently-loaded drivers.
+        $svc = Get-Service -Name $Component -ErrorAction SilentlyContinue
+        if ($svc) {
+            Write-Host "Removing residual $Component service registration..." -ForegroundColor Yellow
+            if ($svc.Status -ne 'Stopped') {
+                try { Stop-Service -Name $Component -Force -ErrorAction Stop } catch { }
+            }
+            sc.exe delete $Component | Write-Verbose
+        }
+    }
+
     if (Check-Driver $Driver) {
         $AllDrivers | Write-Verbose
         Write-Error "$Driver loaded!"

--- a/tools/check-drivers.ps1
+++ b/tools/check-drivers.ps1
@@ -17,6 +17,12 @@ This checks for the presence of any XDP drivers currently loaded.
     [Parameter(Mandatory = $false)]
     [switch]$IgnoreEbpf = $false,
 
+    # Pass -Force to the underlying setup.ps1 so that normally-fatal
+    # uninstall errors are treated as recoverable warnings. Use after a
+    # bugcheck has corrupted on-disk or registry state.
+    [Parameter(Mandatory = $false)]
+    [switch]$Force = $false,
+
     [Parameter(Mandatory = $false)]
     [string]$ComputerName = "",
 
@@ -38,9 +44,82 @@ $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
 
 $Forwarded = Invoke-XdpRemoteIfRequested -InvocationCommand $MyInvocation.MyCommand `
-    -BoundParameters $PSBoundParameters -Config $Config -Platform $Platform -DeployArtifacts $false
+    -BoundParameters $PSBoundParameters -Config $Config -Platform $Platform
 if ($Forwarded -is [array]) { $Forwarded = $Forwarded[-1] }
 if ($Forwarded) { return }
+
+# Detects files written to disk in the seconds before a bugcheck and left
+# truncated / NUL-filled. The XDP runtime layout under C:\xdpruntime is the
+# most common victim because tools\setup.ps1 expands a nupkg there during
+# install. If any of those files look corrupt, blow away the directory so a
+# subsequent install can recreate it cleanly.
+function Repair-CorruptedXdpRuntime {
+    $XdpRuntime = Get-XdpInstallPath
+
+    $needsReExtract = $false
+
+    if (-not (Test-Path $XdpRuntime)) {
+        # The runtime dir has been removed (possibly by a previous repair
+        # attempt) but xdp.sys is still loaded - we still need the
+        # nupkg-based uninstall script to drive teardown, so re-extract.
+        if (Get-Service xdp -ErrorAction SilentlyContinue) {
+            Write-Host "$XdpRuntime is missing but xdp service is still installed." -ForegroundColor Yellow
+            $needsReExtract = $true
+        } else {
+            return
+        }
+    } else {
+        $files = Get-ChildItem -Path $XdpRuntime -Recurse -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.Length -gt 0 -and $_.Length -lt 8MB }
+        foreach ($f in $files) {
+            try {
+                $bytes = [System.IO.File]::ReadAllBytes($f.FullName)
+            } catch { continue }
+            if ($bytes.Length -eq 0) { continue }
+            # A file that is entirely zero is unambiguous post-bugcheck damage.
+            $allZero = $true
+            for ($i = 0; $i -lt $bytes.Length; $i++) {
+                if ($bytes[$i] -ne 0) { $allZero = $false; break }
+            }
+            if ($allZero) {
+                Write-Host "Detected NUL-filled file from a prior bugcheck: $($f.FullName)" -ForegroundColor Yellow
+                $needsReExtract = $true
+                break
+            }
+        }
+    }
+
+    if (-not $needsReExtract) { return }
+
+    if (Test-Path $XdpRuntime) {
+        Write-Host "Removing $XdpRuntime so it can be re-extracted from the nupkg." -ForegroundColor Yellow
+        try {
+            Remove-Item $XdpRuntime -Recurse -Force -ErrorAction Stop
+        } catch {
+            Write-Warning "Could not remove $XdpRuntime`: $_"
+            return
+        }
+    }
+
+    # Re-extract the runtime nupkg so the regular uninstall path
+    # (which delegates to xdpruntime\xdp-setup.ps1) has a working
+    # script to invoke.
+    $ArtifactsBin = Get-ArtifactBinPath -Config $Config -Platform $Platform
+    $Nupkg = Get-ChildItem -Path "$ArtifactsBin\packages" `
+        -Filter "Microsoft.XDP-for-Windows.Runtime.$Platform.*.nupkg" `
+        -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $Nupkg) {
+        Write-Warning "No runtime nupkg found under $ArtifactsBin\packages; cannot re-extract."
+        return
+    }
+    Write-Host "Re-extracting $($Nupkg.Name) into $XdpRuntime ..." -ForegroundColor Yellow
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($Nupkg.FullName, $XdpRuntime)
+}
+
+if ($Force) {
+    Repair-CorruptedXdpRuntime
+}
 
 # Cache driverquery output.
 $AllDrivers = driverquery /v /fo list
@@ -58,10 +137,10 @@ function Check-Driver($Driver) {
 function Check-And-Remove-Driver($Driver, $Component) {
     if (Check-Driver $Driver) {
         Write-Host "Detected $Driver is loaded. Uninstalling $Component..."
-        & $RootDir\tools\setup.ps1 -Uninstall $Component -Config $Config -Platform $Platform
+        & $RootDir\tools\setup.ps1 -Uninstall $Component -Config $Config -Platform $Platform -Force:$Force
 
         # Update cached driverquery output.
-        $AllDrivers = driverquery /v /fo list
+        $script:AllDrivers = driverquery /v /fo list
     }
 
     if (Check-Driver $Driver) {

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -204,6 +204,100 @@ function Get-XdpBuildVersion {
     return $XdpBuildVersion;
 }
 
+# If -ComputerName was passed to a top-level script, forward execution to the
+# remote test machine via tools\remote.ps1 and exit. Returns $true when the
+# command was forwarded (caller should exit), $false otherwise.
+function Get-XdpDefaultRemoteRoot {
+    return 'C:\xdp'
+}
+
+function Invoke-XdpRemoteIfRequested {
+    [CmdletBinding()]
+    param (
+        # The MyInvocation.MyCommand of the caller; used to compute repo-relative path.
+        [Parameter(Mandatory = $true)] $InvocationCommand,
+        # The PSBoundParameters of the caller.
+        [Parameter(Mandatory = $true)] $BoundParameters,
+        # Build config/platform for the deploy step. Callers that have these
+        # parameters should pass them; otherwise the deploy assumes the
+        # default Debug/x64.
+        [string]$Config = 'Debug',
+        [string]$Platform = 'x64',
+        # Whether the caller's workflow needs the artifacts\bin tree on the
+        # remote. Scripts that only operate on machine state (e.g.
+        # prepare-machine.ps1, check-drivers.ps1) should pass $false to
+        # avoid pushing large binaries unnecessarily.
+        [bool]$DeployArtifacts = $true
+    )
+
+    $ComputerName = $null
+    if ($BoundParameters.ContainsKey('ComputerName')) {
+        $ComputerName = [string]$BoundParameters['ComputerName']
+    }
+    if ([string]::IsNullOrEmpty($ComputerName)) {
+        # Fall back to a session-scoped default set via
+        # Set-XdpRemoteDefault. Lets developers stop retyping
+        # -ComputerName on every command.
+        $defaultVar = Get-Variable -Name XdpRemoteDefault -Scope Global -ErrorAction SilentlyContinue
+        if ($defaultVar -and -not [string]::IsNullOrEmpty([string]$defaultVar.Value)) {
+            $ComputerName = [string]$defaultVar.Value
+            Write-Host "Using session-default remote computer: $ComputerName" -ForegroundColor DarkGray
+        }
+    }
+    if ([string]::IsNullOrEmpty($ComputerName)) {
+        return $false
+    }
+
+    $Credential = $null
+    if ($BoundParameters.ContainsKey('Credential')) { $Credential = $BoundParameters['Credential'] }
+    $RemoteRoot = Get-XdpDefaultRemoteRoot
+    if ($BoundParameters.ContainsKey('RemoteRoot') -and -not [string]::IsNullOrEmpty([string]$BoundParameters['RemoteRoot'])) {
+        $RemoteRoot = [string]$BoundParameters['RemoteRoot']
+    }
+    $SkipDeploy = $false
+    if ($BoundParameters.ContainsKey('SkipDeploy')) { $SkipDeploy = [bool]$BoundParameters['SkipDeploy'] }
+
+    # Strip parameters that are meaningful only on the dev machine before
+    # forwarding to the remote.
+    $remoteArgs = @{}
+    foreach ($key in @($BoundParameters.Keys)) {
+        if ($key -in @('ComputerName','Credential','RemoteRoot','SkipDeploy')) { continue }
+        $remoteArgs[$key] = $BoundParameters[$key]
+    }
+
+    $RootDir = Split-Path $PSScriptRoot -Parent
+    $RemoteScript = $InvocationCommand.Path
+    if ([string]::IsNullOrEmpty($RemoteScript)) {
+        Write-Error "Unable to determine caller script path for remote forwarding."
+    }
+    $RelScript = $RemoteScript.Substring($RootDir.Length).TrimStart('\','/')
+
+    $RemoteScriptPs1 = "$RootDir\tools\remote.ps1"
+
+    if (-not $SkipDeploy) {
+        $deployArgs = @{
+            ComputerName = $ComputerName
+            RemoteRoot   = $RemoteRoot
+            Config       = $Config
+            Platform     = $Platform
+        }
+        if (-not $DeployArtifacts) { $deployArgs.SkipArtifacts = $true }
+        if ($Credential) { $deployArgs.Credential = $Credential }
+        & $RemoteScriptPs1 -Deploy @deployArgs
+    }
+
+    $invokeArgs = @{
+        ComputerName = $ComputerName
+        RemoteRoot   = $RemoteRoot
+        ScriptPath   = $RelScript
+        ArgumentList = $remoteArgs
+    }
+    if ($Credential) { $invokeArgs.Credential = $Credential }
+    & $RemoteScriptPs1 -Invoke @invokeArgs
+
+    return $true
+}
+
 function Get-XdpBuildVersionString {
     $XdpVersion = Get-XdpBuildVersion
     $VersionString = "$($XdpVersion.Major).$($XdpVersion.Minor).$($XdpVersion.Patch)"

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -218,16 +218,14 @@ function Invoke-XdpRemoteIfRequested {
         [Parameter(Mandatory = $true)] $InvocationCommand,
         # The PSBoundParameters of the caller.
         [Parameter(Mandatory = $true)] $BoundParameters,
-        # Build config/platform for the deploy step. Callers that have these
-        # parameters should pass them; otherwise the deploy assumes the
-        # default Debug/x64.
-        [string]$Config = 'Debug',
-        [string]$Platform = 'x64',
         # Whether the caller's workflow needs the artifacts\bin tree on the
         # remote. Scripts that only operate on machine state (e.g.
         # prepare-machine.ps1, check-drivers.ps1) should pass $false to
         # avoid pushing large binaries unnecessarily.
-        [bool]$DeployArtifacts = $true
+        [bool]$DeployArtifacts = $true,
+        # Build config/platform for the deploy step.
+        [string]$Config = '',
+        [string]$Platform = ''
     )
 
     $ComputerName = $null

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -276,9 +276,9 @@ function Invoke-XdpRemoteIfRequested {
         $deployArgs = @{
             ComputerName = $ComputerName
             RemoteRoot   = $RemoteRoot
-            Config       = $Config
-            Platform     = $Platform
         }
+        if (-not [string]::IsNullOrEmpty($Config))   { $deployArgs.Config   = $Config }
+        if (-not [string]::IsNullOrEmpty($Platform)) { $deployArgs.Platform = $Platform }
         if (-not $DeployArtifacts) { $deployArgs.SkipArtifacts = $true }
         if ($Credential) { $deployArgs.Credential = $Credential }
         & $RemoteScriptPs1 -Deploy @deployArgs

--- a/tools/functional.ps1
+++ b/tools/functional.ps1
@@ -48,7 +48,22 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("INF", "NuGet")]
-    [string]$XdpInstaller = "NuGet"
+    [string]$XdpInstaller = "NuGet",
+
+    # Remote execution: when set, deploy + run this script on the named test
+    # machine over PowerShell remoting. See tools\remote.ps1 for setup.
+    [Parameter(Mandatory = $false)]
+    [string]$ComputerName = "",
+
+    [Parameter(Mandatory = $false)]
+    [System.Management.Automation.PSCredential]$Credential,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RemoteRoot = "",
+
+    # Skip the file deployment step (assume a previous -Deploy is current).
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipDeploy
 )
 
 Set-StrictMode -Version 'Latest'
@@ -57,6 +72,11 @@ $ErrorActionPreference = 'Stop'
 # Important paths.
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
+
+$Forwarded = Invoke-XdpRemoteIfRequested -InvocationCommand $MyInvocation.MyCommand `
+    -BoundParameters $PSBoundParameters -Config $Config -Platform $Platform
+if ($Forwarded -is [array]) { $Forwarded = $Forwarded[-1] }
+if ($Forwarded) { return }
 $ArtifactsDir = Get-ArtifactBinPath -Config $Config -Platform $Platform
 $LogsDir = "$RootDir\artifacts\logs"
 $IterationFailureCount = 0

--- a/tools/pktfuzz.ps1
+++ b/tools/pktfuzz.ps1
@@ -11,7 +11,19 @@ param (
     [int]$Minutes = 0,
 
     [Parameter(Mandatory = $false)]
-    [int]$Workers = 1
+    [int]$Workers = 1,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ComputerName = "",
+
+    [Parameter(Mandatory = $false)]
+    [System.Management.Automation.PSCredential]$Credential,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RemoteRoot = "",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipDeploy
 )
 
 Set-StrictMode -Version 'Latest'
@@ -20,6 +32,11 @@ $ErrorActionPreference = 'Stop'
 # Important paths.
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
+
+$Forwarded = Invoke-XdpRemoteIfRequested -InvocationCommand $MyInvocation.MyCommand `
+    -BoundParameters $PSBoundParameters -Config $Config -Platform $Platform
+if ($Forwarded -is [array]) { $Forwarded = $Forwarded[-1] }
+if ($Forwarded) { return }
 $ArtifactsDir = Get-ArtifactBinPath -Config $Config -Platform $Platform
 $LogsDir = "$RootDir\artifacts\logs"
 

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -73,7 +73,21 @@ param (
     [switch]$Force = $false,
 
     [Parameter(Mandatory = $false)]
-    [switch]$Cleanup = $false
+    [switch]$Cleanup = $false,
+
+    # Remote execution: when set, deploy + run this script on the named test
+    # machine over PowerShell remoting. See tools\remote.ps1 for setup.
+    [Parameter(Mandatory = $false)]
+    [string]$ComputerName = "",
+
+    [Parameter(Mandatory = $false)]
+    [System.Management.Automation.PSCredential]$Credential,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RemoteRoot = "",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipDeploy
 )
 
 Set-StrictMode -Version 'Latest'
@@ -81,6 +95,16 @@ $ErrorActionPreference = 'Stop'
 
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
+
+# Build-related setup is for the dev machine only; never forward those
+# scenarios to a remote test machine. Test/runtime setup scenarios honor
+# -ComputerName as usual.
+if (-not $ForBuild -and -not $ForEbpfBuild) {
+    $Forwarded = Invoke-XdpRemoteIfRequested -InvocationCommand $MyInvocation.MyCommand `
+        -BoundParameters $PSBoundParameters -Platform $Platform -DeployArtifacts $false
+    if ($Forwarded -is [array]) { $Forwarded = $Forwarded[-1] }
+    if ($Forwarded) { return }
+}
 
 $ArtifactsDir = "$RootDir\artifacts"
 $NugetDir = "$ArtifactsDir/nuget"

--- a/tools/remote-set-default.ps1
+++ b/tools/remote-set-default.ps1
@@ -13,7 +13,7 @@ Clear the session default and any cached credentials.
 
 .EXAMPLE
 # Set default; subsequent commands auto-route to this machine:
-.\tools\remote-set-default.ps1 mifriese-ws2022
+.\tools\remote-set-default.ps1 mytesthost
 .\tools\functional.ps1 -ListTestCases
 
 .EXAMPLE

--- a/tools/remote-set-default.ps1
+++ b/tools/remote-set-default.ps1
@@ -1,0 +1,45 @@
+<#
+
+.SYNOPSIS
+Set or clear a default remote test machine for the current PowerShell
+session, so that subsequent XDP test scripts (functional.ps1,
+spinxsk.ps1, ...) don't need a -ComputerName argument.
+
+.PARAMETER ComputerName
+The remote test machine. Use '' or omit to clear.
+
+.PARAMETER Clear
+Clear the session default and any cached credentials.
+
+.EXAMPLE
+# Set default; subsequent commands auto-route to this machine:
+.\tools\remote-set-default.ps1 mifriese-ws2022
+.\tools\functional.ps1 -ListTestCases
+
+.EXAMPLE
+# Clear the default and any cached credentials:
+.\tools\remote-set-default.ps1 -Clear
+
+#>
+
+param (
+    [Parameter(Position = 0)]
+    [string]$ComputerName,
+
+    [Parameter()]
+    [switch]$Clear
+)
+
+Set-StrictMode -Version 'Latest'
+$ErrorActionPreference = 'Stop'
+
+if ($Clear -or [string]::IsNullOrWhiteSpace($ComputerName)) {
+    Remove-Variable -Name XdpRemoteDefault -Scope Global -ErrorAction SilentlyContinue
+    Remove-Variable -Name XdpRemoteCredentialCache -Scope Global -ErrorAction SilentlyContinue
+    Write-Host "Cleared session default remote computer and cached credentials." -ForegroundColor Green
+    return
+}
+
+Set-Variable -Name XdpRemoteDefault -Scope Global -Value $ComputerName
+Write-Host "Default remote computer for this session: $ComputerName" -ForegroundColor Green
+Write-Host "Subsequent .\tools\*.ps1 invocations will run against this machine."

--- a/tools/remote.ps1
+++ b/tools/remote.ps1
@@ -411,24 +411,31 @@ function Invoke-XdpRemote {
         # side merges all streams (*>&1) and converts them to plain strings
         # via Out-String -Stream so deserialized error/warning records
         # don't get re-emitted as red errors locally. Piping
-        # Invoke-Command's output directly into Write-Host (instead of
-        # capturing into a variable) preserves the live streaming behavior
-        # PowerShell remoting provides natively.
+        # Invoke-Command's output directly into Write-Host preserves the
+        # live streaming behavior PowerShell remoting provides natively.
+        # The exit code is emitted as a final sentinel line so we don't
+        # need a follow-up call against a runspace that may have already
+        # torn down.
+        $exitCode = 0
+        $sentinel = '##XDP-REMOTE-EXIT##'
         Invoke-Command -Session $session -ScriptBlock {
-            param($Root, $Rel, $ScriptArgs)
+            param($Root, $Rel, $ScriptArgs, $Sentinel)
             Set-Location $Root
             & (Join-Path $Root $Rel) @ScriptArgs *>&1 | Out-String -Stream
-        } -ArgumentList $RemoteRoot, $ScriptPath, $ArgumentList | ForEach-Object {
-            Write-Host $_
+            "$Sentinel $LASTEXITCODE"
+        } -ArgumentList $RemoteRoot, $ScriptPath, $ArgumentList, $sentinel | ForEach-Object {
+            if ($_ -is [string] -and $_.StartsWith($sentinel)) {
+                $val = $_.Substring($sentinel.Length).Trim()
+                if (-not [string]::IsNullOrEmpty($val)) {
+                    [int]::TryParse($val, [ref]$exitCode) | Out-Null
+                }
+            } else {
+                Write-Host $_
+            }
         }
 
-        # Fetch the remote $LASTEXITCODE in a follow-up call so streaming
-        # of the main output isn't blocked waiting for it.
-        $exitCode = Invoke-Command -Session $session -ScriptBlock { $LASTEXITCODE }
-        if ($null -eq $exitCode) { $exitCode = 0 }
-
         if ($exitCode -ne 0) {
-            $global:LASTEXITCODE = [int]$exitCode
+            $global:LASTEXITCODE = $exitCode
             Write-Error "Remote script exited with code $exitCode"
         }
     } finally {

--- a/tools/remote.ps1
+++ b/tools/remote.ps1
@@ -420,9 +420,18 @@ function Invoke-XdpRemote {
         $sentinel = '##XDP-REMOTE-EXIT##'
         Invoke-Command -Session $session -ScriptBlock {
             param($Root, $Rel, $ScriptArgs, $Sentinel)
+            $ErrorActionPreference = 'Continue'
             Set-Location $Root
-            & (Join-Path $Root $Rel) @ScriptArgs *>&1 | Out-String -Stream
-            "$Sentinel $LASTEXITCODE"
+            try {
+                & (Join-Path $Root $Rel) @ScriptArgs *>&1 | Out-String -Stream
+                $code = $LASTEXITCODE
+            } catch {
+                # Surface the error as text so it streams cleanly, then
+                # mark a non-zero exit code.
+                ($_ | Out-String).TrimEnd()
+                $code = 1
+            }
+            "$Sentinel $code"
         } -ArgumentList $RemoteRoot, $ScriptPath, $ArgumentList, $sentinel | ForEach-Object {
             if ($_ -is [string] -and $_.StartsWith($sentinel)) {
                 $val = $_.Substring($sentinel.Length).Trim()

--- a/tools/remote.ps1
+++ b/tools/remote.ps1
@@ -407,29 +407,28 @@ function Invoke-XdpRemote {
     try {
         Write-Host "Running $ScriptPath on $ComputerName ..." -ForegroundColor Cyan
 
-        # Convert every remote stream (output, error, warning, verbose,
-        # information) to plain text on the remote side. Returning strings
-        # avoids having deserialized ErrorRecord/WarningRecord objects
-        # re-rendered in red on the local console, while preserving line
-        # breaks. The trailing PSCustomObject carries the exit code.
-        $results = Invoke-Command -Session $session -ScriptBlock {
+        # Stream remote output to the local host as it arrives. The remote
+        # side merges all streams (*>&1) and converts them to plain strings
+        # via Out-String -Stream so deserialized error/warning records
+        # don't get re-emitted as red errors locally. Piping
+        # Invoke-Command's output directly into Write-Host (instead of
+        # capturing into a variable) preserves the live streaming behavior
+        # PowerShell remoting provides natively.
+        Invoke-Command -Session $session -ScriptBlock {
             param($Root, $Rel, $ScriptArgs)
             Set-Location $Root
             & (Join-Path $Root $Rel) @ScriptArgs *>&1 | Out-String -Stream
-            [pscustomobject]@{ XdpRemoteExitCode = $LASTEXITCODE }
-        } -ArgumentList $RemoteRoot, $ScriptPath, $ArgumentList
-
-        $exitCode = 0
-        foreach ($item in $results) {
-            if ($item -is [string]) {
-                Write-Host $item
-            } elseif ($item.PSObject.Properties.Match('XdpRemoteExitCode').Count) {
-                if ($null -ne $item.XdpRemoteExitCode) { $exitCode = [int]$item.XdpRemoteExitCode }
-            }
+        } -ArgumentList $RemoteRoot, $ScriptPath, $ArgumentList | ForEach-Object {
+            Write-Host $_
         }
 
+        # Fetch the remote $LASTEXITCODE in a follow-up call so streaming
+        # of the main output isn't blocked waiting for it.
+        $exitCode = Invoke-Command -Session $session -ScriptBlock { $LASTEXITCODE }
+        if ($null -eq $exitCode) { $exitCode = 0 }
+
         if ($exitCode -ne 0) {
-            $global:LASTEXITCODE = $exitCode
+            $global:LASTEXITCODE = [int]$exitCode
             Write-Error "Remote script exited with code $exitCode"
         }
     } finally {

--- a/tools/remote.ps1
+++ b/tools/remote.ps1
@@ -1,0 +1,456 @@
+<#
+
+.SYNOPSIS
+Helpers for running the XDP test scripts on a remote test machine over
+PowerShell remoting (WinRM).
+
+.DESCRIPTION
+This script provides three modes that together make running the existing
+XDP test scripts (functional.ps1, spinxsk.ps1, ...) against a remote test
+machine seamless:
+
+  -EnableRemoting   Run ON THE TEST MACHINE (admin) to enable WinRM. This
+                    is a one-time setup. Equivalent to running:
+                        Enable-PSRemoting -Force -SkipNetworkProfileCheck
+
+  -Deploy           Run from the dev machine to copy the local 'tools' and
+                    relevant 'artifacts' folders to the remote machine.
+                    Uses a single compressed archive over the WinRM session
+                    so transfer is fast. Re-running is safe and only
+                    overwrites files.
+
+  -Invoke           Run from the dev machine to execute one of the XDP
+                    PowerShell scripts on the remote machine. Output,
+                    verbose, warning, and error streams are forwarded back.
+
+This script is also dot-source friendly: helper functions
+(Connect-XdpRemote, Deploy-XdpRemote, Invoke-XdpRemote) are exported so
+other scripts (e.g. functional.ps1) can integrate the -ComputerName
+workflow directly.
+
+.PARAMETER ComputerName
+The remote test machine. Accepts hostname, FQDN, or IP. When using an IP
+or non-domain hostname, ensure the client's TrustedHosts list includes it
+or supply an explicit -Credential authenticated via Kerberos.
+
+.PARAMETER Credential
+Optional PSCredential for authenticating to the remote machine.
+
+.PARAMETER RemoteRoot
+Destination directory on the remote machine. Defaults to C:\xdp.
+The XDP scripts on the remote will run with this directory as their
+workspace root, mirroring the local layout (tools\, artifacts\, src\).
+
+.PARAMETER ScriptPath
+For -Invoke: path (relative to repo root) of the script to run on the
+remote, e.g. 'tools\functional.ps1'.
+
+.PARAMETER ArgumentList
+For -Invoke: hashtable of parameters splatted to the remote script.
+
+.PARAMETER SkipArtifacts
+For -Deploy: only copy tools\ and src\xdp.props, skip the (large)
+artifacts\bin\... payload. Useful for iterating on scripts only.
+
+.EXAMPLE
+# One-time, on the test machine (elevated PowerShell):
+.\tools\remote.ps1 -EnableRemoting
+
+.EXAMPLE
+# From the dev box:
+.\tools\remote.ps1 -Deploy -ComputerName test-vm-1
+.\tools\functional.ps1 -ComputerName test-vm-1
+
+.EXAMPLE
+# Run a one-off remote command:
+.\tools\remote.ps1 -Invoke -ComputerName test-vm-1 -ScriptPath tools\functional.ps1 `
+    -ArgumentList @{ TestCaseFilter = 'Name=GenericBinding' }
+
+#>
+
+[CmdletBinding(DefaultParameterSetName = 'None')]
+param (
+    [Parameter(Mandatory = $true, ParameterSetName = 'EnableRemoting')]
+    [switch]$EnableRemoting,
+
+    [Parameter(Mandatory = $true, ParameterSetName = 'Deploy')]
+    [switch]$Deploy,
+
+    [Parameter(Mandatory = $true, ParameterSetName = 'Invoke')]
+    [switch]$Invoke,
+
+    [Parameter(Mandatory = $true, ParameterSetName = 'Deploy')]
+    [Parameter(Mandatory = $true, ParameterSetName = 'Invoke')]
+    [string]$ComputerName,
+
+    [Parameter(ParameterSetName = 'Deploy')]
+    [Parameter(ParameterSetName = 'Invoke')]
+    [System.Management.Automation.PSCredential]$Credential,
+
+    [Parameter(ParameterSetName = 'Deploy')]
+    [Parameter(ParameterSetName = 'Invoke')]
+    [string]$RemoteRoot = '',
+
+    [Parameter(ParameterSetName = 'Deploy')]
+    [ValidateSet('Debug', 'Release')]
+    [string]$Config = 'Debug',
+
+    [Parameter(ParameterSetName = 'Deploy')]
+    [ValidateSet('x64', 'arm64')]
+    [string]$Platform = 'x64',
+
+    [Parameter(ParameterSetName = 'Deploy')]
+    [switch]$SkipArtifacts,
+
+    [Parameter(Mandatory = $true, ParameterSetName = 'Invoke')]
+    [string]$ScriptPath,
+
+    [Parameter(ParameterSetName = 'Invoke')]
+    [hashtable]$ArgumentList = @{}
+)
+
+Set-StrictMode -Version 'Latest'
+$ErrorActionPreference = 'Stop'
+
+$RootDir = Split-Path $PSScriptRoot -Parent
+. $RootDir\tools\common.ps1
+
+function Enable-XdpRemoting {
+    if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+            [Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        Write-Error "Run this from an elevated PowerShell on the TEST machine."
+    }
+
+    Write-Host "Enabling PowerShell remoting (WinRM) ..."
+    Enable-PSRemoting -Force -SkipNetworkProfileCheck | Out-Null
+
+    # Allow long-running test invocations and large payload pushes.
+    Write-Host "Tuning WinRM limits for large file transfer and long tests ..."
+    Set-Item WSMan:\localhost\MaxEnvelopeSizekb 8192 -Force
+    Set-Item WSMan:\localhost\Shell\MaxMemoryPerShellMB 4096 -Force
+    Set-Item WSMan:\localhost\Shell\IdleTimeout 7200000 -Force
+    Set-Item WSMan:\localhost\Service\Auth\Negotiate $true -Force
+
+    $hostName = [System.Net.Dns]::GetHostName()
+    Write-Host ""
+    Write-Host "Test machine is ready for remoting." -ForegroundColor Green
+    Write-Host "From the dev machine, just run e.g. '.\tools\functional.ps1 -ComputerName $hostName'."
+    Write-Host "For workgroup or IP-based connections, the dev script will automatically"
+    Write-Host "add the test machine to WSMan TrustedHosts on first use (elevation required)."
+}
+
+# Ensure $ComputerName is in the local WSMan TrustedHosts list when needed.
+# Domain-joined Kerberos targets do not require this; for workgroup / IP
+# targets WinRM rejects the connection until the host is trusted. We add it
+# automatically so the dev-side commands are copy/paste friendly.
+function Add-XdpTrustedHostIfNeeded {
+    param ([Parameter(Mandatory = $true)] [string]$ComputerName)
+
+    function script:Test-XdpTrustedHost {
+        param ([string]$Name)
+        try {
+            $value = (Get-Item WSMan:\localhost\Client\TrustedHosts -ErrorAction Stop).Value
+        } catch {
+            return $false
+        }
+        if ([string]::IsNullOrWhiteSpace($value)) { return $false }
+        $entries = $value.Split(',') | ForEach-Object { $_.Trim() }
+        return ($entries -contains '*' -or $entries -contains $Name)
+    }
+
+    if (Test-XdpTrustedHost -Name $ComputerName) { return }
+
+    if (Test-Admin) {
+        Write-Host "Adding '$ComputerName' to WSMan TrustedHosts ..." -ForegroundColor Yellow
+        Set-Item WSMan:\localhost\Client\TrustedHosts -Value $ComputerName -Concatenate -Force
+        return
+    }
+
+    Write-Host "Adding '$ComputerName' to WSMan TrustedHosts (requires elevation) ..." -ForegroundColor Yellow
+
+    # The elevated child writes its diagnostics to a log file, since
+    # -RedirectStandardError is not allowed with -Verb RunAs.
+    $tmpDir   = [System.IO.Path]::GetTempPath()
+    $stamp    = [guid]::NewGuid().ToString('N')
+    $logPath  = Join-Path $tmpDir ("xdp-trustedhosts-$stamp.log")
+    $scriptPath = Join-Path $tmpDir ("xdp-trustedhosts-$stamp.ps1")
+
+    $scriptBody = @"
+`$ErrorActionPreference = 'Stop'
+Start-Transcript -Path '$logPath' -Force | Out-Null
+try {
+    Start-Service WinRM -ErrorAction SilentlyContinue
+    `$existing = ''
+    try { `$existing = (Get-Item WSMan:\localhost\Client\TrustedHosts -ErrorAction Stop).Value } catch {}
+    `$entries = @()
+    if (-not [string]::IsNullOrWhiteSpace(`$existing)) {
+        `$entries = `$existing.Split(',') | ForEach-Object { `$_.Trim() } | Where-Object { `$_ }
+    }
+    if (`$entries -notcontains '*' -and `$entries -notcontains '$ComputerName') {
+        `$entries += '$ComputerName'
+        `$new = (`$entries -join ',')
+        try {
+            Set-Item WSMan:\localhost\Client\TrustedHosts -Value `$new -Force
+        } catch {
+            Write-Output "Set-Item failed: `$_"
+            cmd.exe /c "winrm set winrm/config/client `@`{TrustedHosts=`"`$new`"`}"
+        }
+    }
+    Stop-Transcript | Out-Null
+    exit 0
+} catch {
+    Write-Output `$_
+    Stop-Transcript | Out-Null
+    exit 1
+}
+"@
+    Set-Content -Path $scriptPath -Value $scriptBody -Encoding UTF8
+
+    try {
+        $proc = Start-Process -FilePath 'powershell.exe' `
+            -ArgumentList @('-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', $scriptPath) `
+            -Verb RunAs -Wait -PassThru -ErrorAction Stop
+        if ($proc.ExitCode -ne 0) {
+            Write-Warning "Elevated TrustedHosts update exited with code $($proc.ExitCode)."
+            if (Test-Path $logPath) {
+                $logText = (Get-Content -Raw $logPath).Trim()
+                if ($logText) { Write-Warning $logText }
+            }
+        }
+    } catch {
+        Write-Warning "Could not auto-elevate to update TrustedHosts: $_"
+    } finally {
+        Remove-Item $logPath, $scriptPath -Force -ErrorAction SilentlyContinue
+    }
+
+    if (-not (Test-XdpTrustedHost -Name $ComputerName)) {
+        Write-Error @"
+WSMan TrustedHosts still does not include '$ComputerName'. WinRM will reject
+the connection. Run once from an elevated PowerShell on this dev machine:
+
+    Set-Item WSMan:\localhost\Client\TrustedHosts -Value '$ComputerName' -Concatenate -Force
+
+Then retry your command.
+"@
+    }
+}
+
+function Connect-XdpRemote {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)] [string]$ComputerName,
+        [System.Management.Automation.PSCredential]$Credential
+    )
+
+    Add-XdpTrustedHostIfNeeded -ComputerName $ComputerName
+
+    # Cache credentials per target host in the user's PowerShell session so
+    # subsequent commands don't prompt repeatedly. The cache lives on the
+    # global scope so it survives across script invocations within the same
+    # process.
+    $cacheVar = Get-Variable -Name XdpRemoteCredentialCache -Scope Global -ErrorAction SilentlyContinue
+    if ($cacheVar) {
+        $cache = $cacheVar.Value
+    } else {
+        $cache = @{}
+        Set-Variable -Name XdpRemoteCredentialCache -Scope Global -Value $cache
+    }
+    if (-not $Credential -and $cache.ContainsKey($ComputerName)) {
+        $Credential = $cache[$ComputerName]
+    }
+
+    $attempts = 0
+    while ($true) {
+        $attempts++
+        $sessionParams = @{ ComputerName = $ComputerName; ErrorAction = 'Stop' }
+        if ($Credential) { $sessionParams.Credential = $Credential }
+
+        try {
+            Write-Verbose "Opening PSSession to $ComputerName ..."
+            $session = New-PSSession @sessionParams
+            if ($Credential) {
+                $cache[$ComputerName] = $Credential
+            }
+            return $session
+        } catch {
+            $msg = "$_"
+            $isAuth = $msg -match 'Access is denied' -or $msg -match 'authentication' -or
+                      $msg -match 'logon failure' -or $msg -match 'user name or password'
+            if (-not $isAuth -or $attempts -ge 2) {
+                throw
+            }
+            Write-Host "Authentication required for $ComputerName." -ForegroundColor Yellow
+            $defaultUser = "$ComputerName\Administrator"
+            $userName = Read-Host "Username [$defaultUser]"
+            if ([string]::IsNullOrWhiteSpace($userName)) { $userName = $defaultUser }
+            $password = Read-Host "Password for $userName" -AsSecureString
+            if (-not $password -or $password.Length -eq 0) {
+                throw
+            }
+            $Credential = New-Object System.Management.Automation.PSCredential($userName, $password)
+        }
+    }
+}
+
+function Get-XdpDeployManifest {
+    param (
+        [Parameter(Mandatory = $true)] [string]$Config,
+        [Parameter(Mandatory = $true)] [string]$Platform,
+        [switch]$SkipArtifacts
+    )
+
+    $items = @(
+        @{ Path = "tools";         Required = $true }
+    )
+
+    if (-not $SkipArtifacts) {
+        $items += @{
+            Path     = (Get-ArtifactBinPathBase -Config $Config -Platform $Platform)
+            Required = $true
+        }
+    }
+
+    return $items
+}
+
+function Deploy-XdpRemote {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)] [string]$ComputerName,
+        [System.Management.Automation.PSCredential]$Credential,
+        [string]$RemoteRoot,
+        [Parameter(Mandatory = $true)] [string]$Config,
+        [Parameter(Mandatory = $true)] [string]$Platform,
+        [switch]$SkipArtifacts
+    )
+
+    if ([string]::IsNullOrEmpty($RemoteRoot)) { $RemoteRoot = Get-XdpDefaultRemoteRoot }
+
+    $manifest = Get-XdpDeployManifest -Config $Config -Platform $Platform -SkipArtifacts:$SkipArtifacts
+
+    $session = Connect-XdpRemote -ComputerName $ComputerName -Credential $Credential
+    try {
+        Invoke-Command -Session $session -ScriptBlock {
+            param($Root)
+            if (-not (Test-Path $Root)) { New-Item -ItemType Directory -Path $Root -Force | Out-Null }
+        } -ArgumentList $RemoteRoot
+
+        # Clean the remote artifacts\bin\<plat>_<cfg>\ directory before
+        # copying. Stale files (e.g. from a prior build of a different
+        # configuration) cause Copy-Item conflicts and confusing test errors.
+        if (-not $SkipArtifacts) {
+            $remoteBin = Join-Path $RemoteRoot (Get-ArtifactBinPathBase -Config $Config -Platform $Platform)
+            Write-Host "Cleaning $ComputerName`:$remoteBin ..."
+            Invoke-Command -Session $session -ScriptBlock {
+                param($Path)
+                if (Test-Path $Path) { Remove-Item $Path -Recurse -Force -ErrorAction Stop }
+            } -ArgumentList $remoteBin
+        }
+
+        Write-Host "Copying files to $ComputerName`:$RemoteRoot ..."
+        foreach ($item in $manifest) {
+            $sources = @(Get-Item -Path (Join-Path $RootDir $item.Path) -ErrorAction SilentlyContinue)
+            if ($sources.Count -eq 0) {
+                if ($item.Required) {
+                    Write-Error "Required path not found: $($item.Path). Did you build $Config\$Platform?"
+                }
+                continue
+            }
+            foreach ($src in $sources) {
+                $relative = $src.FullName.Substring($RootDir.Length).TrimStart('\','/')
+                $dest = Join-Path $RemoteRoot $relative
+                $destParent = Split-Path $dest -Parent
+
+                Invoke-Command -Session $session -ScriptBlock {
+                    param($Parent, $Target, $IsContainer)
+                    if (-not (Test-Path $Parent)) { New-Item -ItemType Directory -Path $Parent -Force | Out-Null }
+                    if ($IsContainer -and (Test-Path $Target)) { Remove-Item $Target -Recurse -Force }
+                } -ArgumentList $destParent, $dest, $src.PSIsContainer
+
+                Write-Host "  -> $relative"
+                if ($src.PSIsContainer) {
+                    Copy-Item -ToSession $session -Path $src.FullName -Destination $dest -Recurse -Force
+                } else {
+                    Copy-Item -ToSession $session -Path $src.FullName -Destination $dest -Force
+                }
+            }
+        }
+
+        Write-Host "Deployment complete: $ComputerName -> $RemoteRoot" -ForegroundColor Green
+    } finally {
+        Remove-PSSession $session
+    }
+}
+
+function Invoke-XdpRemote {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)] [string]$ComputerName,
+        [System.Management.Automation.PSCredential]$Credential,
+        [string]$RemoteRoot,
+        [Parameter(Mandatory = $true)] [string]$ScriptPath,
+        [hashtable]$ArgumentList = @{}
+    )
+
+    if ([string]::IsNullOrEmpty($RemoteRoot)) { $RemoteRoot = Get-XdpDefaultRemoteRoot }
+
+    # Normalize: accept absolute paths under $RootDir or repo-relative paths.
+    if ([System.IO.Path]::IsPathRooted($ScriptPath)) {
+        if (-not $ScriptPath.StartsWith($RootDir, [System.StringComparison]::OrdinalIgnoreCase)) {
+            Write-Error "ScriptPath '$ScriptPath' is not under the repo root '$RootDir'."
+        }
+        $ScriptPath = $ScriptPath.Substring($RootDir.Length).TrimStart('\','/')
+    }
+    $ScriptPath = $ScriptPath -replace '/', '\'
+
+    $session = Connect-XdpRemote -ComputerName $ComputerName -Credential $Credential
+    try {
+        Write-Host "Running $ScriptPath on $ComputerName ..." -ForegroundColor Cyan
+
+        # Convert every remote stream (output, error, warning, verbose,
+        # information) to plain text on the remote side. Returning strings
+        # avoids having deserialized ErrorRecord/WarningRecord objects
+        # re-rendered in red on the local console, while preserving line
+        # breaks. The trailing PSCustomObject carries the exit code.
+        $results = Invoke-Command -Session $session -ScriptBlock {
+            param($Root, $Rel, $ScriptArgs)
+            Set-Location $Root
+            & (Join-Path $Root $Rel) @ScriptArgs *>&1 | Out-String -Stream
+            [pscustomobject]@{ XdpRemoteExitCode = $LASTEXITCODE }
+        } -ArgumentList $RemoteRoot, $ScriptPath, $ArgumentList
+
+        $exitCode = 0
+        foreach ($item in $results) {
+            if ($item -is [string]) {
+                Write-Host $item
+            } elseif ($item.PSObject.Properties.Match('XdpRemoteExitCode').Count) {
+                if ($null -ne $item.XdpRemoteExitCode) { $exitCode = [int]$item.XdpRemoteExitCode }
+            }
+        }
+
+        if ($exitCode -ne 0) {
+            $global:LASTEXITCODE = $exitCode
+            Write-Error "Remote script exited with code $exitCode"
+        }
+    } finally {
+        Remove-PSSession $session
+    }
+}
+
+# When this script is dot-sourced (no parameter set selected), just expose
+# the helper functions and return.
+if ($PSCmdlet.ParameterSetName -eq 'None') {
+    return
+}
+
+switch ($PSCmdlet.ParameterSetName) {
+    'EnableRemoting' { Enable-XdpRemoting }
+    'Deploy'         {
+        Deploy-XdpRemote -ComputerName $ComputerName -Credential $Credential `
+            -RemoteRoot $RemoteRoot -Config $Config -Platform $Platform -SkipArtifacts:$SkipArtifacts
+    }
+    'Invoke'         {
+        Invoke-XdpRemote -ComputerName $ComputerName -Credential $Credential `
+            -RemoteRoot $RemoteRoot -ScriptPath $ScriptPath -ArgumentList $ArgumentList
+    }
+}

--- a/tools/ringperf.ps1
+++ b/tools/ringperf.ps1
@@ -5,7 +5,19 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("x64", "arm64")]
-    [string]$Platform = "x64"
+    [string]$Platform = "x64",
+
+    [Parameter(Mandatory = $false)]
+    [string]$ComputerName = "",
+
+    [Parameter(Mandatory = $false)]
+    [System.Management.Automation.PSCredential]$Credential,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RemoteRoot = "",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipDeploy
 )
 
 Set-StrictMode -Version 'Latest'
@@ -14,6 +26,11 @@ $ErrorActionPreference = 'Stop'
 # Important paths.
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
+
+$Forwarded = Invoke-XdpRemoteIfRequested -InvocationCommand $MyInvocation.MyCommand `
+    -BoundParameters $PSBoundParameters -Config $Config -Platform $Platform
+if ($Forwarded -is [array]) { $Forwarded = $Forwarded[-1] }
+if ($Forwarded) { return }
 $ArtifactsDir = Get-ArtifactBinPath -Config $Config -Platform $Platform
 
 $Time = Measure-Command {

--- a/tools/rxfilter.ps1
+++ b/tools/rxfilter.ps1
@@ -18,7 +18,19 @@ param (
     [int]$QueueCount = 1,
 
     [Parameter(Mandatory = $false)]
-    [string]$Action = "Drop"
+    [string]$Action = "Drop",
+
+    [Parameter(Mandatory = $false)]
+    [string]$ComputerName = "",
+
+    [Parameter(Mandatory = $false)]
+    [System.Management.Automation.PSCredential]$Credential,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RemoteRoot = "",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipDeploy
 )
 
 Set-StrictMode -Version 'Latest'
@@ -27,6 +39,11 @@ $ErrorActionPreference = 'Stop'
 # Important paths.
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
+
+$Forwarded = Invoke-XdpRemoteIfRequested -InvocationCommand $MyInvocation.MyCommand `
+    -BoundParameters $PSBoundParameters -Config $Config -Platform $Platform
+if ($Forwarded -is [array]) { $Forwarded = $Forwarded[-1] }
+if ($Forwarded) { return }
 $ArtifactsDir = Get-ArtifactBinPath -Config $Config -Platform $Platform
 
 for ($i = 0; $i -lt $QueueCount; $i++) {

--- a/tools/rxfilterperf.ps1
+++ b/tools/rxfilterperf.ps1
@@ -27,7 +27,19 @@ param (
     [string]$RawResultsFile = "",
 
     [Parameter(Mandatory=$false)]
-    [string]$CommitHash = ""
+    [string]$CommitHash = "",
+
+    [Parameter(Mandatory = $false)]
+    [string]$ComputerName = "",
+
+    [Parameter(Mandatory = $false)]
+    [System.Management.Automation.PSCredential]$Credential,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RemoteRoot = "",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipDeploy
 )
 
 Set-StrictMode -Version 'Latest'
@@ -36,6 +48,11 @@ $ErrorActionPreference = 'Stop'
 # Important paths.
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
+
+$Forwarded = Invoke-XdpRemoteIfRequested -InvocationCommand $MyInvocation.MyCommand `
+    -BoundParameters $PSBoundParameters -Config $Config -Platform $Platform
+if ($Forwarded -is [array]) { $Forwarded = $Forwarded[-1] }
+if ($Forwarded) { return }
 $ArtifactsDir = Get-ArtifactBinPath -Config $Config -Platform $Platform
 $LogsDir = "$RootDir\artifacts\logs"
 $RxFilter = "$ArtifactsDir\test\rxfilter.exe"

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -48,7 +48,14 @@ param (
     [switch]$EnableEbpf = $false,
 
     [Parameter(Mandatory = $false)]
-    [switch]$PaLayer = $false
+    [switch]$PaLayer = $false,
+
+    # When set, propagates -Force to the underlying xdpruntime\xdp-setup.ps1
+    # so that normally-fatal uninstall errors (e.g. xdpbpfexport --clear
+    # failing because the eBPF store registry was wedged by a bugcheck) are
+    # downgraded to warnings. Use only for recovery scenarios.
+    [Parameter(Mandatory = $false)]
+    [switch]$Force = $false
 )
 
 Set-StrictMode -Version 'Latest'
@@ -345,15 +352,15 @@ function Uninstall-Xdp {
 
         if ((Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Services\xdp\Parameters").PSObject.Properties["XdpEbpfEnabled"]) {
             Write-Verbose "$XdpSetupPath -Uninstall xdpebpf"
-            & $XdpSetupPath -Uninstall xdpebpf
+            & $XdpSetupPath -Uninstall xdpebpf -Force:$Force
         }
         if (Get-NetAdapterBinding -ComponentID ms_xdp_pa -ErrorAction Ignore) {
             Write-Verbose "$XdpSetupPath -Uninstall xdppa"
-            & $XdpSetupPath -Uninstall xdppa
+            & $XdpSetupPath -Uninstall xdppa -Force:$Force
         }
         if (Get-NetAdapterBinding -ComponentID ms_xdp -ErrorAction Ignore) {
             Write-Verbose "$XdpSetupPath -Uninstall xdp"
-            & $XdpSetupPath -Uninstall xdp
+            & $XdpSetupPath -Uninstall xdp -Force:$Force
         }
 
         Write-Verbose "Remove-Item $XdpPath -Recurse -Force"
@@ -632,6 +639,10 @@ function Uninstall-Ebpf {
 
         if ($Process.ExitCode -eq 0x645) {
             Write-Warning "eBPF is present but the MSI is not installed. Trying to uninstall services and binaries..."
+
+            Write-Verbose "Stop-Service ebpfsvc"
+            try { Stop-Service ebpfsvc -NoWait } catch { }
+            Cleanup-Service ebpfsvc
 
             Write-Verbose "Stop-Service netebpfext"
             try { Stop-Service netebpfext -NoWait } catch { }

--- a/tools/spinxsk.ps1
+++ b/tools/spinxsk.ps1
@@ -105,7 +105,21 @@ param (
     [string]$XdpInstaller = "NuGet",
 
     [Parameter(Mandatory = $false)]
-    [switch]$TxInspect = $false
+    [switch]$TxInspect = $false,
+
+    # Remote execution: when set, deploy + run this script on the named test
+    # machine over PowerShell remoting. See tools\remote.ps1 for setup.
+    [Parameter(Mandatory = $false)]
+    [string]$ComputerName = "",
+
+    [Parameter(Mandatory = $false)]
+    [System.Management.Automation.PSCredential]$Credential,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RemoteRoot = "",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipDeploy
 )
 
 Set-StrictMode -Version 'Latest'
@@ -114,6 +128,11 @@ $ErrorActionPreference = 'Stop'
 # Important paths.
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
+
+$Forwarded = Invoke-XdpRemoteIfRequested -InvocationCommand $MyInvocation.MyCommand `
+    -BoundParameters $PSBoundParameters -Config $Config -Platform $Platform
+if ($Forwarded -is [array]) { $Forwarded = $Forwarded[-1] }
+if ($Forwarded) { return }
 
 $ArtifactsDir = Get-ArtifactBinPath -Config $Config -Platform $Platform
 $LogsDir = "$RootDir\artifacts\logs"

--- a/tools/xskfwdkm.ps1
+++ b/tools/xskfwdkm.ps1
@@ -18,7 +18,19 @@ param (
 
     [Parameter(Mandatory = $false)]
     [ValidateSet("x64", "arm64")]
-    [string]$Platform = "x64"
+    [string]$Platform = "x64",
+
+    [Parameter(Mandatory = $false)]
+    [string]$ComputerName = "",
+
+    [Parameter(Mandatory = $false)]
+    [System.Management.Automation.PSCredential]$Credential,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RemoteRoot = "",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipDeploy
 )
 
 Set-StrictMode -Version 'Latest'
@@ -27,6 +39,11 @@ $ErrorActionPreference = 'Stop'
 # Important paths.
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
+
+$Forwarded = Invoke-XdpRemoteIfRequested -InvocationCommand $MyInvocation.MyCommand `
+    -BoundParameters $PSBoundParameters -Config $Config -Platform $Platform
+if ($Forwarded -is [array]) { $Forwarded = $Forwarded[-1] }
+if ($Forwarded) { return }
 
 try {
     & "$RootDir\tools\log.ps1" -Start -Name xskfwdkm -Profile XdpFunctional.Verbose -Config $Config -Platform $Platform

--- a/tools/xskmaprx.ps1
+++ b/tools/xskmaprx.ps1
@@ -26,7 +26,19 @@ param (
     [string]$Platform = "x64",
 
     [Parameter(Mandatory = $false)]
-    [Int32]$TimeoutSeconds = 5
+    [Int32]$TimeoutSeconds = 5,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ComputerName = "",
+
+    [Parameter(Mandatory = $false)]
+    [System.Management.Automation.PSCredential]$Credential,
+
+    [Parameter(Mandatory = $false)]
+    [string]$RemoteRoot = "",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$SkipDeploy
 )
 
 Set-StrictMode -Version 'Latest'
@@ -35,6 +47,11 @@ $ErrorActionPreference = 'Stop'
 # Important paths.
 $RootDir = Split-Path $PSScriptRoot -Parent
 . $RootDir\tools\common.ps1
+
+$Forwarded = Invoke-XdpRemoteIfRequested -InvocationCommand $MyInvocation.MyCommand `
+    -BoundParameters $PSBoundParameters -Config $Config -Platform $Platform
+if ($Forwarded -is [array]) { $Forwarded = $Forwarded[-1] }
+if ($Forwarded) { return }
 $ArtifactsDir = Get-ArtifactBinPath -Config $Config -Platform $Platform
 $XskMapRx = "$ArtifactsDir\test\xskmaprx.exe"
 


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Enable developers and AI to run existing Powershell scripts using remoting. Also add AI instructions to monitor remote KD.

Also includes some long-overdue improvements to driver cleanup after an unscheduled reboot.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

Seems to work manually and with AI locally. We'll probably need to refine further.

## Documentation

_Is there any documentation impact for this change?_

Yep, added.

## Installation

_Is there any installer impact for this change?_

No.