### PR TITLE
xdp: guard optional size outputs in XdpDeleteContext

### DIFF
--- a/src/xdp/program.c
+++ b/src/xdp/program.c
@@ -166,7 +166,7 @@ XdpDeleteContext(
         }
         memcpy(DataOut, XdpMd->Base.data, DataSize);
         *DataSizeOut = DataSize;
-    } else {
+    } else if (DataSizeOut != NULL) {
         *DataSizeOut = 0;
     }
 
@@ -181,7 +181,7 @@ XdpDeleteContext(
         XdpContextOut->data_meta = XdpMd->Base.data_meta;
         XdpContextOut->ingress_ifindex = XdpMd->Base.ingress_ifindex;
         *ContextSizeOut = context_size;
-    } else {
+    } else if (ContextSizeOut != NULL) {
         *ContextSizeOut = 0;
     }
 


### PR DESCRIPTION
## Summary
  `XdpDeleteContext` treats `DataSizeOut` and `ContextSizeOut` as optional
  in the copy paths, but fallback branches unconditionally dereference them.

  This change guards those writes so zeroing only occurs when each pointer
  is non-NULL.

  ## Description
  In `src/xdp/program.c`, two fallback branches previously did:

  - `*DataSizeOut = 0`
  - `*ContextSizeOut = 0`

  without first ensuring the corresponding pointer was non-NULL.

  That could cause a NULL pointer dereference in kernel mode during eBPF
  prog test-run context teardown when optional size outputs are omitted.

  This PR updates both branches to:

  - `else if (DataSizeOut != NULL) { *DataSizeOut = 0; }`
  - `else if (ContextSizeOut != NULL) { *ContextSizeOut = 0; }`

  ## Testing
  - Build/test not run locally in this environment.
  - Change is minimal and scoped to defensive NULL checks in teardown path.

  ## Documentation
  No documentation changes required.

  ## Installation
  No installer impact.