### PR TITLE
Add bytes received + ICMP rule support to the sample xsk_map_rx.exe 

### DIFF
--- a/samples/xskmaprx/xskmaprx.c
+++ b/samples/xskmaprx/xskmaprx.c
@@ -10,11 +10,14 @@
 // inserts the sockets into the map keyed by queue ID, and creates an XDP program
 // that redirects matching traffic to the XSK for the current receive queue.
 //
-// Note: this sample does not demonstrate receiving the redirected packets.
+// Each XSK is fully configured with UMEM, RX and fill rings, and activated so
+// that redirected packets are received. The sample prints per-queue and total
+// packet/byte counts periodically and on exit.
 //
 
 #include <xdpapi.h>
 #include <afxdp.h>
+#include <afxdp_helper.h>
 #include <ws2tcpip.h>
 #include <assert.h>
 #include <stdio.h>
@@ -33,6 +36,11 @@ CONST CHAR *UsageText =
 "       Match only UDP traffic with this destination port.\n"
 "       Default: match all traffic.\n"
 "\n"
+"   -IcmpOnly\n"
+"\n"
+"       Match only ICMPv4 traffic (protocol 1). This allows ping\n"
+"       experiments without disrupting other traffic on the interface.\n"
+"\n"
 "   -XdpMode <Mode>\n"
 "\n"
 "       The XDP interface provider mode:\n"
@@ -50,15 +58,32 @@ CONST CHAR *UsageText =
 "\n"
 "   xskmaprx.exe -IfIndex 6 -QueueCount 4\n"
 "   xskmaprx.exe -IfIndex 6 -QueueCount 2 -UdpDstPort 9000\n"
+"   xskmaprx.exe -IfIndex 6 -QueueCount 1 -IcmpOnly -TimeoutSeconds 30\n"
 ;
 
 #define LOGERR(...) \
     fprintf(stderr, "ERR: "); fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n")
 
+//
+// Per-queue RX state.
+//
+#define RX_RING_SIZE 64
+#define FRAME_SIZE 2048
+
+typedef struct _QUEUE_CONTEXT {
+    HANDLE Socket;
+    XSK_RING RxRing;
+    XSK_RING RxFillRing;
+    UCHAR *Umem;
+    UINT64 PacketsReceived;
+    UINT64 BytesReceived;
+} QUEUE_CONTEXT;
+
 UINT32 IfIndex;
 UINT32 QueueCount;
 UINT16 UdpDstPort;
 BOOLEAN UseUdpMatch;
+BOOLEAN UseIcmpMatch;
 UINT32 TimeoutSeconds;
 XDP_CREATE_PROGRAM_FLAGS ProgramFlags;
 
@@ -74,6 +99,7 @@ ParseArgs(
     QueueCount = 0;
     UdpDstPort = 0;
     UseUdpMatch = FALSE;
+    UseIcmpMatch = FALSE;
     TimeoutSeconds = 0;
     ProgramFlags = XDP_CREATE_PROGRAM_FLAG_ALL_QUEUES;
 
@@ -114,6 +140,8 @@ ParseArgs(
                 LOGERR("Invalid XdpMode");
                 goto Usage;
             }
+        } else if (!_stricmp(ArgV[i], "-IcmpOnly")) {
+            UseIcmpMatch = TRUE;
         } else if (!_stricmp(ArgV[i], "-TimeoutSeconds")) {
             if (++i >= ArgC) {
                 LOGERR("Missing TimeoutSeconds");
@@ -146,6 +174,135 @@ Usage:
     exit(1);
 }
 
+static
+XDP_STATUS
+SetupQueueSocket(
+    _In_ UINT32 QueueId,
+    _Inout_ QUEUE_CONTEXT *Ctx
+    )
+{
+    XDP_STATUS XdpStatus;
+    XSK_UMEM_REG UmemReg = {0};
+    UINT32 RingSize = RX_RING_SIZE;
+    XSK_RING_INFO_SET RingInfo;
+    UINT32 OptionLength;
+
+    Ctx->PacketsReceived = 0;
+    Ctx->BytesReceived = 0;
+
+    //
+    // Allocate UMEM: one frame per fill ring entry.
+    //
+    Ctx->Umem = (UCHAR *)calloc(RX_RING_SIZE, FRAME_SIZE);
+    if (Ctx->Umem == NULL) {
+        LOGERR("Failed to allocate UMEM for queue %u", QueueId);
+        return E_OUTOFMEMORY;
+    }
+
+    //
+    // Create the socket.
+    //
+    XdpStatus = XskCreate(&Ctx->Socket);
+    if (FAILED(XdpStatus)) {
+        LOGERR("XskCreate failed for queue %u: %x", QueueId, XdpStatus);
+        return XdpStatus;
+    }
+
+    //
+    // Register the UMEM buffer region.
+    //
+    UmemReg.TotalSize = (UINT32)RX_RING_SIZE * FRAME_SIZE;
+    UmemReg.ChunkSize = FRAME_SIZE;
+    UmemReg.Address = Ctx->Umem;
+
+    XdpStatus = XskSetSockopt(Ctx->Socket, XSK_SOCKOPT_UMEM_REG, &UmemReg, sizeof(UmemReg));
+    if (FAILED(XdpStatus)) {
+        LOGERR("XSK_SOCKOPT_UMEM_REG failed for queue %u: %x", QueueId, XdpStatus);
+        return XdpStatus;
+    }
+
+    //
+    // Bind to the interface and queue for RX only.
+    //
+    XdpStatus = XskBind(Ctx->Socket, IfIndex, QueueId, XSK_BIND_FLAG_RX);
+    if (FAILED(XdpStatus)) {
+        LOGERR("XskBind failed for queue %u: %x", QueueId, XdpStatus);
+        return XdpStatus;
+    }
+
+    //
+    // Configure RX and fill ring sizes.
+    //
+    XdpStatus = XskSetSockopt(Ctx->Socket, XSK_SOCKOPT_RX_RING_SIZE, &RingSize, sizeof(RingSize));
+    if (FAILED(XdpStatus)) {
+        LOGERR("XSK_SOCKOPT_RX_RING_SIZE failed for queue %u: %x", QueueId, XdpStatus);
+        return XdpStatus;
+    }
+
+    XdpStatus = XskSetSockopt(Ctx->Socket, XSK_SOCKOPT_RX_FILL_RING_SIZE, &RingSize, sizeof(RingSize));
+    if (FAILED(XdpStatus)) {
+        LOGERR("XSK_SOCKOPT_RX_FILL_RING_SIZE failed for queue %u: %x", QueueId, XdpStatus);
+        return XdpStatus;
+    }
+
+    //
+    // Activate the socket so rings become available.
+    //
+    XdpStatus = XskActivate(Ctx->Socket, XSK_ACTIVATE_FLAG_NONE);
+    if (FAILED(XdpStatus)) {
+        LOGERR("XskActivate failed for queue %u: %x", QueueId, XdpStatus);
+        return XdpStatus;
+    }
+
+    //
+    // Retrieve ring info and initialize helper rings.
+    //
+    OptionLength = sizeof(RingInfo);
+    XdpStatus = XskGetSockopt(Ctx->Socket, XSK_SOCKOPT_RING_INFO, &RingInfo, &OptionLength);
+    if (FAILED(XdpStatus)) {
+        LOGERR("XSK_SOCKOPT_RING_INFO failed for queue %u: %x", QueueId, XdpStatus);
+        return XdpStatus;
+    }
+
+    XskRingInitialize(&Ctx->RxRing, &RingInfo.Rx);
+    XskRingInitialize(&Ctx->RxFillRing, &RingInfo.Fill);
+
+    //
+    // Pre-fill the fill ring with all frame descriptors so the socket is
+    // immediately ready to receive.
+    //
+    UINT32 FillIndex;
+    XskRingProducerReserve(&Ctx->RxFillRing, RX_RING_SIZE, &FillIndex);
+    for (UINT32 j = 0; j < RX_RING_SIZE; j++) {
+        *(UINT64 *)XskRingGetElement(&Ctx->RxFillRing, FillIndex + j) =
+            (UINT64)j * FRAME_SIZE;
+    }
+    XskRingProducerSubmit(&Ctx->RxFillRing, RX_RING_SIZE);
+
+    return S_OK;
+}
+
+static
+VOID
+PrintStats(
+    _In_ QUEUE_CONTEXT *Queues,
+    _In_ UINT32 Count
+    )
+{
+    UINT64 TotalPackets = 0;
+    UINT64 TotalBytes = 0;
+
+    printf("\n--- RX Stats ---\n");
+    for (UINT32 i = 0; i < Count; i++) {
+        printf("  Queue %2u: %8llu pkts  %12llu bytes\n",
+            i, Queues[i].PacketsReceived, Queues[i].BytesReceived);
+        TotalPackets += Queues[i].PacketsReceived;
+        TotalBytes += Queues[i].BytesReceived;
+    }
+    printf("  Total:    %8llu pkts  %12llu bytes\n", TotalPackets, TotalBytes);
+    printf("----------------\n");
+}
+
 INT
 __cdecl
 main(
@@ -156,7 +313,7 @@ main(
     XDP_STATUS XdpStatus;
     HANDLE XskMap = NULL;
     HANDLE Program = NULL;
-    HANDLE *Sockets = NULL;
+    QUEUE_CONTEXT *Queues = NULL;
     const XDP_HOOK_ID XdpInspectRxL2 = {
         XDP_HOOK_L2,
         XDP_HOOK_RX,
@@ -177,31 +334,31 @@ main(
     printf("Created XSKMAP\n");
 
     //
-    // Allocate array to track socket handles.
+    // Allocate per-queue context.
     //
-    Sockets = (HANDLE *)calloc(QueueCount, sizeof(HANDLE));
-    if (Sockets == NULL) {
-        LOGERR("Failed to allocate socket array");
+    Queues = (QUEUE_CONTEXT *)calloc(QueueCount, sizeof(QUEUE_CONTEXT));
+    if (Queues == NULL) {
+        LOGERR("Failed to allocate queue context array");
         return 1;
     }
 
     //
-    // Create and bind an XSK socket for each queue, then insert into the map.
+    // Create, configure, and activate an XSK socket for each queue, then
+    // insert into the map.
     //
     for (UINT32 i = 0; i < QueueCount; i++) {
-        XdpStatus = XskCreate(&Sockets[i]);
+        XdpStatus = SetupQueueSocket(i, &Queues[i]);
         if (FAILED(XdpStatus)) {
-            LOGERR("XskCreate failed for queue %u: %x", i, XdpStatus);
             return 1;
         }
 
-        XdpStatus = XdpMapInsert(XskMap, &i, &Sockets[i]);
+        XdpStatus = XdpMapInsert(XskMap, &i, &Queues[i].Socket);
         if (FAILED(XdpStatus)) {
             LOGERR("XdpMapInsert failed for queue %u: %x", i, XdpStatus);
             return 1;
         }
 
-        printf("Inserted XSK for queue %u into XSKMAP\n", i);
+        printf("Queue %u: XSK created, bound, activated, and inserted into XSKMAP\n", i);
     }
 
     //
@@ -213,6 +370,9 @@ main(
     if (UseUdpMatch) {
         Rule.Match = XDP_MATCH_UDP_DST;
         Rule.Pattern.Port = UdpDstPort;
+    } else if (UseIcmpMatch) {
+        Rule.Match = XDP_MATCH_IP_NEXT_HEADER;
+        Rule.Pattern.NextHeader = 1; // IPPROTO_ICMP
     } else {
         Rule.Match = XDP_MATCH_ALL;
     }
@@ -231,38 +391,85 @@ main(
 
     printf(
         "XDP program created. Redirecting %s traffic across %u queues.\n",
-        UseUdpMatch ? "matching UDP" : "all",
+        UseUdpMatch ? "matching UDP" : UseIcmpMatch ? "ICMPv4" : "all",
         QueueCount);
 
     //
-    // Let XDP redirect frames until the timeout expires (or forever).
+    // Poll all queues for received packets. Print stats every second.
     //
-    if (TimeoutSeconds == 0) {
-        printf("Press Ctrl+C to stop.\n");
-        Sleep(INFINITE);
-    } else {
-        printf("Will exit after %u seconds.\n", TimeoutSeconds);
-        Sleep(TimeoutSeconds * 1000);
+    printf("Receiving... (Ctrl+C to stop)\n");
+
+    ULONGLONG StartTick = GetTickCount64();
+    ULONGLONG LastPrintTick = StartTick;
+
+    for (;;) {
+        //
+        // Check timeout.
+        //
+        ULONGLONG Now = GetTickCount64();
+        if (TimeoutSeconds != 0 && (Now - StartTick) >= TimeoutSeconds * 1000) {
+            break;
+        }
+
+        //
+        // Print stats once per second.
+        //
+        if (Now - LastPrintTick >= 1000) {
+            PrintStats(Queues, QueueCount);
+            LastPrintTick = Now;
+        }
+
+        //
+        // Drain RX from each queue.
+        //
+        for (UINT32 q = 0; q < QueueCount; q++) {
+            QUEUE_CONTEXT *Ctx = &Queues[q];
+            UINT32 RxIndex;
+            UINT32 Available = XskRingConsumerReserve(&Ctx->RxRing, RX_RING_SIZE, &RxIndex);
+
+            for (UINT32 j = 0; j < Available; j++) {
+                XSK_BUFFER_DESCRIPTOR *Desc =
+                    (XSK_BUFFER_DESCRIPTOR *)XskRingGetElement(&Ctx->RxRing, RxIndex + j);
+                Ctx->PacketsReceived++;
+                Ctx->BytesReceived += Desc->Length;
+            }
+
+            if (Available > 0) {
+                XskRingConsumerRelease(&Ctx->RxRing, Available);
+
+                //
+                // Recycle the consumed frame descriptors back onto the fill ring
+                // so the socket can receive more packets.
+                //
+                UINT32 FillIndex;
+                UINT32 Filled = XskRingProducerReserve(&Ctx->RxFillRing, Available, &FillIndex);
+                for (UINT32 j = 0; j < Filled; j++) {
+                    //
+                    // Re-post the same UMEM offsets. The order doesn't matter;
+                    // just cycle through the buffer pool.
+                    //
+                    *(UINT64 *)XskRingGetElement(&Ctx->RxFillRing, FillIndex + j) =
+                        (UINT64)((RxIndex + j) % RX_RING_SIZE) * FRAME_SIZE;
+                }
+                XskRingProducerSubmit(&Ctx->RxFillRing, Filled);
+            }
+        }
     }
 
+    PrintStats(Queues, QueueCount);
+
     //
-    // Clean up: The XDP program is detached when its handle is closed. The
-    // XSKMAP is freed once its handle is closed and no programs reference it.
-    // Closing each XSK releases the underlying socket resources.
-    //
-    // This can be done in any order: closing a socket handle will release all
-    // user-supplied pinned memory, even if an XSKMAP or program still have a
-    // reference.
+    // Clean up.
     //
     CloseHandle(Program);
     CloseHandle(XskMap);
     for (UINT32 i = 0; i < QueueCount; i++) {
-#pragma warning(suppress: 6001) // Sockets was zero-initialized by calloc.
-        if (Sockets[i] != NULL) {
-            CloseHandle(Sockets[i]);
+        if (Queues[i].Socket != NULL) {
+            CloseHandle(Queues[i].Socket);
         }
+        free(Queues[i].Umem);
     }
-    free(Sockets);
+    free(Queues);
 
     return 0;
 }

--- a/samples/xskmaprx/xskmaprx.c
+++ b/samples/xskmaprx/xskmaprx.c
@@ -77,6 +77,7 @@ typedef struct _QUEUE_CONTEXT {
     UCHAR *Umem;
     UINT64 PacketsReceived;
     UINT64 BytesReceived;
+    UINT64 PacketsDropped;
 } QUEUE_CONTEXT;
 
 UINT32 IfIndex;
@@ -211,7 +212,7 @@ SetupQueueSocket(
     //
     // Register the UMEM buffer region.
     //
-    UmemReg.TotalSize = (UINT32)RX_RING_SIZE * FRAME_SIZE;
+    UmemReg.TotalSize = RX_RING_SIZE * FRAME_SIZE;
     UmemReg.ChunkSize = FRAME_SIZE;
     UmemReg.Address = Ctx->Umem;
 
@@ -291,15 +292,17 @@ PrintStats(
 {
     UINT64 TotalPackets = 0;
     UINT64 TotalBytes = 0;
+    UINT64 TotalDrops = 0;
 
     printf("\n--- RX Stats ---\n");
     for (UINT32 i = 0; i < Count; i++) {
-        printf("  Queue %2u: %8llu pkts  %12llu bytes\n",
-            i, Queues[i].PacketsReceived, Queues[i].BytesReceived);
+        printf("  Queue %2u: %8llu pkts  %12llu bytes  %8llu drops\n",
+            i, Queues[i].PacketsReceived, Queues[i].BytesReceived, Queues[i].PacketsDropped);
         TotalPackets += Queues[i].PacketsReceived;
         TotalBytes += Queues[i].BytesReceived;
+        TotalDrops += Queues[i].PacketsDropped;
     }
-    printf("  Total:    %8llu pkts  %12llu bytes\n", TotalPackets, TotalBytes);
+    printf("  Total:    %8llu pkts  %12llu bytes  %8llu drops\n", TotalPackets, TotalBytes, TotalDrops);
     printf("----------------\n");
 }
 
@@ -427,23 +430,20 @@ main(
             UINT32 RxIndex;
             UINT32 Available = XskRingConsumerReserve(&Ctx->RxRing, RX_RING_SIZE, &RxIndex);
 
-            for (UINT32 j = 0; j < Available; j++) {
-                XSK_BUFFER_DESCRIPTOR *Desc =
-                    (XSK_BUFFER_DESCRIPTOR *)XskRingGetElement(&Ctx->RxRing, RxIndex + j);
-                Ctx->PacketsReceived++;
-                Ctx->BytesReceived += Desc->Length;
-            }
-
             if (Available > 0) {
-                XskRingConsumerRelease(&Ctx->RxRing, Available);
-
                 //
-                // Recycle the consumed frame descriptors back onto the fill ring
-                // so the socket can receive more packets.
+                // Reserve fill ring slots first so we only consume
+                // what we can recycle back to the fill ring.
                 //
                 UINT32 FillIndex;
                 UINT32 Filled = XskRingProducerReserve(&Ctx->RxFillRing, Available, &FillIndex);
+
                 for (UINT32 j = 0; j < Filled; j++) {
+                    XSK_BUFFER_DESCRIPTOR *Desc =
+                        (XSK_BUFFER_DESCRIPTOR *)XskRingGetElement(&Ctx->RxRing, RxIndex + j);
+                    Ctx->PacketsReceived++;
+                    Ctx->BytesReceived += Desc->Length;
+
                     //
                     // Re-post the same UMEM offsets. The order doesn't matter;
                     // just cycle through the buffer pool.
@@ -451,6 +451,9 @@ main(
                     *(UINT64 *)XskRingGetElement(&Ctx->RxFillRing, FillIndex + j) =
                         (UINT64)((RxIndex + j) % RX_RING_SIZE) * FRAME_SIZE;
                 }
+
+                Ctx->PacketsDropped += (Available - Filled);
+                XskRingConsumerRelease(&Ctx->RxRing, Filled);
                 XskRingProducerSubmit(&Ctx->RxFillRing, Filled);
             }
         }


### PR DESCRIPTION
## Description

I've been playing around a lot with the rx map sample program. I found myself changing the xsk_map_rx program to do sanity checks using Ping.exe.

If these additions are useful, I am happy to include them in the official repo. See testing:

## Testing

Terminal 1 (on local VM):
<img width="219" height="245" alt="image" src="https://github.com/user-attachments/assets/de944348-29c2-4f5c-8329-766449339096" />

Terminal 2 (on host, pinging local VM). The bytes received on queue ID = 3 got incremented as soon as I started doing the pinging.


## Documentation

No

## Installation

No
