### PR TITLE
Print dispatch URL to console when creating tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,12 @@ name: CI
 
 on:
   workflow_dispatch:
+    inputs:
+      allow-testsigned-publishing:
+        description: 'Allow publishing a testsigned release.'
+        required: false
+        default: false
+        type: boolean
   push:
     branches:
     - main
@@ -790,7 +796,7 @@ jobs:
 
   publish_testsigned_release:
     name: Publish Testsigned Release
-    if: ${{ github.ref_type == 'tag' && contains(github.ref_name, '-testsigned') }}
+    if: ${{ (github.ref_type == 'tag' || inputs.allow-testsigned-publishing) && contains(github.ref_name, '-testsigned') }}
     needs: [all_tests_complete, build, build_allpackage, onebranch_build_validation]
     uses: ./.github/workflows/publish-testsigned-release.yml
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,6 @@ name: CI
 
 on:
   workflow_dispatch:
-    inputs:
-      allow-testsigned-publishing:
-        description: 'Allow publishing a testsigned release.'
-        required: false
-        default: false
-        type: boolean
   push:
     branches:
     - main
@@ -796,7 +790,7 @@ jobs:
 
   publish_testsigned_release:
     name: Publish Testsigned Release
-    if: ${{ (github.ref_type == 'tag' || inputs.allow-testsigned-publishing) && contains(github.ref_name, '-testsigned') }}
+    if: ${{ github.ref_type == 'tag' && contains(github.ref_name, '-testsigned') }}
     needs: [all_tests_complete, build, build_allpackage, onebranch_build_validation]
     uses: ./.github/workflows/publish-testsigned-release.yml
     permissions:

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -81,8 +81,7 @@ jobs:
         # workflows. Explicitly dispatch ci.yml on the tag ref so the run
         # natively reports GITHUB_REF=refs/tags/<tag> and the build derives
         # the version straight from the tag.
-        gh api "repos/$env:GITHUB_REPOSITORY/actions/workflows/ci.yml/dispatches" `
-          -f "ref=$env:TAG" `
+        gh api "repos/$env:GITHUB_REPOSITORY/actions/workflows/ci.yml/dispatches" -f "ref=$env:TAG" `
 
         # Wait briefly for the run to appear, then print its URL.
         Start-Sleep -Seconds 5

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -85,5 +85,5 @@ jobs:
 
         # Wait briefly for the run to appear, then print its URL.
         Start-Sleep -Seconds 5
-        $RunUrl = gh run list --workflow=ci.yml --branch=$env:TAG --limit=1 --json url --jq '.[0].url'
+        $RunUrl = gh run list --repo $env:GITHUB_REPOSITORY --workflow=ci.yml --branch=$env:TAG --limit=1 --json url --jq '.[0].url'
         Write-Host "Dispatched CI run: $RunUrl"

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -79,6 +79,13 @@ jobs:
         $ErrorActionPreference = 'Stop'
         # The tag push above uses GITHUB_TOKEN, which does not trigger push
         # workflows. Explicitly dispatch ci.yml on the tag ref so the run
-        # natively reports GITHUB_REF=refs/tags/<tag> / GITHUB_REF_TYPE=tag,
-        # and the build derives the version straight from the tag.
-        gh api "repos/$env:GITHUB_REPOSITORY/actions/workflows/ci.yml/dispatches" -f "ref=$env:TAG"
+        # natively reports GITHUB_REF=refs/tags/<tag> and the build derives
+        # the version straight from the tag.
+        gh api "repos/$env:GITHUB_REPOSITORY/actions/workflows/ci.yml/dispatches" `
+          -f "ref=$env:TAG" `
+          -f "inputs[allow-testsigned-publishing]=true"
+
+        # Wait briefly for the run to appear, then print its URL.
+        Start-Sleep -Seconds 5
+        $RunUrl = gh run list --workflow=ci.yml --branch=$env:TAG --limit=1 --json url --jq '.[0].url'
+        Write-Host "Dispatched CI run: $RunUrl"

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -79,9 +79,9 @@ jobs:
         $ErrorActionPreference = 'Stop'
         # The tag push above uses GITHUB_TOKEN, which does not trigger push
         # workflows. Explicitly dispatch ci.yml on the tag ref so the run
-        # natively reports GITHUB_REF=refs/tags/<tag> and the build derives
-        # the version straight from the tag.
-        gh api "repos/$env:GITHUB_REPOSITORY/actions/workflows/ci.yml/dispatches" -f "ref=$env:TAG" `
+        # natively reports GITHUB_REF=refs/tags/<tag> / GITHUB_REF_TYPE=tag,
+        # and the build derives the version straight from the tag.
+        gh api "repos/$env:GITHUB_REPOSITORY/actions/workflows/ci.yml/dispatches" -f "ref=$env:TAG"
 
         # Wait briefly for the run to appear, then print its URL.
         Start-Sleep -Seconds 5

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -83,7 +83,6 @@ jobs:
         # the version straight from the tag.
         gh api "repos/$env:GITHUB_REPOSITORY/actions/workflows/ci.yml/dispatches" `
           -f "ref=$env:TAG" `
-          -f "inputs[allow-testsigned-publishing]=true"
 
         # Wait briefly for the run to appear, then print its URL.
         Start-Sleep -Seconds 5

--- a/.github/workflows/publish-testsigned-release.yml
+++ b/.github/workflows/publish-testsigned-release.yml
@@ -34,7 +34,9 @@ jobs:
         $ErrorActionPreference = 'Stop'
 
         New-Item -ItemType Directory -Path release_assets -Force | Out-Null
-        Get-ChildItem -Path artifacts -Filter *.nupkg -Recurse | Copy-Item -Destination release_assets
+        Get-ChildItem -Path artifacts -Filter *.nupkg -Recurse |
+          Where-Object { $_.FullName -notmatch 'baseref' } |
+          Copy-Item -Destination release_assets
 
         $Packages = Get-ChildItem -Path release_assets -Filter *.nupkg
         Write-Host "NuGet packages found:"


### PR DESCRIPTION
## Description

When a dev creates a tag, the workflow will dispatch `ci.yml` to run all tests and publish a test signed release.
It'd be good to print the URL within the job instead of having someone hunt for it.

Also, this PR includes a small fix to address this [CI error](https://github.com/microsoft/xdp-for-windows/actions/runs/28116317174/job/83284134918) (base ref nugets were also being uploaded)

## Testing

See: https://github.com/microsoft/xdp-for-windows/actions/runs/28133446439

## Documentation

N/A

## Installation

N/A