### PR TITLE
Bump driver start retry count

### DIFF
--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -489,9 +489,9 @@ function New-PerfData {
 function Start-Service-With-Retry($Name) {
     Write-Verbose "Start-Service $Name"
     $StartSuccess = $false
-    for ($i=0; $i -lt 100; $i++) {
+    for ($i=0; $i -lt 200; $i++) {
         try {
-            Start-Sleep -Milliseconds 10
+            Start-Sleep -Milliseconds 5
             Start-Service $Name
             $StartSuccess = $true
             break


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

We hit a CI failure where eBPF has failed to start with fault injection after 100 tries. This is pure noise, so bump the retry count and reduce the back-off timer.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI.

## Documentation

_Is there any documentation impact for this change?_

No.

## Installation

_Is there any installer impact for this change?_

No.