### PR TITLE
Consume eBPF for Windows v1.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,10 @@ jobs:
         windows: [2022, 2025]
         configuration: [Release, Debug]
         platform: [x64, arm64]
+        # eBPF for Windows runtime version installed on the test machine. XDP is
+        # always built against a single (latest) eBPF version; this matrix only
+        # varies the installed runtime to validate backward compatibility.
+        ebpf: ["1.1.0", "1.3.0"]
         exclude:
         - windows: 2022
           platform: arm64
@@ -178,7 +182,7 @@ jobs:
      - self-hosted
      - "1ES.Pool=xdp-ci-functional${{ matrix.platform != 'x64' && format('-{0}', matrix.platform) || '' }}-gh"
      - "1ES.ImageOverride=WS${{ matrix.windows }}${{ matrix.platform != 'x64' && format('-{0}', matrix.platform) || '' }}-Functional"
-     - "JobId=func_${{ matrix.windows }}_${{ matrix.configuration }}_${{ matrix.platform }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"
+     - "JobId=func_${{ matrix.windows }}_${{ matrix.configuration }}_${{ matrix.platform }}_ebpf${{ matrix.ebpf }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}"
     steps:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -189,7 +193,7 @@ jobs:
       run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Verbose -AllowEbpf
     - name: Prepare Machine
       shell: PowerShell
-      run: tools/prepare-machine.ps1 -Platform ${{ matrix.platform }} -ForFunctionalTest -RequireNoReboot -Verbose
+      run: tools/prepare-machine.ps1 -Platform ${{ matrix.platform }} -ForFunctionalTest -RequireNoReboot -Verbose -EbpfVersion ${{ matrix.ebpf }}
     - name: Download Artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
@@ -199,12 +203,12 @@ jobs:
       if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
       shell: PowerShell
       timeout-minutes: 36
-      run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Iterations ${{ env.prIters }} -Timeout ${{ env.fullRuntime }}
+      run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Iterations ${{ env.prIters }} -Timeout ${{ env.fullRuntime }} -EbpfVersion ${{ matrix.ebpf }}
     - name: Run Tests (main)
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch'}}
       shell: PowerShell
       timeout-minutes: 360
-      run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Iterations ${{ env.fullIters }} -Timeout ${{ env.fullRuntime }}
+      run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Iterations ${{ env.fullIters }} -Timeout ${{ env.fullRuntime }} -EbpfVersion ${{ matrix.ebpf }}
     - name: Convert Logs
       if: ${{ always() }}
       timeout-minutes: 15
@@ -214,7 +218,7 @@ jobs:
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       if: ${{ always() }}
       with:
-        name: logs_func_win${{ matrix.windows }}_${{ matrix.configuration }}_${{ matrix.platform }}
+        name: logs_func_win${{ matrix.windows }}_${{ matrix.configuration }}_${{ matrix.platform }}_ebpf${{ matrix.ebpf }}
         path: artifacts/logs
     - name: Check Drivers
       if: ${{ always() }}

--- a/src/xdp.props
+++ b/src/xdp.props
@@ -16,7 +16,7 @@
     <ResolveNuGetPackages>false</ResolveNuGetPackages>
     <HostPlatform>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</HostPlatform>
     <!-- eBPF-for-windows version -->
-    <XdpEbpfVersion>1.1.0</XdpEbpfVersion>
+    <XdpEbpfVersion>1.3.0</XdpEbpfVersion>
     <XdpWdkVersion>10.0.26100.6584</XdpWdkVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/xdp/ebpfstore.h
+++ b/src/xdp/ebpfstore.h
@@ -13,7 +13,7 @@
 #include <ebpf_private_extension.h>
 #include <xdp/ebpfhook.h>
 
-static const ebpf_context_descriptor_t EbpfXdpContextDescriptor = {
+static const ebpf_ctx_descriptor_t EbpfXdpContextDescriptor = {
     .size = sizeof(xdp_md_t),
     .data = FIELD_OFFSET(xdp_md_t, data),
     .end = FIELD_OFFSET(xdp_md_t, data_end),

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -121,24 +121,43 @@ function Get-EbpfVersion {
     return "1.3.0"
 }
 
+# Returns the GitHub release tag for a given eBPF for Windows version. Releases
+# up to and including v1.1.0 use the "Release-v" tag prefix; newer releases use
+# a bare "v" prefix.
+function Get-EbpfReleaseTag {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Version
+    )
+    if ([version]$Version -le [version]"1.1.0") {
+        return "Release-v$Version"
+    }
+    return "v$Version"
+}
+
 # Returns the eBPF MSI full path
 function Get-EbpfMsiFullPath {
     param (
         [Parameter()]
-        [string]$Platform
+        [string]$Platform,
+
+        [Parameter()]
+        [string]$Version = (Get-EbpfVersion)
     )
     $RootDir = Split-Path $PSScriptRoot -Parent
-    $EbpfVersion = Get-EbpfVersion
-    return "$RootDir\artifacts\ebpfmsi\ebpf-for-windows.$EbpfVersion.$Platform.msi"
+    return "$RootDir\artifacts\ebpfmsi\ebpf-for-windows.$Version.$Platform.msi"
 }
 
 function Get-EbpfMsiUrl {
     param (
         [Parameter()]
-        [string]$Platform
+        [string]$Platform,
+
+        [Parameter()]
+        [string]$Version = (Get-EbpfVersion)
     )
-    $EbpfVersion = Get-EbpfVersion
-    return "https://github.com/microsoft/ebpf-for-windows/releases/download/v$EbpfVersion/ebpf-for-windows.$Platform.$EbpfVersion.msi"
+    $Tag = Get-EbpfReleaseTag -Version $Version
+    return "https://github.com/microsoft/ebpf-for-windows/releases/download/$Tag/ebpf-for-windows.$Platform.$Version.msi"
 }
 
 function Get-FnVersion {

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -118,7 +118,7 @@ function Get-EbpfInstallPath {
 }
 
 function Get-EbpfVersion {
-    return "1.1.0"
+    return "1.3.0"
 }
 
 # Returns the eBPF MSI full path
@@ -138,7 +138,7 @@ function Get-EbpfMsiUrl {
         [string]$Platform
     )
     $EbpfVersion = Get-EbpfVersion
-    return "https://github.com/microsoft/ebpf-for-windows/releases/download/Release-v$EbpfVersion/ebpf-for-windows.$Platform.$EbpfVersion.msi"
+    return "https://github.com/microsoft/ebpf-for-windows/releases/download/v$EbpfVersion/ebpf-for-windows.$Platform.$EbpfVersion.msi"
 }
 
 function Get-FnVersion {

--- a/tools/functional.ps1
+++ b/tools/functional.ps1
@@ -37,6 +37,12 @@ param (
     [Parameter(Mandatory = $false)]
     [switch]$EbpfPreinstalled = $false,
 
+    # eBPF for Windows runtime version to install on the test machine. Defaults
+    # to the build-time version (Get-EbpfVersion). XDP is always built against a
+    # single (latest) eBPF version; this only varies the installed runtime.
+    [Parameter(Mandatory = $false)]
+    [string]$EbpfVersion = "",
+
     [Parameter(Mandatory = $false)]
     [switch]$DisablePktMon = $false,
 
@@ -120,7 +126,7 @@ for ($i = 1; $i -le $Iterations; $i++) {
 
         if (!$EbpfPreinstalled) {
             Write-Verbose "installing ebpf..."
-            & "$RootDir\tools\setup.ps1" -Install ebpf -Config $Config -Platform $Platform
+            & "$RootDir\tools\setup.ps1" -Install ebpf -Config $Config -Platform $Platform -EbpfVersion $EbpfVersion
             Write-Verbose "installed ebpf."
         }
 
@@ -206,7 +212,7 @@ for ($i = 1; $i -le $Iterations; $i++) {
         & "$RootDir\tools\setup.ps1" -Uninstall fnmp -Config $Config -Platform $Platform -ErrorAction 'Continue'
         & "$RootDir\tools\setup.ps1" -Uninstall xdp -Config $Config -Platform $Platform -XdpInstaller $XdpInstaller -ErrorAction 'Continue'
         if (!$EbpfPreinstalled) {
-            & "$RootDir\tools\setup.ps1" -Uninstall ebpf -Config $Config -Platform $Platform -ErrorAction 'Continue'
+            & "$RootDir\tools\setup.ps1" -Uninstall ebpf -Config $Config -Platform $Platform -EbpfVersion $EbpfVersion -ErrorAction 'Continue'
         }
         & "$RootDir\tools\log.ps1" -Stop -Name $LogName -Config $Config -Platform $Platform -ErrorAction 'Continue'
     }

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -75,6 +75,11 @@ param (
     [Parameter(Mandatory = $false)]
     [switch]$Cleanup = $false,
 
+    # eBPF for Windows runtime version to download/install for test scenarios.
+    # Defaults to the build-time version returned by Get-EbpfVersion.
+    [Parameter(Mandatory = $false)]
+    [string]$EbpfVersion = "",
+
     # Remote execution: when set, deploy + run this script on the named test
     # machine over PowerShell remoting. See tools\remote.ps1 for setup.
     [Parameter(Mandatory = $false)]
@@ -172,11 +177,12 @@ function Download-eBpf-Nuget {
 
 function Download-Ebpf-Msi {
     # Download and extract private eBPF installer MSI package.
-    $EbpfMsiFullPath = Get-EbpfMsiFullPath -Platform $Platform
+    $Version = if ([string]::IsNullOrEmpty($EbpfVersion)) { Get-EbpfVersion } else { $EbpfVersion }
+    $EbpfMsiFullPath = Get-EbpfMsiFullPath -Platform $Platform -Version $Version
 
     if (!(Test-Path $EbpfMsiFullPath)) {
         $EbpfMsiDir = Split-Path $EbpfMsiFullPath
-        $EbpfMsiUrl = Get-EbpfMsiUrl -Platform $Platform
+        $EbpfMsiUrl = Get-EbpfMsiUrl -Platform $Platform -Version $Version
 
         if (!(Test-Path $EbpfMsiDir)) {
             mkdir $EbpfMsiDir | Write-Verbose

--- a/tools/setup.ps1
+++ b/tools/setup.ps1
@@ -55,7 +55,13 @@ param (
     # failing because the eBPF store registry was wedged by a bugcheck) are
     # downgraded to warnings. Use only for recovery scenarios.
     [Parameter(Mandatory = $false)]
-    [switch]$Force = $false
+    [switch]$Force = $false,
+
+    # eBPF for Windows runtime version to install/uninstall. Defaults to the
+    # build-time version returned by Get-EbpfVersion. Only the installed runtime
+    # varies; XDP is always built against a single (latest) eBPF version.
+    [Parameter(Mandatory = $false)]
+    [string]$EbpfVersion = ""
 )
 
 Set-StrictMode -Version 'Latest'
@@ -576,7 +582,8 @@ function Uninstall-FnSock {
 
 function Install-Ebpf {
     $EbpfPath = Get-EbpfInstallPath
-    $EbpfMsiFullPath = Get-EbpfMsiFullPath -Platform $Platform
+    $Version = if ([string]::IsNullOrEmpty($EbpfVersion)) { Get-EbpfVersion } else { $EbpfVersion }
+    $EbpfMsiFullPath = Get-EbpfMsiFullPath -Platform $Platform -Version $Version
 
     Write-Verbose "Installing eBPF for Windows"
 
@@ -601,7 +608,8 @@ function Install-Ebpf {
 
 function Uninstall-Ebpf {
     $EbpfPath = Get-EbpfInstallPath
-    $EbpfMsiFullPath = Get-EbpfMsiFullPath -Platform $Platform
+    $Version = if ([string]::IsNullOrEmpty($EbpfVersion)) { Get-EbpfVersion } else { $EbpfVersion }
+    $EbpfMsiFullPath = Get-EbpfMsiFullPath -Platform $Platform -Version $Version
     $Timeout = 60
 
     if (!(Test-Path $EbpfPath)) {


### PR DESCRIPTION
## Description

Updates the eBPF for Windows dependency from v1.1.0 to v1.3.0. This lays the groundwork for eventual v1.4 ingestion, and minimizes the churn in #1008.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI. Added logical support for a matrix of eBPF runtimes during test, seeded with both v1.1 and v1.3 for now.

## Documentation

_Is there any documentation impact for this change?_

N/A.

## Installation

_Is there any installer impact for this change?_

N/A.
