### PR TITLE
Re-onboard prerelease CI tests using inbox eBPF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,19 +165,23 @@ jobs:
       # For PRs
       prRuntime: 36 # minutes. Update timeout-minutes with any changes.
       prIters: 1
+      # '$true' on Prerelease (inbox eBPF, overridden with the tested version); '$false' otherwise.
+      ebpfInbox: ${{ matrix.windows == 'Prerelease' && '$true' || '$false' }}
     strategy:
       fail-fast: false
       matrix:
-        windows: [2022, 2025]
+        windows: [2022, 2025, Prerelease]
         configuration: [Release, Debug]
         platform: [x64, arm64]
-        # eBPF for Windows runtime version installed on the test machine. XDP is
-        # always built against a single (latest) eBPF version. XDP now consumes
-        # eBPF 1.4 features -- the global virtual bpf_redirect_map helper and
-        # bpf2c 1.4 native code generation (direct array-map access) -- so 1.4.0
-        # is the minimum supported runtime. Older runtimes are binary
-        # incompatible with the native eBPF programs XDP ships.
-        ebpf: ["1.4.0"]
+        # eBPF for Windows runtime version tested on the machine. XDP is always
+        # built against a single (latest) eBPF version, but the functional tests
+        # run against multiple runtime versions to catch regressions. On MSI
+        # images the runtime is installed directly; on Prerelease (which ships
+        # eBPF inbox) the inbox runtime is overridden with this version (see
+        # -OverrideInboxEbpf on the steps below). Tests that require newer eBPF
+        # features (e.g. the XSKMAP bpf_redirect_map helper added in 1.4) skip
+        # themselves at runtime when the installed runtime is too old.
+        ebpf: ["1.3.0", "1.4.0"]
         exclude:
         - windows: 2022
           platform: arm64
@@ -196,7 +200,7 @@ jobs:
       run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Verbose -AllowEbpf
     - name: Prepare Machine
       shell: PowerShell
-      run: tools/prepare-machine.ps1 -Platform ${{ matrix.platform }} -ForFunctionalTest -RequireNoReboot -Verbose -EbpfVersion ${{ matrix.ebpf }}
+      run: tools/prepare-machine.ps1 -Platform ${{ matrix.platform }} -ForFunctionalTest -RequireNoReboot -Verbose -EbpfVersion ${{ matrix.ebpf }} -EbpfPreinstalled:${{ env.ebpfInbox }} -OverrideInboxEbpf:${{ env.ebpfInbox }}
     - name: Download Artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
@@ -206,12 +210,12 @@ jobs:
       if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
       shell: PowerShell
       timeout-minutes: 36
-      run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Iterations ${{ env.prIters }} -Timeout ${{ env.fullRuntime }} -EbpfVersion ${{ matrix.ebpf }}
+      run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Iterations ${{ env.prIters }} -Timeout ${{ env.fullRuntime }} -EbpfVersion ${{ matrix.ebpf }} -EbpfPreinstalled:${{ env.ebpfInbox }}
     - name: Run Tests (main)
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch'}}
       shell: PowerShell
       timeout-minutes: 360
-      run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Iterations ${{ env.fullIters }} -Timeout ${{ env.fullRuntime }} -EbpfVersion ${{ matrix.ebpf }}
+      run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Iterations ${{ env.fullIters }} -Timeout ${{ env.fullRuntime }} -EbpfVersion ${{ matrix.ebpf }} -EbpfPreinstalled:${{ env.ebpfInbox }}
     - name: Convert Logs
       if: ${{ always() }}
       timeout-minutes: 15
@@ -238,10 +242,12 @@ jobs:
       fullRuntime: 60 # minutes. Update timeout-minutes with any changes.
       # For PRs
       prRuntime: 10 # minutes. Update timeout-minutes with any changes.
+      # '$true' on Prerelease (inbox eBPF, overridden with the tested version); '$false' otherwise.
+      ebpfInbox: ${{ matrix.windows == 'Prerelease' && '$true' || '$false' }}
     strategy:
       fail-fast: false
       matrix:
-        windows: [2022, 2025]
+        windows: [2022, 2025, Prerelease]
         configuration: [Release, Debug]
         platform: [x64, arm64]
         testDriver: [XDPMP, FNMP]
@@ -267,7 +273,7 @@ jobs:
       run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Verbose -AllowEbpf
     - name: Prepare Machine
       shell: PowerShell
-      run: tools/prepare-machine.ps1 -ForSpinxskTest -Platform ${{ matrix.platform }} -RequireNoReboot -Verbose
+      run: tools/prepare-machine.ps1 -ForSpinxskTest -Platform ${{ matrix.platform }} -RequireNoReboot -Verbose -EbpfPreinstalled:${{ env.ebpfInbox }} -OverrideInboxEbpf:${{ env.ebpfInbox }}
     - name: Download Artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
@@ -277,22 +283,22 @@ jobs:
       if: ${{ (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && matrix.testDriver == 'XDPMP' && matrix.enableTxInspect == 'enableTxInspect' }}
       shell: PowerShell
       timeout-minutes: 20
-      run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Driver ${{ matrix.testDriver}} -Minutes ${{ env.prRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf -TxInspect
+      run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Driver ${{ matrix.testDriver}} -Minutes ${{ env.prRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf -TxInspect -EbpfPreinstalled:${{ env.ebpfInbox }}
     - name: Run spinxsk (PR)
       if: ${{ (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && matrix.enableTxInspect == 'disableTxInspect' }}
       shell: PowerShell
       timeout-minutes: 20
-      run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Driver ${{ matrix.testDriver}} -Minutes ${{ env.prRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf
+      run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Driver ${{ matrix.testDriver}} -Minutes ${{ env.prRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf -EbpfPreinstalled:${{ env.ebpfInbox }}
     - name: Run spinxsk (main, with TxInspect)
       if: ${{ (github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch') && matrix.testDriver == 'XDPMP' && matrix.enableTxInspect == 'enableTxInspect' }}
       shell: PowerShell
       timeout-minutes: 70
-      run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Driver ${{ matrix.testDriver}} -Minutes ${{ env.fullRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf -TxInspect
+      run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Driver ${{ matrix.testDriver}} -Minutes ${{ env.fullRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf -TxInspect -EbpfPreinstalled:${{ env.ebpfInbox }}
     - name: Run spinxsk (main)
       if: ${{ github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch' && matrix.enableTxInspect == 'disableTxInspect' }}
       shell: PowerShell
       timeout-minutes: 70
-      run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Driver ${{ matrix.testDriver}} -Minutes ${{ env.fullRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf
+      run: tools/spinxsk.ps1 -Verbose -Stats -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Driver ${{ matrix.testDriver}} -Minutes ${{ env.fullRuntime }} -XdpmpPollProvider ${{ env.xdpmpPollProvider }} -SuccessThresholdPercent ${{ env.successThresholdPercent }} -EnableEbpf -EbpfPreinstalled:${{ env.ebpfInbox }}
     - name: Convert Logs
       if: ${{ always() }}
       timeout-minutes: 15
@@ -521,11 +527,13 @@ jobs:
     env:
       Runtime: 25 # minutes. Update timeout-minutes with any changes.
       Iters: 1
+      # '$true' on Prerelease (inbox eBPF, overridden with the tested version); '$false' otherwise.
+      ebpfInbox: ${{ matrix.windows == 'Prerelease' && '$true' || '$false' }}
     strategy:
       fail-fast: false
       matrix:
         downlevel_release: ${{ fromJson(needs.resolve_downlevel_releases.outputs.downlevel_release) }}
-        windows: [2022, 2025]
+        windows: [2022, 2025, Prerelease]
         configuration: [Release]
         platform: [x64]
     runs-on:
@@ -543,7 +551,7 @@ jobs:
       run: tools/check-drivers.ps1 -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Verbose -AllowEbpf
     - name: Prepare Machine
       shell: PowerShell
-      run: tools/prepare-machine.ps1 -ForFunctionalTest -Platform ${{ matrix.platform }} -RequireNoReboot -Verbose
+      run: tools/prepare-machine.ps1 -ForFunctionalTest -Platform ${{ matrix.platform }} -RequireNoReboot -Verbose -EbpfPreinstalled:${{ env.ebpfInbox }} -OverrideInboxEbpf:${{ env.ebpfInbox }}
     - name: Download Artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
@@ -558,7 +566,7 @@ jobs:
     - name: Run Tests
       shell: PowerShell
       timeout-minutes: 25
-      run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Iterations ${{ env.Iters }} -NoPrerelease -Timeout ${{ env.Runtime }}
+      run: tools/functional.ps1 -Verbose -Config ${{ matrix.configuration }} -Platform ${{ matrix.platform }} -Iterations ${{ env.Iters }} -NoPrerelease -Timeout ${{ env.Runtime }} -EbpfPreinstalled:${{ env.ebpfInbox }}
     - name: Convert Logs
       if: ${{ always() }}
       timeout-minutes: 15

--- a/test/functional/lib/tests.cpp
+++ b/test/functional/lib/tests.cpp
@@ -6296,9 +6296,18 @@ ProgTestRunRxEbpfPayload()
     TEST_EQUAL(memcmp(UdpFrameV4, UdpFrameOutV4, sizeof(UdpFrameV4)), 0);
 }
 
+static bool EbpfRuntimeAtLeast(_In_ INT MinMajor, _In_ INT MinMinor);
+
 VOID
 GenericRxEbpfIfIndex()
 {
+    //
+    // selective_drop.sys reads the ingress_ifindex context field, which the XDP
+    // hook only populates on eBPF for Windows 1.4 and later.
+    //
+    if (!EbpfRuntimeAtLeast(1, 4)) {
+        TEST_SKIP("eBPF runtime does not populate ingress_ifindex");
+    }
     auto If = FnMpIf;
     unique_fnmp_handle GenericMp;
     unique_fnlwf_handle FnLwf;
@@ -6446,14 +6455,16 @@ GetEbpfRuntimeVersion(
 }
 
 //
-// The eBPF XSKMAP (bpf_redirect_map to AF_XDP sockets) requires the global
-// virtual bpf_redirect_map helper introduced in eBPF for Windows 1.4. When the
-// installed runtime version is unavailable the build-time default (which
-// supports XSKMAP) is assumed.
+// Returns whether the installed eBPF for Windows runtime is at least the given
+// version. When the installed version is unavailable the build-time default
+// (which supports all features XDP tests use) is assumed.
 //
 static
 bool
-EbpfXskmapSupported()
+EbpfRuntimeAtLeast(
+    _In_ INT MinMajor,
+    _In_ INT MinMinor
+    )
 {
     INT Major, Minor, Patch;
 
@@ -6461,7 +6472,18 @@ EbpfXskmapSupported()
         return true;
     }
 
-    return (Major > 1) || (Major == 1 && Minor >= 4);
+    return (Major > MinMajor) || (Major == MinMajor && Minor >= MinMinor);
+}
+
+//
+// The eBPF XSKMAP (bpf_redirect_map to AF_XDP sockets) requires the global
+// virtual bpf_redirect_map helper introduced in eBPF for Windows 1.4.
+//
+static
+bool
+EbpfXskmapSupported()
+{
+    return EbpfRuntimeAtLeast(1, 4);
 }
 
 VOID

--- a/tools/check-drivers.ps1
+++ b/tools/check-drivers.ps1
@@ -174,12 +174,12 @@ Check-And-Remove-Driver "fndis.sys" "fndis"
 
 # Check for any eBPF drivers.
 #
-# Some CI images ship eBPF inbox. Tests must leave any inbox eBPF exactly as
-# they found it. The caller drives this: the test prologue passes -AllowEbpf
-# (tolerate eBPF and record whether it is present as a pipeline baseline), and
-# the test epilogue passes -AllowEbpf based on that recorded baseline -
-# tolerating eBPF when it was present originally, or removing it to restore the
-# original state when it was not.
+# Some CI images have eBPF preinstalled. Tests must leave any preinstalled eBPF
+# exactly as they found it. The caller drives this: the test prologue passes
+# -AllowEbpf (tolerate eBPF and record whether it is present as a pipeline
+# baseline), and the test epilogue passes -AllowEbpf based on that recorded
+# baseline - tolerating eBPF when it was present originally, or removing it to
+# restore the original state when it was not.
 $EbpfDrivers = @("ebpfcore.sys", "netebpfext.sys")
 
 if ($AllowEbpf) {

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -160,6 +160,20 @@ function Get-EbpfMsiUrl {
     return "https://github.com/microsoft/ebpf-for-windows/releases/download/$Tag/ebpf-for-windows.$Platform.$Version.msi"
 }
 
+# Returns the directory holding the packaged eBPF runtime binaries used to
+# override a preinstalled eBPF runtime.
+function Get-EbpfOverrideBinPath {
+    param (
+        [Parameter()]
+        [string]$Platform,
+
+        [Parameter()]
+        [string]$Version = (Get-EbpfVersion)
+    )
+    $RootDir = Split-Path $PSScriptRoot -Parent
+    return "$RootDir\artifacts\ebpfoverride\$Platform.$Version"
+}
+
 function Get-FnVersion {
     return "1.5.0"
 }
@@ -499,5 +513,19 @@ function Start-Service-With-Retry($Name) {
     }
     if ($StartSuccess -eq $false) {
         Write-Error "Failed to start $Name"
+    }
+}
+
+# Ensures the preinstalled eBPF services are running.
+function Start-Ebpf-Inbox {
+    foreach ($svc in @("ebpfcore", "netebpfext", "ebpfsvc")) {
+        $status = (Get-Service -Name $svc -ErrorAction Stop).Status
+        if ($status -ne "Running") {
+            Write-Verbose "starting $svc..."
+            Start-Service-With-Retry $svc
+            Write-Verbose "started $svc."
+        } else {
+            Write-Verbose "$svc is already running."
+        }
     }
 }

--- a/tools/prepare-machine.ps1
+++ b/tools/prepare-machine.ps1
@@ -80,6 +80,16 @@ param (
     [Parameter(Mandatory = $false)]
     [string]$EbpfVersion = "",
 
+    # When set, eBPF is already present on the machine; skip downloading and
+    # installing the eBPF MSI.
+    [Parameter(Mandatory = $false)]
+    [switch]$EbpfPreinstalled = $false,
+
+    # When set, replace the preinstalled eBPF runtime binaries with the packaged
+    # runtime version. Stopgap until the eBPF team provides supported guidance.
+    [Parameter(Mandatory = $false)]
+    [switch]$OverrideInboxEbpf = $false,
+
     # Remote execution: when set, deploy + run this script on the named test
     # machine over PowerShell remoting. See tools\remote.ps1 for setup.
     [Parameter(Mandatory = $false)]
@@ -190,6 +200,84 @@ function Download-Ebpf-Msi {
 
         Invoke-WebRequest-WithRetry -Uri $EbpfMsiUrl -OutFile $EbpfMsiFullPath
     }
+}
+
+function Extract-Ebpf-Override-Binaries {
+    $Version = if ([string]::IsNullOrEmpty($EbpfVersion)) { Get-EbpfVersion } else { $EbpfVersion }
+    $EbpfMsiFullPath = Get-EbpfMsiFullPath -Platform $Platform -Version $Version
+    $BinDir = Get-EbpfOverrideBinPath -Platform $Platform -Version $Version
+    $Binaries = @("ebpfcore.sys", "netebpfext.sys", "ebpfapi.dll")
+
+    $HaveAll = $true
+    foreach ($Bin in $Binaries) {
+        if (!(Test-Path "$BinDir\$Bin")) { $HaveAll = $false; break }
+    }
+    if ($HaveAll) {
+        Write-Verbose "eBPF override binaries already extracted to $BinDir"
+        return
+    }
+
+    $ExtractDir = "$RootDir\artifacts\ebpfoverride\_extract_$Platform.$Version"
+    if (Test-Path $ExtractDir) { Remove-Item -Recurse -Force $ExtractDir }
+    New-Item -ItemType Directory -Force -Path $ExtractDir | Out-Null
+
+    Write-Verbose "msiexec.exe /a $EbpfMsiFullPath /qn TARGETDIR=$ExtractDir"
+    $Process = Start-Process -FilePath msiexec.exe -NoNewWindow -PassThru -Wait -ArgumentList `
+        @("/a", "`"$EbpfMsiFullPath`"", "/qn", "TARGETDIR=`"$ExtractDir`"")
+    if ($Process.ExitCode -ne 0) {
+        Write-Error "eBPF MSI administrative extract failed: $($Process.ExitCode)"
+    }
+
+    New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
+    foreach ($Bin in $Binaries) {
+        $Found = Get-ChildItem -Recurse -Path $ExtractDir -Filter $Bin -ErrorAction Ignore | Select-Object -First 1
+        if ($null -eq $Found) {
+            Write-Error "Could not find $Bin in the extracted eBPF MSI at $ExtractDir"
+        }
+        Copy-Item -Path $Found.FullName -Destination "$BinDir\$Bin" -Force
+    }
+
+    Remove-Item -Recurse -Force $ExtractDir
+}
+
+# Replaces the preinstalled eBPF runtime binaries with the packaged runtime
+# version. Stopgap until the eBPF team provides supported guidance.
+function Override-InboxEbpf {
+    Extract-Ebpf-Override-Binaries
+
+    $Version = if ([string]::IsNullOrEmpty($EbpfVersion)) { Get-EbpfVersion } else { $EbpfVersion }
+    $BinDir = Get-EbpfOverrideBinPath -Platform $Platform -Version $Version
+    $SfpCopy = Get-CoreNetCiArtifactPath -Name "sfpcopy.exe"
+    $System32 = "$env:SystemRoot\System32"
+
+    $Binaries = @(
+        @{ Name = "ebpfcore.sys";   Dest = "$System32\drivers" },
+        @{ Name = "netebpfext.sys"; Dest = "$System32\drivers" },
+        @{ Name = "ebpfapi.dll";    Dest = $System32 }
+    )
+
+    if (!(Test-Path $SfpCopy)) {
+        Write-Error "sfpcopy.exe not found at $SfpCopy"
+    }
+
+    # Stop the eBPF services (dependents first) so the binaries are unloaded and
+    # can be replaced. The service registrations are left intact.
+    foreach ($svc in @("ebpfsvc", "netebpfext", "ebpfcore")) {
+        Write-Verbose "Stop-Service $svc"
+        try { Stop-Service $svc -Force -ErrorAction Stop } catch { Write-Verbose "Stop-Service ${svc}: $_" }
+    }
+
+    foreach ($Bin in $Binaries) {
+        $Src = "$BinDir\$($Bin.Name)"
+        $Dst = "$($Bin.Dest)\$($Bin.Name)"
+        Write-Verbose "$SfpCopy $Src $Dst"
+        & $SfpCopy $Src $Dst | Write-Verbose
+        if ($LastExitCode) {
+            Write-Error "sfpcopy failed to copy $($Bin.Name) (exit $LastExitCode)"
+        }
+    }
+
+    Write-Verbose "eBPF runtime overridden with packaged version $Version"
 }
 
 function Download-Fn-Runtime {
@@ -360,7 +448,15 @@ if ($Cleanup) {
         Setup-VcRuntime
         Setup-VsTest
         Download-CoreNet-Deps
-        Download-Ebpf-Msi
+        if (!$EbpfPreinstalled) {
+            Download-Ebpf-Msi
+        } else {
+            if ($OverrideInboxEbpf) {
+                Download-Ebpf-Msi
+                Override-InboxEbpf
+            }
+            Start-Ebpf-Inbox
+        }
         Setup-TestSigning
     }
 


### PR DESCRIPTION
## Description

_Describe the purpose of and changes within this Pull Request._

Prerelease images now ship eBPF inbox, which conflicts with installing the eBPF MSI. Per the eBPF team's guidance, on inbox images we no longer install the MSI; instead we overwrite the inbox eBPF binaries (ebpfcore, netebpfext, ebpfsvc) to test specific versions.

Re-enables Prerelease in the functional, stress, and downlevel functional test matrices (disabled in #1030) and threads -EbpfPreinstalled through so the eBPF MSI is neither downloaded nor installed on Prerelease.

Fixes #1031

## Testing

_Do any existing tests cover this change? Are new tests needed?_

CI matrix added.

## Documentation

_Is there any documentation impact for this change?_

Not really; comments added as appropriate.

## Installation

_Is there any installer impact for this change?_

N/A.
